### PR TITLE
Implement min reviewer branch policy + build validation + fix docs links

### DIFF
--- a/azuredevops/crud/branchpolicy/crud_branch_policy.go
+++ b/azuredevops/crud/branchpolicy/crud_branch_policy.go
@@ -103,7 +103,7 @@ func flattenSettings(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
-_ = json.Unmarshal(policyAsJSON, &policySettings)
+	_ = json.Unmarshal(policyAsJSON, &policySettings)
 	scopes := make([]interface{}, len(policySettings.Scopes))
 	for index, scope := range policySettings.Scopes {
 		scopes[index] = map[string]interface{}{

--- a/azuredevops/crud/branchpolicy/crud_branch_policy.go
+++ b/azuredevops/crud/branchpolicy/crud_branch_policy.go
@@ -103,7 +103,7 @@ func flattenSettings(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
-	json.Unmarshal(policyAsJSON, &policySettings)
+_ = json.Unmarshal(policyAsJSON, &policySettings)
 	scopes := make([]interface{}, len(policySettings.Scopes))
 	for index, scope := range policySettings.Scopes {
 		scopes[index] = map[string]interface{}{

--- a/azuredevops/crud/branchpolicy/crud_branch_policy.go
+++ b/azuredevops/crud/branchpolicy/crud_branch_policy.go
@@ -27,7 +27,7 @@ import (
 var (
 	NoActiveComments = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
 	MinReviewerCount = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4906e5d171dd")
-	SuccessfulBuild  = uuid.MustParse("0609b952-1397-4640-95ec-e00a01b2c241")
+	BuildValidation  = uuid.MustParse("0609b952-1397-4640-95ec-e00a01b2c241")
 )
 
 // Keys for schema elements

--- a/azuredevops/crud/branchpolicy/crud_branch_policy.go
+++ b/azuredevops/crud/branchpolicy/crud_branch_policy.go
@@ -1,0 +1,333 @@
+package branchpolicy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/config"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/suppress"
+)
+
+/**
+ * This file contains base functionality that can be leveraged by all policy configuration
+ * resources. This is possible because a single API is used for configuring many different
+ * policy types.
+ */
+
+// Policy type IDs. These are global and can be listed using the following endpoint:
+//	https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/types/list?view=azure-devops-rest-5.1
+var (
+	NoActiveComments = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
+	MinReviewerCount = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4906e5d171dd")
+	SuccessfulBuild  = uuid.MustParse("0609b952-1397-4640-95ec-e00a01b2c241")
+)
+
+// Keys for schema elements
+const (
+	SchemaProjectID     = "project_id"
+	SchemaEnabled       = "enabled"
+	SchemaBlocking      = "blocking"
+	SchemaSettings      = "settings"
+	SchemaScope         = "scope"
+	SchemaRepositoryID  = "repository_id"
+	SchemaRepositoryRef = "repository_ref"
+	SchemaMatchType     = "match_type"
+)
+
+// The type of repository branch name matching strategy used by the policy
+const (
+	matchTypeExact  string = "Exact"
+	matchTypePrefix string = "Prefix"
+)
+
+// PolicyCrudArgs arguments for GenBasePolicyResource
+type PolicyCrudArgs struct {
+	FlattenFunc func(d *schema.ResourceData, policy *policy.PolicyConfiguration, projectID *string) error
+	ExpandFunc  func(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error)
+	PolicyType  uuid.UUID
+}
+
+// GenBasePolicyResource creates a Resource with the common elements of a build policy
+func GenBasePolicyResource(crudArgs *PolicyCrudArgs) *schema.Resource {
+	return &schema.Resource{
+		Create:   genPolicyCreateFunc(crudArgs),
+		Read:     genPolicyReadFunc(crudArgs),
+		Update:   genPolicyUpdateFunc(crudArgs),
+		Delete:   genPolicyDeleteFunc(crudArgs),
+		Importer: genPolicyImporter(),
+		Schema:   genBaseSchema(),
+	}
+}
+
+type commonPolicySettings struct {
+	Scopes []struct {
+		RepositoryID      string `json:"repositoryId"`
+		RepositoryRefName string `json:"refName"`
+		MatchType         string `json:"matchKind"`
+	} `json:"scope"`
+}
+
+// BaseFlattenFunc flattens each of the base elements of the schema
+func BaseFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	if policyConfig.Id == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(strconv.Itoa(*policyConfig.Id))
+	d.Set(SchemaProjectID, converter.ToString(projectID, ""))
+	d.Set(SchemaEnabled, converter.ToBool(policyConfig.IsEnabled, true))
+	d.Set(SchemaBlocking, converter.ToBool(policyConfig.IsBlocking, true))
+	settings, err := flattenSettings(d, policyConfig)
+	if err != nil {
+		return err
+	}
+	err = d.Set(SchemaSettings, settings)
+	if err != nil {
+		return fmt.Errorf("Unable to persist policy settings configuration: %+v", err)
+	}
+	return nil
+}
+
+func flattenSettings(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration) ([]interface{}, error) {
+	policySettings := commonPolicySettings{}
+	policyAsJSON, err := json.Marshal(policyConfig.Settings)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
+	}
+
+	json.Unmarshal(policyAsJSON, &policySettings)
+	scopes := make([]interface{}, len(policySettings.Scopes))
+	for index, scope := range policySettings.Scopes {
+		scopes[index] = map[string]interface{}{
+			SchemaRepositoryID:  scope.RepositoryID,
+			SchemaRepositoryRef: scope.RepositoryRefName,
+			SchemaMatchType:     scope.MatchType,
+		}
+	}
+	settings := []interface{}{
+		map[string]interface{}{
+			SchemaScope: scopes,
+		},
+	}
+	return settings, nil
+}
+
+// BaseExpandFunc expands each of the base elements of the schema
+func BaseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	projectID := d.Get(SchemaProjectID).(string)
+
+	policyConfig := policy.PolicyConfiguration{
+		IsEnabled:  converter.Bool(d.Get(SchemaEnabled).(bool)),
+		IsBlocking: converter.Bool(d.Get(SchemaBlocking).(bool)),
+		Type: &policy.PolicyTypeRef{
+			Id: &typeID,
+		},
+		Settings: expandSettings(d),
+	}
+
+	if d.Id() != "" {
+		policyID, err := strconv.Atoi(d.Id())
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error parsing policy configuration ID: (%+v)", err)
+		}
+		policyConfig.Id = &policyID
+	}
+
+	return &policyConfig, &projectID, nil
+}
+
+func expandSettings(d *schema.ResourceData) map[string]interface{} {
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+	settingsScopes := settings[SchemaScope].([]interface{})
+
+	scopes := make([]map[string]interface{}, len(settingsScopes))
+	for index, scope := range settingsScopes {
+		scopeMap := scope.(map[string]interface{})
+		scopes[index] = map[string]interface{}{
+			"repositoryId": scopeMap[SchemaRepositoryID],
+			"refName":      scopeMap[SchemaRepositoryRef],
+			"matchKind":    scopeMap[SchemaMatchType],
+		}
+	}
+	return map[string]interface{}{
+		SchemaScope: scopes,
+	}
+}
+
+func genBaseSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		SchemaProjectID: {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		SchemaEnabled: {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		SchemaBlocking: {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		SchemaSettings: {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					SchemaScope: {
+						Type: schema.TypeList,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								SchemaRepositoryID: {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								SchemaRepositoryRef: {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								SchemaMatchType: {
+									Type:             schema.TypeString,
+									Optional:         true,
+									Default:          matchTypeExact,
+									DiffSuppressFunc: suppress.CaseDifference,
+									ValidateFunc: validation.StringInSlice([]string{
+										matchTypeExact, matchTypePrefix,
+									}, true),
+								},
+							},
+						},
+						Required: true,
+						MinItems: 1,
+					},
+				},
+			},
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+		},
+	}
+}
+
+func genPolicyCreateFunc(crudArgs *PolicyCrudArgs) schema.CreateFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*config.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		createdPolicy, err := clients.PolicyClient.CreatePolicyConfiguration(clients.Ctx, policy.CreatePolicyConfigurationArgs{
+			Configuration: policyConfig,
+			Project:       projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error creating policy in Azure DevOps: %+v", err)
+		}
+
+		return crudArgs.FlattenFunc(d, createdPolicy, projectID)
+	}
+}
+
+func genPolicyReadFunc(crudArgs *PolicyCrudArgs) schema.ReadFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*config.AggregatedClient)
+		projectID := d.Get(SchemaProjectID).(string)
+		policyID, err := strconv.Atoi(d.Id())
+
+		if err != nil {
+			return fmt.Errorf("Error converting policy ID to an integer: (%+v)", err)
+		}
+
+		policyConfig, err := clients.PolicyClient.GetPolicyConfiguration(clients.Ctx, policy.GetPolicyConfigurationArgs{
+			Project:         &projectID,
+			ConfigurationId: &policyID,
+		})
+
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
+		}
+
+		return crudArgs.FlattenFunc(d, policyConfig, &projectID)
+	}
+}
+
+func genPolicyUpdateFunc(crudArgs *PolicyCrudArgs) schema.UpdateFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*config.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		updatedPolicy, err := clients.PolicyClient.UpdatePolicyConfiguration(clients.Ctx, policy.UpdatePolicyConfigurationArgs{
+			ConfigurationId: policyConfig.Id,
+			Configuration:   policyConfig,
+			Project:         projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error updating policy in Azure DevOps: %+v", err)
+		}
+
+		return crudArgs.FlattenFunc(d, updatedPolicy, projectID)
+	}
+}
+
+func genPolicyDeleteFunc(crudArgs *PolicyCrudArgs) schema.DeleteFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*config.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		err = clients.PolicyClient.DeletePolicyConfiguration(clients.Ctx, policy.DeletePolicyConfigurationArgs{
+			ConfigurationId: policyConfig.Id,
+			Project:         projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting policy in Azure DevOps: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func genPolicyImporter() *schema.ResourceImporter {
+	return &schema.ResourceImporter{
+		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			id := d.Id()
+			parts := strings.SplitN(id, "/", 2)
+			if len(parts) != 2 || strings.EqualFold(parts[0], "") || strings.EqualFold(parts[1], "") {
+				return nil, fmt.Errorf("unexpected format of ID (%s), expected projectid/resourceId", id)
+			}
+
+			_, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("Policy configuration ID (%s) isn't a valid Int", parts[1])
+			}
+
+			d.Set(SchemaProjectID, parts[0])
+			d.SetId(parts[1])
+			return []*schema.ResourceData{d}, nil
+		},
+	}
+}

