### PR TITLE
WIP: Add Support for GitHub enterprise as a build definition repository type

### DIFF
--- a/azuredevops/internal/model/repo.go
+++ b/azuredevops/internal/model/repo.go
@@ -4,14 +4,16 @@ package model
 type RepoType string
 
 type repoTypeValuesType struct {
-	GitHub    RepoType
-	TfsGit    RepoType
-	Bitbucket RepoType
+	GitHub           RepoType
+	TfsGit           RepoType
+	Bitbucket        RepoType
+	GitHubEnterprise RepoType
 }
 
 // RepoTypeValues enum of the type of the repository
 var RepoTypeValues = repoTypeValuesType{
-	GitHub:    "GitHub",
-	TfsGit:    "TfsGit",
-	Bitbucket: "Bitbucket",
+	GitHub:           "GitHub",
+	TfsGit:           "TfsGit",
+	Bitbucket:        "Bitbucket",
+	GitHubEnterprise: "GitHubEnterprise",
 }

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -161,6 +161,7 @@ func ResourceBuildDefinition() *schema.Resource {
 								string(model.RepoTypeValues.GitHub),
 								string(model.RepoTypeValues.TfsGit),
 								string(model.RepoTypeValues.Bitbucket),
+								string(model.RepoTypeValues.GitHubEnterprise),
 							}, false),
 						},
 						"branch_name": {
@@ -169,6 +170,11 @@ func ResourceBuildDefinition() *schema.Resource {
 							Default:  "master",
 						},
 						"service_connection_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"github_enterprise_url": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "",
@@ -833,6 +839,11 @@ func expandBuildDefinition(d *schema.ResourceData) (*build.BuildDefinition, stri
 		repoName = repoID
 
 		repoAPIURL = fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s", repoName)
+	}
+	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.GitHubEnterprise)) {
+		githubEnterpriseURL := repository["github_enterprise_url"].(string)
+		repoURL = fmt.Sprintf("%s/%s.git", githubEnterpriseURL, repoID)
+		repoAPIURL = fmt.Sprintf("%s/api/v3/repos/%s", githubEnterpriseURL, repoID)
 	}
 
 	ciTriggers := expandBuildDefinitionTriggerList(

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -923,6 +923,9 @@ func validateServiceConnectionIDExistsIfNeeded(d *schema.ResourceData) error {
 	if strings.EqualFold(repoType, string(model.RepoTypeValues.Bitbucket)) && serviceConnectionID == "" {
 		return errors.New("bitbucket repositories need a referenced service connection ID")
 	}
+	if strings.EqualFold(repoType, string(model.RepoTypeValues.GitHubEnterprise)) && serviceConnectionID == "" {
+		return errors.New("GitHub Enterprise repositories need a referenced service connection ID")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Add Support for GitHub enterprise as a build definition repository type.

Under the `repository` block in the `azuredevops_build_definition` resource, you can now specify `GitHubEnterprise` as the `repo_type` and specify the Github Enterprise URL using the `github_enterprise_url` .

Example:
```hcl
resource "azuredevops_build_definition" "build" {
  project_id = azuredevops_project.project.id
  name       = "Sample Build Definition"
  path       = "\\ExampleFolder"

  repository {
    repo_type   = "GitHubEnterprise"
    github_enterprise_url = "https://..."
    personal_access_token = "..."
    service_connection_id = "..."
    repo_id   = "orgName/repoName"
    branch_name = "master"
    yml_path    = "azure-pipelines.yml"
  }
```

Issue Number: #35 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [ ] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->