### PR TITLE
Fix nightly builds

### DIFF
--- a/.azdo/azure-pipeline-nightly.yml
+++ b/.azdo/azure-pipeline-nightly.yml
@@ -8,6 +8,8 @@ schedules:
 jobs:
 - template: ./ci.yml
   parameters:
+    maxParallel: 1 # any more and we get throttled by AzDO!
+
     goVersions:
     - value: '1.12.1'
       ymlSafeName: '1_12_1'

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -5,6 +5,7 @@
 parameters:
   goVersions: []
   vmImages: []
+  maxParallel: 1
 
 jobs:
 
@@ -13,6 +14,7 @@ jobs:
 
   # Build on each combination of supported OS and Go version
   strategy:
+    maxParallel: ${{ parameters.maxParallel }}
     matrix:
       ${{ each goVersion in parameters.goVersions }}:
         ${{ each vmImage in parameters.vmImages }}:
@@ -67,20 +69,26 @@ jobs:
       AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL: $(AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL)
       AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD: $(AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD)
 
-  - bash: docker build -f .devcontainer/Dockerfile -t dev --build-arg GO_VERSION=${GO_VERSION} .
+  - bash: |
+      if [ -x "$(command -v docker)" ]; then
+        docker build -f .devcontainer/Dockerfile -t dev --build-arg GO_VERSION=${GO_VERSION} .
+      fi
     env:
       GO_VERSION: $(goVersion)
     displayName: 'Run Build Script in Docker'
 
   - bash: |
-      docker run --env AZDO_ORG_SERVICE_URL=${AZDO_ORG_SERVICE_URL} \
-      --env AZDO_PERSONAL_ACCESS_TOKEN=${AZDO_PERSONAL_ACCESS_TOKEN} \
-      --env AZDO_GITHUB_SERVICE_CONNECTION_PAT=${AZDO_GITHUB_SERVICE_CONNECTION_PAT} \
-      --env AZDO_TEST_AAD_USER_EMAIL=${AZDO_TEST_AAD_USER_EMAIL} \
-      --env AZDO_DOCKERHUB_SERVICE_CONNECTION_USERNAME=${AZDO_DOCKERHUB_SERVICE_CONNECTION_USERNAME} \
-      --env AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL=${AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL} \
-      --env AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD=${AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD} \
-      -v ${PWD}:/workspaces/terraform-provider-azuredevops dev ./scripts/acctest.sh
+      if [ -x "$(command -v docker)" ]; then
+        docker run --env AZDO_ORG_SERVICE_URL=${AZDO_ORG_SERVICE_URL} \
+        --env AZDO_PERSONAL_ACCESS_TOKEN=${AZDO_PERSONAL_ACCESS_TOKEN} \
+        --env AZDO_GITHUB_SERVICE_CONNECTION_PAT=${AZDO_GITHUB_SERVICE_CONNECTION_PAT} \
+        --env AZDO_TEST_AAD_USER_EMAIL=${AZDO_TEST_AAD_USER_EMAIL} \
+        --env AZDO_DOCKERHUB_SERVICE_CONNECTION_USERNAME=${AZDO_DOCKERHUB_SERVICE_CONNECTION_USERNAME} \
+        --env AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL=${AZDO_DOCKERHUB_SERVICE_CONNECTION_EMAIL} \
+        --env AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD=${AZDO_DOCKERHUB_SERVICE_CONNECTION_PASSWORD} \
+        -v ${PWD}:/workspaces/terraform-provider-azuredevops dev ./scripts/acctest.sh
+      fi
+
     env:
       AZDO_ORG_SERVICE_URL: $(ACC_TEST_AZDO_ORG_URL)
       AZDO_PERSONAL_ACCESS_TOKEN: $(ACC_TEST_AZDO_PAT)


### PR DESCRIPTION
This offers various improvements to the nightly builds that should reduce errors. The changes made are:
 - Add a `maxParallel` flag to limit the number of parallel integration
   tests. These have been found to result in rate limiting by AzDO
   and therefore transient failures
 - Check for docker before running any docker specific tests

## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
Nightly build breaks

Issue Number: N/A

