### PR TITLE
Implement Project Update

### DIFF
--- a/azuredevops/resource_build_definition.go
+++ b/azuredevops/resource_build_definition.go
@@ -23,6 +23,7 @@ func resourceBuildDefinition() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"revision": {
 				Type:     schema.TypeInt,

--- a/azuredevops/resource_project.go
+++ b/azuredevops/resource_project.go
@@ -151,7 +151,6 @@ func projectRead(clients *aggregatedClient, projectID string, projectName string
 }
 
 func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
-	time.Sleep(60 * time.Second)
 	clients := m.(*aggregatedClient)
 	project, err := expandProject(clients, d, false)
 	if err != nil {

--- a/azuredevops/resource_project.go
+++ b/azuredevops/resource_project.go
@@ -29,7 +29,6 @@ func resourceProject() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"project_name": {
 				Type:             schema.TypeString,
-				ForceNew:         true,
 				Required:         true,
 				DiffSuppressFunc: tfhelper.DiffFuncSupressCaseSensitivity,
 			},
@@ -65,7 +64,7 @@ func resourceProject() *schema.Resource {
 
 func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*aggregatedClient)
-	project, err := expandProject(clients, d)
+	project, err := expandProject(clients, d, true)
 	if err != nil {
 		return fmt.Errorf("Error converting terraform data model to AzDO project reference: %+v", err)
 	}
@@ -149,7 +148,34 @@ func projectRead(clients *aggregatedClient, projectID string, projectName string
 }
 
 func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
+	time.Sleep(60 * time.Second)
+	clients := m.(*aggregatedClient)
+	project, err := expandProject(clients, d, false)
+	if err != nil {
+		return fmt.Errorf("Error converting terraform data model to AzDO project reference: %+v", err)
+	}
+
+	err = updateProject(clients, project, projectCreateTimeoutSeconds)
+	if err != nil {
+		return fmt.Errorf("Error updating project in Azure DevOps: %+v", err)
+	}
 	return resourceProjectRead(d, m)
+}
+
+func updateProject(clients *aggregatedClient, project *core.TeamProject, timeoutSeconds time.Duration) error {
+
+	operationRef, err := clients.CoreClient.UpdateProject(
+		clients.ctx,
+		core.UpdateProjectArgs{
+			ProjectUpdate: project,
+			ProjectId:     project.Id,
+		})
+
+	if err != nil {
+		return err
+	}
+
+	return waitForAsyncOperationSuccess(clients, operationRef, timeoutSeconds)
 }
 
 func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
@@ -177,7 +203,7 @@ func deleteProject(clients *aggregatedClient, id string, timeoutSeconds time.Dur
 }
 
 // Convert internal Terraform data structure to an AzDO data structure
-func expandProject(clients *aggregatedClient, d *schema.ResourceData) (*core.TeamProject, error) {
+func expandProject(clients *aggregatedClient, d *schema.ResourceData, forCreate bool) (*core.TeamProject, error) {
 	workItemTemplate := d.Get("work_item_template").(string)
 	processTemplateID, err := lookupProcessTemplateID(clients, workItemTemplate)
 	if err != nil {
@@ -192,19 +218,25 @@ func expandProject(clients *aggregatedClient, d *schema.ResourceData) (*core.Tea
 	}
 
 	visibility := d.Get("visibility").(string)
-	project := &core.TeamProject{
-		Id:          projectID,
-		Name:        converter.String(d.Get("project_name").(string)),
-		Description: converter.String(d.Get("description").(string)),
-		Visibility:  convertVisibilty(visibility),
-		Capabilities: &map[string]map[string]string{
+
+	var capabilities *map[string]map[string]string
+	if forCreate {
+		capabilities = &map[string]map[string]string{
 			"versioncontrol": {
 				"sourceControlType": d.Get("version_control").(string),
 			},
 			"processTemplate": {
 				"templateTypeId": processTemplateID,
 			},
-		},
+		}
+	}
+
+	project := &core.TeamProject{
+		Id:           projectID,
+		Name:         converter.String(d.Get("project_name").(string)),
+		Description:  converter.String(d.Get("description").(string)),
+		Visibility:   convertVisibilty(visibility),
+		Capabilities: capabilities,
 	}
 
 	return project, nil

--- a/azuredevops/resource_project.go
+++ b/azuredevops/resource_project.go
@@ -45,17 +45,20 @@ func resourceProject() *schema.Resource {
 			},
 			"version_control": {
 				Type:         schema.TypeString,
+				ForceNew:     true,
 				Optional:     true,
 				Default:      "Git",
 				ValidateFunc: validation.StringInSlice([]string{"Git", "Tfvc"}, true),
 			},
 			"work_item_template": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Optional: true,
 				Default:  "Agile",
 			},
 			"process_template_id": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Computed: true,
 			},
 		},

--- a/azuredevops/resource_serviceendpoint.go
+++ b/azuredevops/resource_serviceendpoint.go
@@ -21,6 +21,7 @@ func resourceServiceEndpoint() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"service_endpoint_name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NO] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
Issue Number: 13
https://github.com/microsoft/terraform-provider-azuredevops/issues/13
When we create a project, then update, it causes error on GitHubService Connection and 
Build definition. 

## What is the new behavior?
-------------------------------------

-When the ProjectId is updated, GitHub Service Connection and Build Definition is removed and created as new. 

## Does this introduce a breaking change?
-------------------------------------
- [NO]

## Any relevant logs, error output, etc?
-------------------------------------

_current behavior_

Even we change to the new project, GitHub Service Connection and Build Definition is going to updated. 

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azuredevops_project.project: Refreshing state... [id=d8ab5b68-1a77-4c89-b5a1-1d1f304c7162]
azuredevops_serviceendpoint.github_serviceendpoint: Refreshing state... [id=6dd12fcb-d7b4-4611-a723-72412cd9dcbd]
azuredevops_build_definition.build_definition: Refreshing state... [id=35]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # azuredevops_build_definition.build_definition will be updated in-place
  ~ resource "azuredevops_build_definition" "build_definition" {
        agent_pool_name = "Hosted Ubuntu 1604"
        id              = "35"
        name            = "Test Pipeline"
      ~ project_id      = "d8ab5b68-1a77-4c89-b5a1-1d1f304c7162" -> (known after apply)
        revision        = 1

        repository {
            branch_name           = "master"
            repo_name             = "nmiodice/terraform-azure-devops-hack"
            repo_type             = "GitHub"
            service_connection_id = "6dd12fcb-d7b4-4611-a723-72412cd9dcbd"
            yml_path              = "azdo-api-samples/azure-pipeline.yml"
        }
    }

  # azuredevops_project.project must be replaced
-/+ resource "azuredevops_project" "project" {
        description         = "Test Project Description"
      ~ id                  = "d8ab5b68-1a77-4c89-b5a1-1d1f304c7162" -> (known after apply)
      ~ process_template_id = "adcc42ab-9882-485e-a3ed-7678f01f66bc" -> (known after apply)
      ~ project_name        = "Test Project 5" -> "Test Project 6" # forces replacement
        version_control     = "Git"
        visibility          = "private"
        work_item_template  = "Agile"
    }

  # azuredevops_serviceendpoint.github_serviceendpoint will be updated in-place
  ~ resource "azuredevops_serviceendpoint" "github_serviceendpoint" {
      + github_service_endpoint_pat = (sensitive value)
        id                          = "6dd12fcb-d7b4-4611-a723-72412cd9dcbd"
      ~ project_id                  = "d8ab5b68-1a77-4c89-b5a1-1d1f304c7162" -> (known after apply)
        service_endpoint_name       = "GitHub Service Connection"
        service_endpoint_owner      = "Library"
        service_endpoint_type       = "github"
        service_endpoint_url        = "http://github.com"
    }

Plan: 1 to add, 2 to change, 1 to destroy.
```

_new behavior_

When you change the project, all three resources are destroy/created.

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azuredevops_project.project: Refreshing state... [id=8a2828df-d5be-4a57-ae08-c13697f20f55]
azuredevops_serviceendpoint.github_serviceendpoint: Refreshing state... [id=8a367efc-b651-4c5b-ab95-0860b9d651e7]
azuredevops_build_definition.build_definition: Refreshing state... [id=36]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # azuredevops_build_definition.build_definition must be replaced
-/+ resource "azuredevops_build_definition" "build_definition" {
        agent_pool_name = "Hosted Ubuntu 1604"
      ~ id              = "36" -> (known after apply)
        name            = "Test Pipeline"
      ~ project_id      = "8a2828df-d5be-4a57-ae08-c13697f20f55" -> (known after apply) # forces replacement
      ~ revision        = 1 -> (known after apply)

      - repository {
          - branch_name           = "master" -> null
          - repo_name             = "nmiodice/terraform-azure-devops-hack" -> null
          - repo_type             = "GitHub" -> null
          - service_connection_id = "8a367efc-b651-4c5b-ab95-0860b9d651e7" -> null
          - yml_path              = "azdo-api-samples/azure-pipeline.yml" -> null
        }
      + repository {
          + branch_name           = "master"
          + repo_name             = "nmiodice/terraform-azure-devops-hack"
          + repo_type             = "GitHub"
          + service_connection_id = (known after apply)
          + yml_path              = "azdo-api-samples/azure-pipeline.yml"
        }
    }

  # azuredevops_project.project must be replaced
-/+ resource "azuredevops_project" "project" {
        description         = "Test Project Description"
      ~ id                  = "8a2828df-d5be-4a57-ae08-c13697f20f55" -> (known after apply)
      ~ process_template_id = "adcc42ab-9882-485e-a3ed-7678f01f66bc" -> (known after apply)
      ~ project_name        = "Test Project 7" -> "Test Project 8" # forces replacement
        version_control     = "Git"
        visibility          = "private"
        work_item_template  = "Agile"
    }

  # azuredevops_serviceendpoint.github_serviceendpoint must be replaced
-/+ resource "azuredevops_serviceendpoint" "github_serviceendpoint" {
      + github_service_endpoint_pat = (sensitive value)
      ~ id                          = "8a367efc-b651-4c5b-ab95-0860b9d651e7" -> (known after apply)
      ~ project_id                  = "8a2828df-d5be-4a57-ae08-c13697f20f55" -> (known after apply) # forces replacement
        service_endpoint_name       = "GitHub Service Connection"
        service_endpoint_owner      = "Library"
        service_endpoint_type       = "github"
        service_endpoint_url        = "http://github.com"
    }

Plan: 3 to add, 0 to change, 3 to destroy.

```

## Other information

Since this change is only on schema option. Also, I don't see any Acceptance Testing. Do I need to write Acceptance Testing for this? 