--- a/azuredevops/crud/branchpolicy/crud_branch_policy_test.go
+++ b/azuredevops/crud/branchpolicy/crud_branch_policy_test.go
@@ -1,0 +1,169 @@
+package branchpolicy
+
+// The tests in this file use the mock clients in mock_client.go to mock out
+// the Azure DevOps client operations.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/config"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/converter"
+)
+
+/**
+ * Begin unit tests
+ */
+
+var projectID = uuid.New().String()
+var randomUUID = uuid.New()
+var testPolicy = &policy.PolicyConfiguration{
+	Id:         converter.Int(1),
+	IsEnabled:  converter.Bool(true),
+	IsBlocking: converter.Bool(true),
+	Type: &policy.PolicyTypeRef{
+		Id: &randomUUID,
+	},
+	Settings: map[string]interface{}{
+		"scope": []map[string]interface{}{
+			{
+				"repositoryId": "test-repo-id",
+				"refName":      "test-ref-name",
+				"matchKind":    "test-match-kind",
+			},
+		},
+	},
+}
+
+var testResource = GenBasePolicyResource(&PolicyCrudArgs{
+	BaseFlattenFunc,
+	BaseExpandFunc,
+	randomUUID,
+})
+
+func getFlattenedResourceData(t *testing.T) *schema.ResourceData {
+	resourceData := schema.TestResourceDataRaw(t, testResource.Schema, nil)
+	err := BaseFlattenFunc(resourceData, testPolicy, &projectID)
+	require.Nil(t, err)
+	return resourceData
+}
+
+// verifies that the flatten/expand round trip path produces repeatable results
+func TestBranchPolicyCRUD_ExpandFlatten_Roundtrip(t *testing.T) {
+	resourceData := getFlattenedResourceData(t)
+	expandedPolicy, expandedProjectID, err := BaseExpandFunc(resourceData, randomUUID)
+	require.Nil(t, err)
+
+	require.Equal(t, testPolicy, expandedPolicy)
+	require.Equal(t, projectID, *expandedProjectID)
+}
+
+// verifies that CREATE failures are not swallowed
+func TestBranchPolicyCRUD_CreateError_NotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resourceData := getFlattenedResourceData(t)
+
+	policyClient := azdosdkmocks.NewMockPolicyClient(ctrl)
+	clients := &config.AggregatedClient{PolicyClient: policyClient, Ctx: context.Background()}
+
+	expectedArgs := policy.CreatePolicyConfigurationArgs{
+		Configuration: testPolicy,
+		Project:       &projectID,
+	}
+
+	policyClient.
+		EXPECT().
+		CreatePolicyConfiguration(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("CreatePolicyConfiguration() Failed")).
+		Times(1)
+
+	err := testResource.Create(resourceData, clients)
+	require.Regexp(t, ".*CreatePolicyConfiguration\\(\\) Failed$", err.Error())
+}
+
+// verifies that READ failures are not swallowed
+func TestBranchPolicyCRUD_ReadError_NotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resourceData := getFlattenedResourceData(t)
+
+	policyClient := azdosdkmocks.NewMockPolicyClient(ctrl)
+	clients := &config.AggregatedClient{PolicyClient: policyClient, Ctx: context.Background()}
+
+	expectedArgs := policy.GetPolicyConfigurationArgs{
+		ConfigurationId: testPolicy.Id,
+		Project:         &projectID,
+	}
+
+	policyClient.
+		EXPECT().
+		GetPolicyConfiguration(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("GetPolicyConfiguration() Failed")).
+		Times(1)
+
+	err := testResource.Read(resourceData, clients)
+	require.Regexp(t, ".*GetPolicyConfiguration\\(\\) Failed$", err.Error())
+}
+
+// verifies that UDPATE failures are not swallowed
+func TestBranchPolicyCRUD_UpdateError_NotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resourceData := getFlattenedResourceData(t)
+
+	policyClient := azdosdkmocks.NewMockPolicyClient(ctrl)
+	clients := &config.AggregatedClient{PolicyClient: policyClient, Ctx: context.Background()}
+
+	expectedArgs := policy.UpdatePolicyConfigurationArgs{
+		ConfigurationId: testPolicy.Id,
+		Configuration:   testPolicy,
+		Project:         &projectID,
+	}
+
+	policyClient.
+		EXPECT().
+		UpdatePolicyConfiguration(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("UpdatePolicyConfiguration() Failed")).
+		Times(1)
+
+	err := testResource.Update(resourceData, clients)
+	require.Regexp(t, ".*UpdatePolicyConfiguration\\(\\) Failed$", err.Error())
+}
+
+// verifies that DELETE failures are not swallowed
+func TestBranchPolicyCRUD_DeleteError_NotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resourceData := getFlattenedResourceData(t)
+
+	policyClient := azdosdkmocks.NewMockPolicyClient(ctrl)
+	clients := &config.AggregatedClient{PolicyClient: policyClient, Ctx: context.Background()}
+
+	expectedArgs := policy.DeletePolicyConfigurationArgs{
+		ConfigurationId: testPolicy.Id,
+		Project:         &projectID,
+	}
+
+	policyClient.
+		EXPECT().
+		DeletePolicyConfiguration(clients.Ctx, expectedArgs).
+		Return(errors.New("DeletePolicyConfiguration() Failed")).
+		Times(1)
+
+	err := testResource.Delete(resourceData, clients)
+	require.Regexp(t, ".*DeletePolicyConfiguration\\(\\) Failed$", err.Error())
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -10,6 +10,7 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"azuredevops_resource_authorization":         resourceResourceAuthorization(),
+			"azuredevops_branch_policy_min_reviewers":    resourceBranchPolicyMinReviewers(),
 			"azuredevops_build_definition":               resourceBuildDefinition(),
 			"azuredevops_project":                        resourceProject(),
 			"azuredevops_variable_group":                 resourceVariableGroup(),

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -10,6 +10,7 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"azuredevops_resource_authorization":         resourceResourceAuthorization(),
+			"azuredevops_branch_policy_build_validation": resourceBranchPolicyBuildValidation(),
 			"azuredevops_branch_policy_min_reviewers":    resourceBranchPolicyMinReviewers(),
 			"azuredevops_build_definition":               resourceBuildDefinition(),
 			"azuredevops_project":                        resourceProject(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -17,6 +17,7 @@ func TestAzureDevOpsProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"azuredevops_resource_authorization",
 		"azuredevops_build_definition",
+		"azuredevops_branch_policy_min_reviewers",
 		"azuredevops_project",
 		"azuredevops_serviceendpoint_github",
 		"azuredevops_serviceendpoint_dockerregistry",

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -17,6 +17,7 @@ func TestAzureDevOpsProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"azuredevops_resource_authorization",
 		"azuredevops_build_definition",
+		"azuredevops_branch_policy_build_validation",
 		"azuredevops_branch_policy_min_reviewers",
 		"azuredevops_project",
 		"azuredevops_serviceendpoint_github",

--- a/azuredevops/resource_branchpolicy_acceptance_test.go
+++ b/azuredevops/resource_branchpolicy_acceptance_test.go
@@ -59,10 +59,10 @@ func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
 				Config: getHCL(opts2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", fmt.Sprintf("%t", opts2.minReviewerOptions.blocking)),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", fmt.Sprintf("%t", opts2.minReviewerOptions.enabled)),
-					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", fmt.Sprintf("%t", opts2.buildValidationOptions.enabled)),
-					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", fmt.Sprintf("%t", opts2.buildValidationOptions.enabled)),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "false"),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", "false"),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", "false"),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", "false"),
 				),
 			}, {
 				ResourceName:      minReviewerTfNode,

--- a/azuredevops/resource_branchpolicy_acceptance_test.go
+++ b/azuredevops/resource_branchpolicy_acceptance_test.go
@@ -1,0 +1,106 @@
+package azuredevops
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/testhelper"
+)
+
+/**
+ * Begin acceptance tests
+ */
+
+// Verifies that the following sequence of events occurrs without error:
+//	(1) Branch policies can be created with no errors
+//	(2) Branch policies can be updated with no errors
+//	(3) Branch policies can be deleted with no errors
+func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
+	projName := testhelper.TestAccResourcePrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repoName := testhelper.TestAccResourcePrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	opts1 := hclOptions{
+		projectName: projName,
+		repoName:    repoName,
+		minReviewerOptions: policyOptions{
+			true,
+			true,
+		},
+	}
+
+	opts2 := hclOptions{
+		projectName: projName,
+		repoName:    repoName,
+		minReviewerOptions: policyOptions{
+			false,
+			false,
+		},
+	}
+
+	minReviewerTfNode := "azuredevops_branch_policy_min_reviewers.p"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testhelper.TestAccPreCheck(t, nil) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: getHCL(opts1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", fmt.Sprintf("%t", opts1.minReviewerOptions.blocking)),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", fmt.Sprintf("%t", opts1.minReviewerOptions.enabled)),
+				),
+			}, {
+				Config: getHCL(opts2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", fmt.Sprintf("%t", opts2.minReviewerOptions.blocking)),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", fmt.Sprintf("%t", opts2.minReviewerOptions.enabled)),
+				),
+			}, {
+				ResourceName:      minReviewerTfNode,
+				ImportStateIdFunc: testAccImportStateIDFunc(minReviewerTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+type policyOptions struct {
+	enabled  bool
+	blocking bool
+}
+
+type hclOptions struct {
+	projectName        string
+	repoName           string
+	minReviewerOptions policyOptions
+}
+
+func getHCL(opts hclOptions) string {
+	projectAndRepo := testhelper.TestAccAzureGitRepoResource(opts.projectName, opts.repoName, "Clean")
+	minReviewCountPolicyFmt := `
+	resource "azuredevops_branch_policy_min_reviewers" "p" {
+		project_id = azuredevops_project.project.id
+		enabled  = %t
+		blocking = %t
+		settings {
+			reviewer_count     = 1
+			submitter_can_vote = false
+			scope {
+				repository_id  = azuredevops_git_repository.gitrepo.id
+				repository_ref = azuredevops_git_repository.gitrepo.default_branch
+				match_type     = "exact"
+			}
+		}
+	}`
+
+	minReviewCountPolicy := fmt.Sprintf(
+		minReviewCountPolicyFmt,
+		opts.minReviewerOptions.enabled,
+		opts.minReviewerOptions.blocking)
+
+	return fmt.Sprintf("%s\n%s", projectAndRepo, minReviewCountPolicy)
+}

--- a/azuredevops/resource_branchpolicy_acceptance_test.go
+++ b/azuredevops/resource_branchpolicy_acceptance_test.go
@@ -1,3 +1,5 @@
+// +build all resource_branchpolicy_acceptance_test
+
 package azuredevops
 
 // The tests in this file use the mock clients in mock_client.go to mock out

--- a/azuredevops/resource_branchpolicy_acceptance_test.go
+++ b/azuredevops/resource_branchpolicy_acceptance_test.go
@@ -1,7 +1,11 @@
 package azuredevops
 
+// The tests in this file use the mock clients in mock_client.go to mock out
+// the Azure DevOps client operations.
+
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -22,24 +26,22 @@ func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
 	projName := testhelper.TestAccResourcePrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	repoName := testhelper.TestAccResourcePrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	opts1 := hclOptions{
-		projectName: projName,
-		repoName:    repoName,
-		minReviewerOptions: policyOptions{
-			true,
-			true,
-		},
+		projectName:            projName,
+		repoName:               repoName,
+		minReviewerOptions:     minReviewPolicyOpts{true, true, 1, false},
+		buildValidationOptions: buildValidationPolicyOpts{true, true, "build validation", 0},
 	}
 
 	opts2 := hclOptions{
-		projectName: projName,
-		repoName:    repoName,
-		minReviewerOptions: policyOptions{
-			false,
-			false,
-		},
+		projectName:            projName,
+		repoName:               repoName,
+		minReviewerOptions:     minReviewPolicyOpts{false, false, 2, true},
+		buildValidationOptions: buildValidationPolicyOpts{false, false, "build validation rename", 720},
 	}
 
 	minReviewerTfNode := "azuredevops_branch_policy_min_reviewers.p"
+	buildVlidationTfNode := "azuredevops_branch_policy_build_validation.p"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testhelper.TestAccPreCheck(t, nil) },
 		Providers: testAccProviders,
@@ -48,8 +50,10 @@ func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
 				Config: getHCL(opts1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", fmt.Sprintf("%t", opts1.minReviewerOptions.blocking)),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", fmt.Sprintf("%t", opts1.minReviewerOptions.enabled)),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "true"),
