### PR TITLE
Prevent Service Principal password from being reset to "" for updates

### DIFF
--- a/azuredevops/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/resource_serviceendpoint_azurerm.go
@@ -89,13 +89,29 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 	if _, ok := d.GetOk("credentials"); ok {
 		credentials := d.Get("credentials").([]interface{})[0].(map[string]interface{})
 		(*serviceEndpoint.Authorization.Parameters)["serviceprincipalid"] = credentials["serviceprincipalid"].(string)
-		(*serviceEndpoint.Authorization.Parameters)["serviceprincipalkey"] = credentials["serviceprincipalkey"].(string)
+		(*serviceEndpoint.Authorization.Parameters)["serviceprincipalkey"] = expandSpnKey(credentials)
 		(*serviceEndpoint.Data)["creationMode"] = "Manual"
 	}
 
 	serviceEndpoint.Type = converter.String("azurerm")
 	serviceEndpoint.Url = converter.String("https://management.azure.com/")
 	return serviceEndpoint, projectID
+}
+
+func expandSpnKey(credentials map[string]interface{}) string {
+	// Note: if this is an update for a field other than `serviceprincipalkey`, the `serviceprincipalkey` will be
+	// set to `""`. Without catching this case and setting the value to `"null"`, the `serviceprincipalkey` will
+	// actually be set to `""` by the Azure DevOps service.
+	//
+	// This step is critical in order to ensure that the service connection can update without loosing its password!
+	//
+	// This behavior is unfortunately not documented in the API documentation.
+	spnKeyI, ok := credentials["serviceprincipalkey"]
+	if !ok || spnKeyI.(string) == "" {
+		return "null"
+	}
+
+	return spnKeyI.(string)
 }
 
 func flattenCredentials(serviceEndpoint *serviceendpoint.ServiceEndpoint, hashKey string, hashValue string) interface{} {

--- a/azuredevops/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/resource_serviceendpoint_azurerm.go
@@ -106,12 +106,12 @@ func expandSpnKey(credentials map[string]interface{}) string {
 	// This step is critical in order to ensure that the service connection can update without loosing its password!
 	//
 	// This behavior is unfortunately not documented in the API documentation.
-	spnKeyI, ok := credentials["serviceprincipalkey"]
-	if !ok || spnKeyI.(string) == "" {
+	spnKey, ok := credentials["serviceprincipalkey"]
+	if !ok || spnKey.(string) == "" {
 		return "null"
 	}
 
-	return spnKeyI.(string)
+	return spnKey.(string)
 }
 
 func flattenCredentials(serviceEndpoint *serviceendpoint.ServiceEndpoint, hashKey string, hashValue string) interface{} {

--- a/azuredevops/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/resource_serviceendpoint_azurerm_test.go
@@ -224,6 +224,16 @@ func TestAzureDevOpsServiceEndpointAzureRM_Update_DoesNotSwallowError(t *testing
 	}
 }
 
+func TestAzureDevOpsServiceEndpointAzureRM_ExpandCredentials(t *testing.T) {
+	spnKeyExistsWithValue := map[string]interface{}{"serviceprincipalkey": "fake-spn-key"}
+	spnKeyExistsWithEmptyValue := map[string]interface{}{"serviceprincipalkey": ""}
+	spnKeyDoesNotExists := map[string]interface{}{}
+
+	require.Equal(t, expandSpnKey(spnKeyExistsWithValue), "fake-spn-key")
+	require.Equal(t, expandSpnKey(spnKeyExistsWithEmptyValue), "null")
+	require.Equal(t, expandSpnKey(spnKeyDoesNotExists), "null")
+}
+
 /**
  * Begin acceptance tests
  */

--- a/azuredevops/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/resource_serviceendpoint_azurerm_test.go
@@ -26,7 +26,35 @@ var azurermTestServiceEndpointAzureRMID = uuid.New()
 var azurermRandomServiceEndpointAzureRMProjectID = uuid.New().String()
 var azurermTestServiceEndpointAzureRMProjectID = &azurermRandomServiceEndpointAzureRMProjectID
 
+func getManualAuthServiceEndpoint() serviceendpoint.ServiceEndpoint {
+	return serviceendpoint.ServiceEndpoint{
+		Authorization: &serviceendpoint.EndpointAuthorization{
+			Parameters: &map[string]string{
+				"authenticationType":  "spnKey",
+				"serviceprincipalid":  "e31eaaac-47da-4156-b433-9b0538c94b7e", //fake value
+				"serviceprincipalkey": "d96d8515-20b2-4413-8879-27c5d040cbc2", //fake value
+				"tenantid":            "aba07645-051c-44b4-b806-c34d33f3dcd1", //fake value
+			},
+			Scheme: converter.String("ServicePrincipal"),
+		},
+		Data: &map[string]string{
+			"creationMode":     "Manual",
+			"environment":      "AzureCloud",
+			"scopeLevel":       "Subscription",
+			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
+			"subscriptionName": "SUBSCRIPTION_TEST",
+		},
+		Id:          &azurermTestServiceEndpointAzureRMID,
+		Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
+		Description: converter.String("_AZURERM_UNIT_TEST_CONN_DESCRIPTION"),
+		Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+		Type:        converter.String("azurerm"),
+		Url:         converter.String("https://management.azure.com/"),
+	}
+}
+
 var azurermTestServiceEndpointsAzureRM = []serviceendpoint.ServiceEndpoint{
+	getManualAuthServiceEndpoint(),
 	{
 		Authorization: &serviceendpoint.EndpointAuthorization{
 			Parameters: &map[string]string{
@@ -39,30 +67,6 @@ var azurermTestServiceEndpointsAzureRM = []serviceendpoint.ServiceEndpoint{
 		},
 		Data: &map[string]string{
 			"creationMode":     "Automatic",
-			"environment":      "AzureCloud",
-			"scopeLevel":       "Subscription",
-			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
-			"subscriptionName": "SUBSCRIPTION_TEST",
-		},
-		Id:          &azurermTestServiceEndpointAzureRMID,
-		Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
-		Description: converter.String("_AZURERM_UNIT_TEST_CONN_DESCRIPTION"),
-		Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
-		Type:        converter.String("azurerm"),
-		Url:         converter.String("https://management.azure.com/"),
-	},
-	{
-		Authorization: &serviceendpoint.EndpointAuthorization{
-			Parameters: &map[string]string{
-				"authenticationType":  "spnKey",
-				"serviceprincipalid":  "e31eaaac-47da-4156-b433-9b0538c94b7e", //fake value
-				"serviceprincipalkey": "d96d8515-20b2-4413-8879-27c5d040cbc2", //fake value
-				"tenantid":            "aba07645-051c-44b4-b806-c34d33f3dcd1", //fake value
-			},
-			Scheme: converter.String("ServicePrincipal"),
-		},
-		Data: &map[string]string{
-			"creationMode":     "Manual",
 			"environment":      "AzureCloud",
 			"scopeLevel":       "Subscription",
 			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
@@ -232,6 +236,31 @@ func TestAzureDevOpsServiceEndpointAzureRM_ExpandCredentials(t *testing.T) {
 	require.Equal(t, expandSpnKey(spnKeyExistsWithValue), "fake-spn-key")
 	require.Equal(t, expandSpnKey(spnKeyExistsWithEmptyValue), "null")
 	require.Equal(t, expandSpnKey(spnKeyDoesNotExists), "null")
+}
+
+// This is a little different than most. The steps done, along with the motivation behind each, are as follows:
+//	(1) The service endpoint is configured. The `serviceprincipalkey` is set to `""`, which matches
+//		the Azure DevOps API behavior. The service will intentionally hide the value of
+//		`serviceprincipalkey` because it is a secret value
+//	(2) The resource is flattened/expanded
+//	(3) The `serviceprincipalkey` field is inspected and asserted to equal `"null"`. This special
+//		value, which is unfortunately not documented in the REST API, will be interpreted by the
+//		Azure DevOps API as an indicator to "not update" the field. The resulting behavior is that
+//		this Terraform Resource will be able to update the Service Endpoint without needing to
+//		pass the password along in each request.
+func TestAzureDevOpsServiceEndpointAzureRM_ExpandHandlesMissingSpnKeyInAPIResponse(t *testing.T) {
+	// step (1)
+	endpoint := getManualAuthServiceEndpoint()
+	resourceData := getResourceData(t, endpoint)
+	(*endpoint.Authorization.Parameters)["serviceprincipalkey"] = ""
+
+	// step (2)
+	flattenServiceEndpointAzureRM(resourceData, &endpoint, azurermTestServiceEndpointAzureRMProjectID)
+	expandedEndpoint, _ := expandServiceEndpointAzureRM(resourceData)
+
+	// step (3)
+	spnKeyProperty := (*expandedEndpoint.Authorization.Parameters)["serviceprincipalkey"]
+	require.Equal(t, "null", spnKeyProperty)
 }
 
 /**


### PR DESCRIPTION
This change fixes a bug that was caused when there was an update applied
to a service connection. The bug would result in the service principal
secret being reset to the empty string.

This change fixes the problem by catching this case and setting the
value to "null", which indicates to the AzDO services that the
password should not be updated.

## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
The SPN secret can get set to `""` if the resource needs to be updated.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/273


## What is the new behavior?
-------------------------------------
The SPN secret is not reset to `""` if the resource needs to be updated. This was tested by ensuring that the "verify" feature within AzDO works before and after the service connection update.
