### PR TITLE
Fix 400 bad request not found

### DIFF
--- a/azuredevops/internal/service/build/resource_resource_authorization.go
+++ b/azuredevops/internal/service/build/resource_resource_authorization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils/suppress"
 )
@@ -89,6 +90,10 @@ func resourceResourceAuthorizationRead(d *schema.ResourceData, m interface{}) er
 		})
 
 		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				d.SetId("")
+				return nil
+			}
 			return err
 		}
 

--- a/azuredevops/internal/utils/HttpResponse.go
+++ b/azuredevops/internal/utils/HttpResponse.go
@@ -44,7 +44,7 @@ func ResponseContainsStatusMessage(err error, statusMessage string) bool {
 		return false
 	}
 	if wrapperErr, ok := err.(azuredevops.WrappedError); ok {
-		if wrapperErr.Message == nil{
+		if wrapperErr.Message == nil {
 			return false
 		}
 		return strings.Contains(*wrapperErr.Message, statusMessage)

--- a/azuredevops/internal/utils/HttpResponse.go
+++ b/azuredevops/internal/utils/HttpResponse.go
@@ -2,13 +2,27 @@ package utils
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 )
 
-// ResponseWasNotFound was used for check if error status was 404
+// ResponseWasNotFound was used for check if error is due to resource not found
 func ResponseWasNotFound(err error) bool {
-	return ResponseWasStatusCode(err, http.StatusNotFound)
+	// If API returns 404, resource was not found
+	statusNotFound := ResponseWasStatusCode(err, http.StatusNotFound)
+	if statusNotFound {
+		return statusNotFound
+	}
+
+	// Some APIs return 400 BadRequest with the VS800075 error message if
+	// DevOps Project doesn't exist. If parent project doesn't exist, all
+	// child resources are considered "doesn't exist".
+	statusBadRequest := ResponseWasStatusCode(err, http.StatusBadRequest)
+	if statusBadRequest {
+		return ResponseContainsStatusMessage(err, "VS800075")
+	}
+	return false
 }
 
 // ResponseWasStatusCode was used for check if error status code was specific http status code
@@ -20,6 +34,20 @@ func ResponseWasStatusCode(err error, statusCode int) bool {
 		if wrapperErr.StatusCode != nil && *wrapperErr.StatusCode == statusCode {
 			return true
 		}
+	}
+	return false
+}
+
+// ResponseContainsStatusMessage is used for check if error message contains specific message
+func ResponseContainsStatusMessage(err error, statusMessage string) bool {
+	if err == nil {
+		return false
+	}
+	if wrapperErr, ok := err.(azuredevops.WrappedError); ok {
+		if wrapperErr.Message == nil{
+			return false
+		}
+		return strings.Contains(*wrapperErr.Message, statusMessage)
 	}
 	return false
 }

--- a/azuredevops/internal/utils/HttpResponse_test.go
+++ b/azuredevops/internal/utils/HttpResponse_test.go
@@ -1,32 +1,32 @@
 package utils
 
 import "testing"