+					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", "true"),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", "true"),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", "true"),
 				),
 			}, {
 				Config: getHCL(opts2),
@@ -57,10 +61,17 @@ func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", fmt.Sprintf("%t", opts2.minReviewerOptions.blocking)),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", fmt.Sprintf("%t", opts2.minReviewerOptions.enabled)),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", fmt.Sprintf("%t", opts2.buildValidationOptions.enabled)),
+					resource.TestCheckResourceAttr(buildVlidationTfNode, "enabled", fmt.Sprintf("%t", opts2.buildValidationOptions.enabled)),
 				),
 			}, {
 				ResourceName:      minReviewerTfNode,
 				ImportStateIdFunc: testAccImportStateIDFunc(minReviewerTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			}, {
+				ResourceName:      buildVlidationTfNode,
+				ImportStateIdFunc: testAccImportStateIDFunc(buildVlidationTfNode),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -68,39 +79,97 @@ func TestAccAzureDevOpsBranchPolicy_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-type policyOptions struct {
-	enabled  bool
-	blocking bool
+type minReviewPolicyOpts struct {
+	enabled          bool
+	blocking         bool
+	reviewers        int
+	submitterCanVote bool
+}
+
+type buildValidationPolicyOpts struct {
+	enabled       bool
+	blocking      bool
+	displayName   string
+	validDuration int
 }
 
 type hclOptions struct {
-	projectName        string
-	repoName           string
-	minReviewerOptions policyOptions
+	projectName            string
+	repoName               string
+	minReviewerOptions     minReviewPolicyOpts
+	buildValidationOptions buildValidationPolicyOpts
 }
 
 func getHCL(opts hclOptions) string {
 	projectAndRepo := testhelper.TestAccAzureGitRepoResource(opts.projectName, opts.repoName, "Clean")
+	buildDef := `
+	resource "azuredevops_build_definition" "build" {
+		project_id = azuredevops_project.project.id
+		name       = "Sample Build Definition"
+
+		repository {
+			repo_type   = "TfsGit"
+			repo_id     = azuredevops_git_repository.gitrepo.id
+			yml_path    = "azure-pipelines.yml"
+		}
+	}
+`
 	minReviewCountPolicyFmt := `
 	resource "azuredevops_branch_policy_min_reviewers" "p" {
 		project_id = azuredevops_project.project.id
 		enabled  = %t
 		blocking = %t
 		settings {
-			reviewer_count     = 1
-			submitter_can_vote = false
+			reviewer_count     = %d
+			submitter_can_vote = %t
 			scope {
 				repository_id  = azuredevops_git_repository.gitrepo.id
 				repository_ref = azuredevops_git_repository.gitrepo.default_branch
 				match_type     = "exact"
 			}
 		}
-	}`
+	}
+`
 
 	minReviewCountPolicy := fmt.Sprintf(
 		minReviewCountPolicyFmt,
 		opts.minReviewerOptions.enabled,
-		opts.minReviewerOptions.blocking)
+		opts.minReviewerOptions.blocking,
+		opts.minReviewerOptions.reviewers,
+		opts.minReviewerOptions.submitterCanVote)
 
-	return fmt.Sprintf("%s\n%s", projectAndRepo, minReviewCountPolicy)
+	buildValidationPolicyFmt := `
+	resource "azuredevops_branch_policy_build_validation" "p" {
+		project_id = azuredevops_project.project.id
+		enabled  = %t
+		blocking = %t
+		settings {
+			display_name = "%s"
+			valid_duration = %d
+			build_definition_id = azuredevops_build_definition.build.id
+			scope {
+				repository_id  = azuredevops_git_repository.gitrepo.id
+				repository_ref = azuredevops_git_repository.gitrepo.default_branch
+				match_type     = "exact"
+			}
+		}
+	}
+`
+	buildValidationPolicyFmt = fmt.Sprintf(
+		buildValidationPolicyFmt,
+		opts.buildValidationOptions.enabled,
+		opts.buildValidationOptions.blocking,
+		opts.buildValidationOptions.displayName,
+		opts.buildValidationOptions.validDuration)
+
+	return strings.Join(
+		[]string{
+			projectAndRepo,
+			buildDef,
+			minReviewCountPolicy,
+			buildValidationPolicyFmt,
+		},
+		"\n",
+	)
+
 }

--- a/azuredevops/resource_branchpolicy_build_validation.go
+++ b/azuredevops/resource_branchpolicy_build_validation.go
@@ -1,0 +1,113 @@
+package azuredevops
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/crud/branchpolicy"
+)
+
+const (
+	buildDefinitionID       = "build_definition_id"
+	policyDisplayName       = "display_name"
+	manualQueueOnly         = "manual_queue_only"
+	queueOnSourceUpdateOnly = "queue_on_source_update_only"
+	validDuration           = "valid_duration"
+)
+
+type buildValidationPolicySettings struct {
+	BuildDefinitionID       int    `json:"buildDefinitionId"`
+	PolicyDisplayName       string `json:"displayName"`
+	ManualQueueOnly         bool   `json:"manualQueueOnly"`
+	QueueOnSourceUpdateOnly bool   `json:"queueOnSourceUpdateOnly"`
+	ValidDuration           int    `json:"validDuration"`
+}
+
+func resourceBranchPolicyBuildValidation() *schema.Resource {
+	resource := branchpolicy.GenBasePolicyResource(&branchpolicy.PolicyCrudArgs{
+		FlattenFunc: buildValidationFlattenFunc,
+		ExpandFunc:  buildValidationExpandFunc,
+		PolicyType:  branchpolicy.BuildValidation,
+	})
+
+	settingsSchema := resource.Schema[branchpolicy.SchemaSettings].Elem.(*schema.Resource).Schema
+	settingsSchema[buildDefinitionID] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Required: true,
+	}
+	settingsSchema[policyDisplayName] = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.NoZeroValues,
+	}
+	settingsSchema[manualQueueOnly] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Default:  false,
+		Optional: true,
+	}
+	settingsSchema[queueOnSourceUpdateOnly] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Default:  true,
+		Optional: true,
+	}
+	settingsSchema[validDuration] = &schema.Schema{
+		Type:         schema.TypeInt,
+		Default:      720,
+		Optional:     true,
+		ValidateFunc: validation.IntAtLeast(0),
+	}
+	return resource
+}
+
+func buildValidationFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	err := branchpolicy.BaseFlattenFunc(d, policyConfig, projectID)
+	if err != nil {
+		return err
+	}
+	policyAsJSON, err := json.Marshal(policyConfig.Settings)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
+	}
+
+	policySettings := buildValidationPolicySettings{}
+	err = json.Unmarshal(policyAsJSON, &policySettings)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
+	}
+
+	settingsList := d.Get(branchpolicy.SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	settings[buildDefinitionID] = policySettings.BuildDefinitionID
+	settings[policyDisplayName] = policySettings.PolicyDisplayName
+	settings[manualQueueOnly] = policySettings.ManualQueueOnly
+	settings[queueOnSourceUpdateOnly] = policySettings.QueueOnSourceUpdateOnly
+	settings[validDuration] = policySettings.ValidDuration
+
+	d.Set(branchpolicy.SchemaSettings, settingsList)
+	return nil
+}
+
+func buildValidationExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	policyConfig, projectID, err := branchpolicy.BaseExpandFunc(d, typeID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	settingsList := d.Get(branchpolicy.SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+	policySettings := policyConfig.Settings.(map[string]interface{})
+
+	policySettings["buildDefinitionId"] = settings[buildDefinitionID].(int)
+	policySettings["displayName"] = settings[policyDisplayName].(string)
+	policySettings["manualQueueOnly"] = settings[manualQueueOnly].(bool)
+	policySettings["queueOnSourceUpdateOnly"] = settings[queueOnSourceUpdateOnly].(bool)
+	policySettings["validDuration"] = settings[validDuration].(int)
+
+	return policyConfig, projectID, nil
+}

--- a/azuredevops/resource_branchpolicy_min_reviewers.go
+++ b/azuredevops/resource_branchpolicy_min_reviewers.go
@@ -1,0 +1,86 @@
+package azuredevops
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/crud/branchpolicy"
+)
+
+const (
+	schemaReviewerCount    = "reviewer_count"
+	schemaSubmitterCanVote = "submitter_can_vote"
+)
+
+type minReviewerPolicySettings struct {
+	ApprovalCount    int  `json:"minimumApproverCount"`
+	SubmitterCanVote bool `json:"creatorVoteCounts"`
+}
+
+func resourceBranchPolicyMinReviewers() *schema.Resource {
+	resource := branchpolicy.GenBasePolicyResource(&branchpolicy.PolicyCrudArgs{
+		FlattenFunc: flattenFunc,
+		ExpandFunc:  expandFunc,
+		PolicyType:  branchpolicy.MinReviewerCount,
+	})
+
+	settingsSchema := resource.Schema[branchpolicy.SchemaSettings].Elem.(*schema.Resource).Schema
+	settingsSchema[schemaReviewerCount] = &schema.Schema{
+		Type:         schema.TypeInt,
+		Required:     true,
+		ValidateFunc: validation.IntAtLeast(1),
+	}
+	settingsSchema[schemaSubmitterCanVote] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Default:  false,
+		Optional: true,
+	}
+	return resource
+}
+
+func flattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	err := branchpolicy.BaseFlattenFunc(d, policyConfig, projectID)
+	if err != nil {
+		return err
+	}
+	policyAsJSON, err := json.Marshal(policyConfig.Settings)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
+	}
+
+	policySettings := minReviewerPolicySettings{}
+	err = json.Unmarshal(policyAsJSON, &policySettings)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
+	}
+
+	settingsList := d.Get(branchpolicy.SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	settings[schemaReviewerCount] = policySettings.ApprovalCount
+	settings[schemaSubmitterCanVote] = policySettings.SubmitterCanVote
+
+	d.Set(branchpolicy.SchemaSettings, settingsList)
+	return nil
+}
+
+func expandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	policyConfig, projectID, err := branchpolicy.BaseExpandFunc(d, typeID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	settingsList := d.Get(branchpolicy.SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+	policySettings["minimumApproverCount"] = settings[schemaReviewerCount].(int)
+	policySettings["creatorVoteCounts"] = settings[schemaSubmitterCanVote].(bool)
+
+	return policyConfig, projectID, nil
+}

--- a/azuredevops/resource_branchpolicy_min_reviewers.go
+++ b/azuredevops/resource_branchpolicy_min_reviewers.go
@@ -24,8 +24,8 @@ type minReviewerPolicySettings struct {
 
 func resourceBranchPolicyMinReviewers() *schema.Resource {
 	resource := branchpolicy.GenBasePolicyResource(&branchpolicy.PolicyCrudArgs{
-		FlattenFunc: flattenFunc,
-		ExpandFunc:  expandFunc,
+		FlattenFunc: minReviewersFlattenFunc,
+		ExpandFunc:  minReviewersExpandFunc,
 		PolicyType:  branchpolicy.MinReviewerCount,
 	})
 
@@ -43,7 +43,7 @@ func resourceBranchPolicyMinReviewers() *schema.Resource {
 	return resource
 }
 
-func flattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+func minReviewersFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
 	err := branchpolicy.BaseFlattenFunc(d, policyConfig, projectID)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func flattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguratio
 	return nil
 }
 
-func expandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+func minReviewersExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
 	policyConfig, projectID, err := branchpolicy.BaseExpandFunc(d, typeID)
 	if err != nil {
 		return nil, nil, err

--- a/azuredevops/utils/HttpResponse.go
+++ b/azuredevops/utils/HttpResponse.go
@@ -13,6 +13,9 @@ func ResponseWasNotFound(err error) bool {
 
 // ResponseWasStatusCode was used for check if error status code was specific http status code
 func ResponseWasStatusCode(err error, statusCode int) bool {
+	if err == nil {
+		return false
+	}
 	if wrapperErr, ok := err.(azuredevops.WrappedError); ok {
 		if wrapperErr.StatusCode != nil && *wrapperErr.StatusCode == statusCode {
 			return true

--- a/azuredevops/utils/config/config.go
+++ b/azuredevops/utils/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/graph"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/memberentitlementmanagement"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/operations"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/version"
@@ -34,6 +35,7 @@ type AggregatedClient struct {
 	GitReposClient                git.Client
 	GraphClient                   graph.Client
 	OperationsClient              operations.Client
+	PolicyClient                  policy.Client
 	ServiceEndpointClient         serviceendpoint.Client
 	TaskAgentClient               taskagent.Client
 	MemberEntitleManagementClient memberentitlementmanagement.Client
@@ -111,6 +113,13 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		return nil, err
 	}
 
+	// https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-5.1
+	policyClient, err := policy.NewClient(ctx, connection)
+	if err != nil {
+		log.Printf("getAzdoClient(): policy.NewClient failed.")
+		return nil, err
+	}
+
 	aggregatedClient := &AggregatedClient{
 		OrganizationURL:               organizationURL,
 		CoreClient:                    coreClient,
@@ -118,6 +127,7 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		GitReposClient:                gitReposClient,
 		GraphClient:                   graphClient,
 		OperationsClient:              operationsClient,
+		PolicyClient:                  policyClient,
 		ServiceEndpointClient:         serviceEndpointClient,
 		TaskAgentClient:               taskagentClient,
 		MemberEntitleManagementClient: memberentitlementmanagementClient,

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/microsoft/azure-devops-go-api/azuredevops v0.0.0-20200327121006-543de4815ec2 h1:Xi4UB142pCZ7i5UAvJO60PZQCCyQf+6uJ5/6aX/Z5bk=
-github.com/microsoft/azure-devops-go-api/azuredevops v0.0.0-20200327121006-543de4815ec2/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b2 h1:BF9jJAspnyzig7c8e1Ka3sxaYRJLC9HntYH2jE3f9C8=
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b2/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/scripts/fmt-check-go.sh
+++ b/scripts/fmt-check-go.sh
@@ -4,14 +4,14 @@ set -euo pipefail
 
 . $(dirname $0)/commons.sh
 
-info "Formatting Go Files... If this fails, run 'find . -name \"*.go\" | xargs gofmt -s -w' to fix"
+info "Formatting Go Files... If this fails, run 'find . -name \"*.go\" | grep -v 'vendor' | xargs gofmt -s -w' to fix"
 (
     cd "$SOURCE_DIR"
 
     # This runs a go fmt on each file without using the 'go fmt ./...' syntax.
     # This is advantageous because it avoids having to download all of the go
     # dependencies that would have been triggered by using the './...' syntax.
-    FILES_WITH_FMT_ISSUES=$(find . -name "*.go" | grep -v 'vendor'|  xargs gofmt -s -l | wc -l)
+    FILES_WITH_FMT_ISSUES=$(find . -name "*.go" | grep -v 'vendor' |  xargs gofmt -s -l | wc -l)
 
     # convert to integer...
     FILES_WITH_FMT_ISSUES=$(($FILES_WITH_FMT_ISSUES + 0))

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -29,11 +29,22 @@
               <a href="#">Data Sources</a>
               <ul class="nav">
                 <li>
+                    <a href="/docs/providers/azuredevops/d/data_client_config.html">azuredevops_client_config</a>
+                </li>
+                <li>
+                    <a href="/docs/providers/azuredevops/d/data_git_repositories.html">azuredevops_git_repositories</a>
+                </li>                
+                <li>
                     <a href="/docs/providers/azuredevops/d/data_group.html">azuredevops_group</a>
                 </li>
-
                 <li>
-                    <a href="/docs/providers/azuredevops/d/data_project.html">azuredevops_projects</a>
+                    <a href="/docs/providers/azuredevops/d/data_project.html">azuredevops_project</a>
+                </li>
+                <li>
+                    <a href="/docs/providers/azuredevops/d/data_projects.html">azuredevops_projects</a>
+                </li>
+                <li>
+                    <a href="/docs/providers/azuredevops/d/data_users.html">azuredevops_users</a>
                 </li>
               </ul>
             </li>
@@ -48,6 +59,9 @@
                   <a href="/docs/providers/azuredevops/r/azure_git_repository.html">azuredevops_azure_git_repository</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/branch_policy_min_reviewers.html">azuredevops_branch_policy_min_reviewers</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/build_definition.html">azuredevops_build_definition</a>
                 </li>
                 <li>
@@ -60,6 +74,9 @@
                   <a href="/docs/providers/azuredevops/r/project.html">azuredevops_project</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/resource_authorization.html">azuredevops_resource_authorization</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/serviceendpoint_azurerm.html">azuredevops_serviceendpoint_azurerm</a>
                 </li>
                 <li>
@@ -70,6 +87,9 @@
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/serviceendpoint_github.html">azuredevops_serviceendpoint_github</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azuredevops/r/serviceendpoint_kubernetes.html">azuredevops_serviceendpoint_kubernetes</a>
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/user_entitlement.html">azuredevops_user_entitlement</a>

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -59,6 +59,9 @@
                   <a href="/docs/providers/azuredevops/r/azure_git_repository.html">azuredevops_azure_git_repository</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/branch_policy_build_validation.html">azuredevops_branch_policy_build_validation</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_min_reviewers.html">azuredevops_branch_policy_min_reviewers</a>
                 </li>
                 <li>

--- a/website/docs/r/branch_policy_build_validation.html.markdown
+++ b/website/docs/r/branch_policy_build_validation.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_branch_policy_build_validation"
+description: |-
+  Manages a build validation branch policy within Azure DevOps project.
+---
+
+# azuredevops_branch_policy_build_validation
+Manages a build validation branch policy within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "p" {
+  project_name = "Sample Project"
+}
+
+resource "azuredevops_git_repository" "r" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Repo"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_build_definition" "b" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Build Definition"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = azuredevops_git_repository.r.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_branch_policy_build_validation" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    display_name        = "Don't break the build!"
+    build_definition_id = azuredevops_build_definition.b.id
+    valid_duration      = 720
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = azuredevops_git_repository.r.default_branch
+      match_type     = "Exact"
+    }
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = "refs/heads/releases"
+      match_type     = "Prefix"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project in which the policy will be created.
+* `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
+* `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+* `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
+
+A `settings` block supports the following:
+
+* `build_definition_id` - (Required) The ID of the build to monitor for the policy.
+* `display_name` - (Required) The display name for the policy.
+* `manual_queue_only` - (Optional) If set to true, the build will need to be manually queued. Defaults to `false`
+* `queue_on_source_update_only` - (Optional) True if the build should queue on source updates only. Defaults to `true`.
+* `valid_duration` - (Optional) The number of minutes for which the build is valid. If `0`, the build will not expire. Defaults to `720` (12 hours).
+* `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
+
+A `settings` `scope` block supports the following:
+* `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
+* `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+* `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of branch policy configuration.
+
+
+## Relevant Links
+* [Azure DevOps Service REST API 5.1 - Policy Configurations](https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-5.1)
+
+## Import
+Azure DevOps Branch Policies can be imported using the project ID and policy configuration ID:
+
+```
+terraform import azuredevops_branch_policy_min_reviewers.p aa4a9756-8a86-4588-86d7-b3ee2d88b033/60```

--- a/website/docs/r/branch_policy_build_validation.html.markdown
+++ b/website/docs/r/branch_policy_build_validation.html.markdown
@@ -98,4 +98,4 @@ In addition to all arguments above, the following attributes are exported:
 Azure DevOps Branch Policies can be imported using the project ID and policy configuration ID:
 
 ```
-terraform import azuredevops_branch_policy_min_reviewers.p aa4a9756-8a86-4588-86d7-b3ee2d88b033/60```
+terraform import azuredevops_branch_policy_build_validation.p aa4a9756-8a86-4588-86d7-b3ee2d88b033/60```

--- a/website/docs/r/branch_policy_min_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_min_reviewers.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_branch_policy_min_reviewers"
+description: |-
+  Manages a minimum reviewer branch policy within Azure DevOps project.
+---
+
+# azuredevops_branch_policy_min_reviewers
+Manages a minimum reviewer branch policy within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "p" {
+  project_name = "Sample Project"
+}
+
+resource "azuredevops_git_repository" "r" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Repo"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_branch_policy_min_reviewers" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    reviewer_count     = 2
+    submitter_can_vote = false
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = azuredevops_git_repository.r.default_branch
+      match_type     = "Exact"
+    }
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = "refs/heads/releases"
+      match_type     = "Prefix"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project in which the policy will be created.
+* `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
+* `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+* `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
+
+A `settings` block supports the following:
+
+* `reviewer_count` - (Required) The number of reviewrs needed to approve.
+* `submitter_can_vote` - (Optional) Controls whether or not the submitter's vote counts. Defaults to `false`.
+* `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
+
+A `settings` `scope` block supports the following:
+* `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
+* `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+* `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of branch policy configuration.
+
+
+## Relevant Links
+* [Azure DevOps Service REST API 5.1 - Policy Configurations](https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-5.1)
+
+## Import
+Azure DevOps Branch Policies can be imported using the project ID and policy configuration ID:
+
+```
+terraform import azuredevops_branch_policy_min_reviewers.p aa4a9756-8a86-4588-86d7-b3ee2d88b033/60```


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open PRs for the same update/change?

## What is the current behavior?
-------------------------------------
This change adds two main components:
 - Base code that enables configuration of all build policy types
 - Concrete implementation of `min reviewer` build policy
 - Concrete implementation of `build validation` build policy

It also fixes some missing documentation links for resources.

There will be a follow up story to implement other types of build policies, but they will not be included in this PR.

Closes:
 - https://github.com/microsoft/terraform-provider-azuredevops/issues/182
 - https://github.com/microsoft/terraform-provider-azuredevops/issues/184
 - https://github.com/microsoft/terraform-provider-azuredevops/issues/183


## What is the new behavior?
-------------------------------------
It is now possible to configure min reviewer branch policies like so:
```hcl
resource "azuredevops_branch_policy_min_reviewers" "p" {
  project_id = azuredevops_project.p.id

  enabled  = true
  blocking = true

  settings {
    reviewer_count     = 2
    submitter_can_vote = false

    scope {
      repository_id  = azuredevops_git_repository.r.id
      repository_ref = azuredevops_git_repository.r.default_branch
      match_type     = "Exact"
    }

    scope {
      repository_id  = azuredevops_git_repository.r.id
      repository_ref = "refs/heads/releases"
      match_type     = "Prefix"
    }
  }
}
```

or for a build validation:

```hcl
resource "azuredevops_branch_policy_build_validation" "p" {
  project_id = azuredevops_project.p.id

  enabled  = true
  blocking = true

  settings {
    display_name        = "Don't break the build!"
    build_definition_id = azuredevops_build_definition.b.id
    valid_duration      = 720

    scope {
      repository_id  = azuredevops_git_repository.r.id
      repository_ref = azuredevops_git_repository.r.default_branch
      match_type     = "Exact"
    }

    scope {
      repository_id  = azuredevops_git_repository.r.id
      repository_ref = "refs/heads/releases"
      match_type     = "Prefix"
    }
  }
}
```

## Does this introduce a breaking change?
-------------------------------------
- [NO]

## Other information
-------------------------------------
This change also updates the version of the `azure-devops-go-api` dependency, which includes a fix that enables the development of this feature.