### PR TITLE
increasing project create timeout to handle build failures

### DIFF
--- a/azuredevops/resource_project.go
+++ b/azuredevops/resource_project.go
@@ -21,7 +21,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/validate"
 )
 
-var projectCreateTimeoutDuration time.Duration = 60
+var projectCreateTimeoutDuration time.Duration = 60 * 3
 var projectDeleteTimeoutDuration time.Duration = 60
 
 func resourceProject() *schema.Resource {


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
Automated CICD checks fail sometimes because there is a timeout condition waiting for a new project to create


## What is the new behavior?
-------------------------------------
- The timeout has been increased from 1 minute to 3 minutes


## Does this introduce a breaking change?
-------------------------------------
- [NO]
