### PR TITLE
Make `initialization` a required field in `azuredevops_git_repository`

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -97,7 +97,7 @@ func ResourceGitRepository() *schema.Resource {
 			},
 			"initialization": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -394,7 +394,6 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 
 	var initialization *repoInitializationMeta = nil
 	initData := d.Get("initialization").(*schema.Set).List()
-
 	// Note: If configured, this will be of length 1 based on the schema definition above.
 	if len(initData) == 1 {
 		initValues := initData[0].(map[string]interface{})

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -111,31 +111,8 @@ func TestGitRepo_FlattenExpand_RoundTrip(t *testing.T) {
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceGitRepository().Schema, nil)
 	resourceData.SetId(gitRepo.Id.String())
-	flattenGitRepository(resourceData, &gitRepo)
-
-	expandedGitRepo, repoInitialization, expandedProjectID, err := expandGitRepository(resourceData)
-
-	require.Nil(t, err)
-	require.NotNil(t, expandedGitRepo)
-	require.NotNil(t, expandedGitRepo.Id)
-	require.Equal(t, *expandedGitRepo.Id, repoID)
-	require.NotNil(t, expandedProjectID)
-	require.Equal(t, *expandedProjectID, projectID)
-	require.Nil(t, repoInitialization)
-}
-
-func TestGitRepo_FlattenExpandInitialization_RoundTrip(t *testing.T) {
-	projectID := uuid.New()
-	project := core.TeamProjectReference{Id: &projectID}
-
-	repoID := uuid.New()
-	repoName := "name"
-	gitRepo := git.GitRepository{Id: &repoID, Name: &repoName, Project: &project}
-
-	resourceData := schema.TestResourceDataRaw(t, ResourceGitRepository().Schema, nil)
-	resourceData.SetId(gitRepo.Id.String())
-	flattenGitRepository(resourceData, &gitRepo)
 	configureCleanInitialization(resourceData)
+	flattenGitRepository(resourceData, &gitRepo)
 
 	expandedGitRepo, repoInitialization, expandedProjectID, err := expandGitRepository(resourceData)
 


### PR DESCRIPTION
Instead of crashing when no initialization type is provided.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] ~~I have updated the documentation accordingly~~ -> Documentation already implies behavior.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #54

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->