### PR TITLE
Fix variable group update and build script

### DIFF
--- a/azuredevops/resource_variable_group.go
+++ b/azuredevops/resource_variable_group.go
@@ -2,6 +2,8 @@ package azuredevops
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
@@ -9,7 +11,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/validate"
-	"strconv"
 )
 
 func resourceVariableGroup() *schema.Resource {
@@ -74,10 +75,6 @@ func resourceVariableGroup() *schema.Resource {
 				},
 				Required: true,
 				MinItems: 1,
-				Set: func(i interface{}) int {
-					item := i.(map[string]interface{})
-					return schema.HashString(item["name"].(string))
-				},
 			},
 		},
 	}

--- a/azuredevops/resource_variable_group_test.go
+++ b/azuredevops/resource_variable_group_test.go
@@ -94,6 +94,7 @@ func TestAccAzureDevOpsVariableGroup_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameFirst),
 					testAccCheckVariableGroupResourceExists(vargroupNameFirst, allowAccessFirst),
 				),
+				// due to the value of "secret" variables not being returned in the API response.
 				ExpectNonEmptyPlan: true,
 			}, {
 				Config: testhelper.TestAccVariableGroupResource(projectName, vargroupNameSecond, allowAccessSecond),
@@ -102,7 +103,15 @@ func TestAccAzureDevOpsVariableGroup_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameSecond),
 					testAccCheckVariableGroupResourceExists(vargroupNameSecond, allowAccessSecond),
 				),
+				// due to the value of "secret" variables not being returned in the API response.
 				ExpectNonEmptyPlan: true,
+			}, {
+				Config: testhelper.TestAccVariableGroupResourceNoSecrets(projectName, vargroupNameSecond, allowAccessSecond),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameSecond),
+					testAccCheckVariableGroupResourceExists(vargroupNameSecond, allowAccessSecond),
+				),
 			},
 			{
 				// Resource Acceptance Testing https://www.terraform.io/docs/extend/resources/import.html#resource-acceptance-testing-implementation

--- a/azuredevops/resource_variable_group_test.go
+++ b/azuredevops/resource_variable_group_test.go
@@ -94,6 +94,7 @@ func TestAccAzureDevOpsVariableGroup_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameFirst),
 					testAccCheckVariableGroupResourceExists(vargroupNameFirst, allowAccessFirst),
 				),
+				ExpectNonEmptyPlan: true,
 			}, {
 				Config: testhelper.TestAccVariableGroupResource(projectName, vargroupNameSecond, allowAccessSecond),
 				Check: resource.ComposeTestCheckFunc(
@@ -101,6 +102,7 @@ func TestAccAzureDevOpsVariableGroup_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameSecond),
 					testAccCheckVariableGroupResourceExists(vargroupNameSecond, allowAccessSecond),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				// Resource Acceptance Testing https://www.terraform.io/docs/extend/resources/import.html#resource-acceptance-testing-implementation

--- a/azuredevops/utils/testhelper/hcl.go
+++ b/azuredevops/utils/testhelper/hcl.go
@@ -129,6 +129,24 @@ resource "azuredevops_variable_group" "vg" {
 	return fmt.Sprintf("%s\n%s", projectResource, variableGroupResource)
 }
 
+// TestAccVariableGroupResourceNoSecrets Similar to TestAccVariableGroupResource, but without a secret variable
+func TestAccVariableGroupResourceNoSecrets(projectName string, variableGroupName string, allowAccess bool) string {
+	variableGroupResource := fmt.Sprintf(`
+resource "azuredevops_variable_group" "vg" {
+	project_id  = azuredevops_project.project.id
+	name        = "%s"
+	description = "A sample variable group."
+	allow_access = %t
+	variable {
+		name      = "key1"
+		value     = "value1"
+	}
+}`, variableGroupName, allowAccess)
+
+	projectResource := TestAccProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, variableGroupResource)
+}
+
 // TestAccAgentPoolResource HCL describing an AzDO Agent Pool
 func TestAccAgentPoolResource(poolName string) string {
 	return fmt.Sprintf(`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,8 +30,8 @@ function clean() {
 }
 
 function compile() {
-  NAME=$(cat $PROVIDER_NAME_FILE)
-  VERSION=$(cat $PROVIDER_VERSION_FILE)
+  NAME=$(cat "$PROVIDER_NAME_FILE")
+  VERSION=$(cat "$PROVIDER_VERSION_FILE")
 
   BUILD_ARTIFACT="terraform-provider-${NAME}_v${VERSION}"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,8 +30,8 @@ function clean() {
 }
 
 function compile() {
-  NAME=$(cat "$PROVIDER_NAME_FILE")
-  VERSION=$(cat "$PROVIDER_VERSION_FILE")
+  NAME=$(cat $PROVIDER_NAME_FILE)
+  VERSION=$(cat $PROVIDER_VERSION_FILE)
 
   BUILD_ARTIFACT="terraform-provider-${NAME}_v${VERSION}"
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
Variable groups will not update if the only change is the value of a variable. 

Note: this is not an optimal change, but I'm not seeing a clean way to implement it differently based on the commentary in the linked issue.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/240


## What is the new behavior?
-------------------------------------
- Variable group value can now update.
-

## Does this introduce a breaking change?
-------------------------------------
- [NO]