-import 	"github.com/microsoft/azure-devops-go-api/azuredevops"
+import "github.com/microsoft/azure-devops-go-api/azuredevops"
 
 func TestResponseContainsStatusMessage(t *testing.T) {
 	cases := []struct {
-		Name string
-		Error  error
+		Name               string
+		Error              error
 		StatusMessageRegex string
-		Result bool
+		Result             bool
 	}{
 		{
-			Name: "ProjectNotFound",
-			Error:  GetError(400, "VS800075: The project with id"),
+			Name:               "ProjectNotFound",
+			Error:              GetError(400, "VS800075: The project with id"),
 			StatusMessageRegex: "VS800075",
-			Result: true,
+			Result:             true,
 		},
 		{
-			Name: "RandomError",
-			Error:  GetError(400, "VS800075: The project with id"),
+			Name:               "RandomError",
+			Error:              GetError(400, "VS800075: The project with id"),
 			StatusMessageRegex: "VS800076",
-			Result: false,
+			Result:             false,
 		},
 		{
-			Name: "MissingMessage",
-			Error:  azuredevops.WrappedError{},
+			Name:               "MissingMessage",
+			Error:              azuredevops.WrappedError{},
 			StatusMessageRegex: "VS800076",
-			Result: false,
+			Result:             false,
 		},
 	}
 
@@ -43,27 +43,27 @@ func TestResponseContainsStatusMessage(t *testing.T) {
 
 func TestResponseWasNotFound(t *testing.T) {
 	cases := []struct {
-		Name string
+		Name   string
 		Error  error
 		Result bool
 	}{
 		{
-			Name: "NoStatus",
+			Name:   "NoStatus",
 			Error:  azuredevops.WrappedError{},
 			Result: false,
 		},
 		{
-			Name: "404NotFound",
+			Name:   "404NotFound",
 			Error:  GetError(404, ""),
 			Result: true,
 		},
 		{
-			Name: "400NotFound",
+			Name:   "400NotFound",
 			Error:  GetError(400, "VS800075: The project with id"),
 			Result: true,
 		},
 		{
-			Name: "400Different",
+			Name:   "400Different",
 			Error:  GetError(400, "Some different issue"),
 			Result: false,
 		},
@@ -83,6 +83,6 @@ func TestResponseWasNotFound(t *testing.T) {
 func GetError(statusCode int, message string) azuredevops.WrappedError {
 	return azuredevops.WrappedError{
 		StatusCode: &statusCode,
-		Message: &message,
+		Message:    &message,
 	}
 }

--- a/azuredevops/internal/utils/HttpResponse_test.go
+++ b/azuredevops/internal/utils/HttpResponse_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import "testing"
+import 	"github.com/microsoft/azure-devops-go-api/azuredevops"
+
+func TestResponseContainsStatusMessage(t *testing.T) {
+	cases := []struct {
+		Name string
+		Error  error
+		StatusMessageRegex string
+		Result bool
+	}{
+		{
+			Name: "ProjectNotFound",
+			Error:  GetError(400, "VS800075: The project with id"),
+			StatusMessageRegex: "VS800075",
+			Result: true,
+		},
+		{
+			Name: "RandomError",
+			Error:  GetError(400, "VS800075: The project with id"),
+			StatusMessageRegex: "VS800076",
+			Result: false,
+		},
+		{
+			Name: "MissingMessage",
+			Error:  azuredevops.WrappedError{},
+			StatusMessageRegex: "VS800076",
+			Result: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := ResponseContainsStatusMessage(tc.Error, tc.StatusMessageRegex)
+
+			if result != tc.Result {
+				t.Errorf("ResponseContainsStatusMessage returned unexpected result.")
+			}
+		})
+	}
+}
+
+func TestResponseWasNotFound(t *testing.T) {
+	cases := []struct {
+		Name string
+		Error  error
+		Result bool
+	}{
+		{
+			Name: "NoStatus",
+			Error:  azuredevops.WrappedError{},
+			Result: false,
+		},
+		{
+			Name: "404NotFound",
+			Error:  GetError(404, ""),
+			Result: true,
+		},
+		{
+			Name: "400NotFound",
+			Error:  GetError(400, "VS800075: The project with id"),
+			Result: true,
+		},
+		{
+			Name: "400Different",
+			Error:  GetError(400, "Some different issue"),
+			Result: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := ResponseWasNotFound(tc.Error)
+
+			if result != tc.Result {
+				t.Errorf("ResponseWasNotFound returned unexpected result.")
+			}
+		})
+	}
+}
+
+func GetError(statusCode int, message string) azuredevops.WrappedError {
+	return azuredevops.WrappedError{
+		StatusCode: &statusCode,
+		Message: &message,
+	}
+}

--- a/azuredevops/internal/utils/HttpResponse_test.go
+++ b/azuredevops/internal/utils/HttpResponse_test.go
@@ -1,7 +1,10 @@
 package utils
 
-import "testing"
-import "github.com/microsoft/azure-devops-go-api/azuredevops"
+import (
+	"testing"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+)
 
 func TestResponseContainsStatusMessage(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Some Azure DevOps APIs return 400 Bad Request if project doesn't exist instead of 404.

Improved `ResponseWasNotFound` function to check Status Message for VS800075 error code that indicates project doesn't exist

Example: service authorization, Build Definition.

Issue Number: closes https://github.com/terraform-providers/terraform-provider-azuredevops/issues/25

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->