### PR TITLE
[azuredevops_serviceendpoint_azurerm] subscriptionName + subscriptionId have to start with a lower-case 's'

### DIFF
--- a/azuredevops/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/resource_serviceendpoint_azurerm.go
@@ -36,8 +36,8 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 		"creationMode":     "Manual",
 		"environment":      "AzureCloud",
 		"scopeLevel":       "Subscription",
-		"SubscriptionId":   d.Get("azurerm_subscription_id").(string),
-		"SubscriptionName": d.Get("azurerm_subscription_name").(string),
+		"subscriptionId":   d.Get("azurerm_subscription_id").(string),
+		"subscriptionName": d.Get("azurerm_subscription_name").(string),
 	}
 	serviceEndpoint.Type = converter.String("azurerm")
 	serviceEndpoint.Url = converter.String("https://management.azure.com/")

--- a/azuredevops/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/resource_serviceendpoint_azurerm_test.go
@@ -41,8 +41,8 @@ var azurermTestServiceEndpointAzureRM = serviceendpoint.ServiceEndpoint{
 		"creationMode":     "Manual",
 		"environment":      "AzureCloud",
 		"scopeLevel":       "Subscription",
-		"SubscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
-		"SubscriptionName": "SUBSCRIPTION_TEST",
+		"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
+		"subscriptionName": "SUBSCRIPTION_TEST",
 	},
 	Id:          &azurermTestServiceEndpointAzureRMID,
 	Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? Yes
* [YES/NO] I have updated the documentation accordingly. Yes
* [YES/NO/NA] I have added tests to cover my changes. Yes
* [YES/NO/NA] All new and existing tests passed. NA
* [YES/NO/NA] My code follows the code style of this project. Yes
* [YES/NO/NA] I ran lint checks locally prior to submission. Yes
* [YES/NO] Have you checked to ensure there aren't other open PRs for the same update/change? Yes

## What is the current behavior?
-------------------------------------
Issue Number: #294 


## What is the new behavior?
-------------------------------------

AzureRM Service Connection can be used to link Azure Key Vaults to a variable group.

## Does this introduce a breaking change?
-------------------------------------
- NO