### PR TITLE
Removing known-to-fail group membership tests

### DIFF
--- a/azuredevops/resource_group_membership_test.go
+++ b/azuredevops/resource_group_membership_test.go
@@ -112,6 +112,7 @@ func TestGroupMembership_Read_DoesNotSwallowErrors(t *testing.T) {
 // Note: This will be uncommented in https://github.com/microsoft/terraform-provider-azuredevops/issues/174
 //
 func TestAccGroupMembership_CreateAndRemove(t *testing.T) {
+	t.Skip("Skipping test TestAccGroupMembership_CreateAndRemove: https://github.com/microsoft/terraform-provider-azuredevops/issues/174")
 	projectName := testhelper.TestAccResourcePrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	userPrincipalName := os.Getenv("AZDO_TEST_AAD_USER_EMAIL")
 	groupName := "Build Administrators"


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
There is a test that is known to be broken (https://github.com/microsoft/terraform-provider-azuredevops/issues/174) that was enabled in a recent commit. This change skips the broken test so that other PRs can merge while the bug is addressed separately.

Issue Number: N/A


## What is the new behavior?
-------------------------------------
- `TestAccGroupMembership_CreateAndRemove` is skipped.

## Does this introduce a breaking change?
-------------------------------------
- [NO]