### PR TITLE
Prevent index out of bound operation when validating build path

### DIFF
--- a/azuredevops/utils/validate/file_path.go
+++ b/azuredevops/utils/validate/file_path.go
@@ -20,7 +20,7 @@ func Path(i interface{}, k string) (warnings []string, errors []error) {
 		errors = append(errors, fmt.Errorf("path can not be empty"))
 	}
 
-	if v[:1] != `\` {
+	if len(v) >= 1 && v[:1] != `\` {
 		errors = append(errors, fmt.Errorf("path must start with backslash"))
 	}
 

--- a/azuredevops/utils/validate/file_path_test.go
+++ b/azuredevops/utils/validate/file_path_test.go
@@ -1,0 +1,51 @@
+// +build all utils path
+
+package validate
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPathValidation(t *testing.T) {
+	type TestCase struct {
+		Value    string
+		TestName string
+		ErrCount int
+	}
+	cases := []TestCase{
+		{
+			Value:    `\`,
+			TestName: "Default Path",
+			ErrCount: 0,
+		},
+		{
+			Value:    "",
+			TestName: "Empty Path",
+			ErrCount: 1,
+		},
+		{
+			Value:    "A",
+			TestName: "Wrong Starting Character",
+			ErrCount: 1,
+		},
+	}
+
+	illegalChars := []string{"<", ">", "|", ":", "$", "@", `"`, "/", "%", "+", "*", "?"}
+	for _, c := range illegalChars {
+		cases = append(cases, TestCase{
+			Value:    fmt.Sprintf(`\%s`, c),
+			TestName: fmt.Sprintf("Illegal Character - %s", c),
+			ErrCount: 1,
+		})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			_, errors := Path(tc.Value, tc.TestName)
+			if len(errors) != tc.ErrCount {
+				t.Fatalf("Expected TestPathValidation to have %d not %d errors for %q", tc.ErrCount, len(errors), tc.TestName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds additional logic inside the build path validation code.
This logic prevents a panic that occurs when validating an empty
string.


## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
Fixes the crash that is detailed here: 

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/272
