### PR TITLE
Use the default_branch as the name of an initialized branch instead of defaulting to master

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -228,13 +228,17 @@ func createGitRepository(clients *client.AggregatedClient, repoName *string, pro
 }
 
 func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepository, defaultBranch *string) error {
+	branchName := converter.ToString(defaultBranch, "")
+	if strings.EqualFold(branchName, "") {
+		branchName = "master"
+	}
 	args := git.CreatePushArgs{
 		RepositoryId: repo.Name,
 		Project:      repo.Project.Name,
 		Push: &git.GitPush{
 			RefUpdates: &[]git.GitRefUpdate{
 				{
-					Name:        converter.String("refs/heads/" + *defaultBranch),
+					Name:        converter.String("refs/heads/" + branchName),
 					OldObjectId: converter.String("0000000000000000000000000000000000000000"),
 				},
 			},

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -230,7 +230,7 @@ func createGitRepository(clients *client.AggregatedClient, repoName *string, pro
 func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepository, defaultBranch *string) error {
 	branchName := converter.ToString(defaultBranch, "")
 	if strings.EqualFold(branchName, "") {
-		branchName = "master"
+		branchName = "refs/heads/master"
 	}
 	args := git.CreatePushArgs{
 		RepositoryId: repo.Name,
@@ -238,7 +238,7 @@ func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepo
 		Push: &git.GitPush{
 			RefUpdates: &[]git.GitRefUpdate{
 				{
-					Name:        converter.String("refs/heads/" + branchName),
+					Name:        converter.String(branchName),
 					OldObjectId: converter.String("0000000000000000000000000000000000000000"),
 				},
 			},

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -162,7 +162,7 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if initialization != nil && strings.EqualFold(initialization.initType, "Clean") {
-		err = initializeGitRepository(clients, createdRepo)
+		err = initializeGitRepository(clients, createdRepo, repo.DefaultBranch)
 		if err != nil {
 			if err := deleteGitRepository(clients, createdRepo.Id.String()); err != nil {
 				log.Printf("[WARN] Unable to delete new Git Repository after initialization failed: %+v", err)
@@ -227,14 +227,14 @@ func createGitRepository(clients *client.AggregatedClient, repoName *string, pro
 	return createdRepository, nil
 }
 
-func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepository) error {
+func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepository, defaultBranch *string) error {
 	args := git.CreatePushArgs{
 		RepositoryId: repo.Name,
 		Project:      repo.Project.Name,
 		Push: &git.GitPush{
 			RefUpdates: &[]git.GitRefUpdate{
 				{
-					Name:        converter.String("refs/heads/master"),
+					Name:        converter.String("refs/heads/" + *defaultBranch),
 					OldObjectId: converter.String("0000000000000000000000000000000000000000"),
 				},
 			},

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -178,6 +178,68 @@ func TestGitRepo_Read_DoesNotSwallowErrorFromFailedReadCall(t *testing.T) {
 	require.Contains(t, err.Error(), "GetRepository() Failed")
 }
 
+// verifies that 'Clean' repo initalization uses default branch name
+func TestGitRepo_Initialize_UsesTheDefaultBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	reposClient := azdosdkmocks.NewMockGitClient(ctrl)
+	clients := &client.AggregatedClient{
+		GitReposClient: reposClient,
+		Ctx:            context.Background(),
+	}
+
+	repoName := "test-repository"
+	projectName := "test-project"
+
+	repo := git.GitRepository {
+		Name: &repoName,
+		Project: &core.TeamProjectReference {
+			Name: &projectName,
+		},
+	}
+
+	defaultBranch := "refs/heads/main"
+
+	expectedArgs := git.CreatePushArgs{
+		RepositoryId: repo.Name,
+		Project:      repo.Project.Name,
+		Push: &git.GitPush{
+			RefUpdates: &[]git.GitRefUpdate{
+				{
+					Name:        converter.String(defaultBranch),
+					OldObjectId: converter.String("0000000000000000000000000000000000000000"),
+				},
+			},
+			Commits: &[]git.GitCommitRef{
+				{
+					Comment: converter.String("Initial commit."),
+					Changes: &[]interface{}{
+						git.Change{
+							ChangeType: &git.VersionControlChangeTypeValues.Add,
+							Item: git.GitItem{
+								Path: converter.String("/readme.md"),
+							},
+							NewContent: &git.ItemContent{
+								ContentType: &git.ItemContentTypeValues.RawText,
+								Content:     repo.Project.Name,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	reposClient.
+		EXPECT().
+		CreatePush(clients.Ctx, expectedArgs).
+		Return(nil, nil).
+		Times(1)
+
+	err := initializeGitRepository(clients, &repo, &defaultBranch)
+	require.Nil(t, err, fmt.Sprintf("Error was %v", err))
+}
+
 // verifies that the resource ID is used for reads if the ID is set
 func TestGitRepo_Read_UsesIdIfSet(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -192,9 +192,9 @@ func TestGitRepo_Initialize_UsesTheDefaultBranch(t *testing.T) {
 	repoName := "test-repository"
 	projectName := "test-project"
 
-	repo := git.GitRepository {
+	repo := git.GitRepository{
 		Name: &repoName,
-		Project: &core.TeamProjectReference {
+		Project: &core.TeamProjectReference{
 			Name: &projectName,
 		},
 	}

--- a/website/docs/r/azure_git_repository.html.markdown
+++ b/website/docs/r/azure_git_repository.html.markdown
@@ -64,7 +64,7 @@ In addition to all arguments above, except `initialization`, the following attri
 
 - `id` - The ID of the Git repository.
 
-- `default_branch` - The ref of the default branch.
+- `default_branch` - The ref of the default branch. Will be used as the branch name for initialized repositories.
 - `is_fork` - True if the repository was created as a fork.
 - `remote_url` - Git HTTPS URL of the repository
 - `size` - Size in bytes.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Currently if you initialize a repo, it will always create a 'master' branch. If you specify a 'default_branch' that isn't master, setting the default branch will fail. This change means that the value of 'default_branch' is used as the branch name on initialization e.g. if you wanted the branch to be called 'refs/heads/main'. Note: this only changes the behaviour for 'Clean' initialization type. For uninitialized, there won't be a branch to set.

Issue Number: No issue

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [x] No

## Does this introduce a breaking change?

- [x] No

This does change the behavior in that 'default_branch' now works when initializing repos where previously it didn't. 

## Any relevant logs, error output, etc?

n/a

## Other information

No component changes.