### PR TITLE
Fix acceptance tests

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -194,7 +194,7 @@ func getProjectRepoBuildUserEntitlementResource() string {
 	userEntitlement := testutils.HclUserEntitlementResource("acc@test.com")
 	buildDef := testutils.HclBuildDefinitionResource(
 		"Sample Build Definition",
-		`\`,
+		`\\`,
 		"TfsGit",
 		"${azuredevops_git_repository.repository.id}",
 		"master",

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
@@ -105,7 +105,7 @@ func TestAccServiceEndpointBitBucket_update(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointBitBucket_requiresImportErrorStep(t *testing.T) {
+func TestAccServiceEndpointBitBucket_RequiresImportErrorStep(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 
@@ -184,7 +184,6 @@ resource "azuredevops_serviceendpoint_bitbucket" "import" {
   project_id                = azuredevops_serviceendpoint_bitbucket.test.project_id
   service_endpoint_name = azuredevops_serviceendpoint_bitbucket.test.service_endpoint_name
   description            = azuredevops_serviceendpoint_bitbucket.test.description
-  authorization          = azuredevops_serviceendpoint_bitbucket.test.authorization
   username          = azuredevops_serviceendpoint_bitbucket.test.username
   password          = "password"
 }

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -485,8 +485,6 @@ func HclBuildDefinitionResource(
 	yamlPath string,
 	serviceConnectionID string,
 ) string {
-	escapedBuildPath := strings.ReplaceAll(buildPath, `\`, `\\`)
-
 	return fmt.Sprintf(`
 	resource "azuredevops_build_definition" "build" {
 		project_id      = azuredevops_project.project.id
@@ -501,7 +499,7 @@ func HclBuildDefinitionResource(
 			yml_path              = "%s"
 			service_connection_id = "%s"
 		}
-	}`, buildDefinitionName, escapedBuildPath, repoType, repoID, branchName, yamlPath, serviceConnectionID)
+	}`, buildDefinitionName, buildPath, repoType, repoID, branchName, yamlPath, serviceConnectionID)
 }
 
 // HclBuildDefinitionResourceWithProject HCL describing an AzDO build definition and a project


### PR DESCRIPTION
## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Fix all failing acceptance tests, except `TestAccServiceEndpointAws` tests. Created issue #94 for `TestAccServiceEndpointAws` tests.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

```sh
15:22 # make testacc
==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if avaliable
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
TF_ACC=1 go test -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v  -timeout 120m
=== RUN   TestAccAgentPool_DataSource
--- PASS: TestAccAgentPool_DataSource (4.75s)
=== RUN   TestAccAgentPools_DataSource
--- PASS: TestAccAgentPools_DataSource (4.38s)
=== RUN   TestAccClientConfig_LoadsCorrectProperties
--- PASS: TestAccClientConfig_LoadsCorrectProperties (2.03s)
=== RUN   TestAccAzureTfsGitRepositories_DataSource
--- PASS: TestAccAzureTfsGitRepositories_DataSource (16.21s)
=== RUN   TestAccGitRepository_DataSource
--- PASS: TestAccGitRepository_DataSource (17.30s)
=== RUN   TestAccGroupDataSource_Read_HappyPath
--- PASS: TestAccGroupDataSource_Read_HappyPath (11.77s)
=== RUN   TestAccProject_DataSource
--- PASS: TestAccProject_DataSource (12.63s)
=== RUN   TestAccProject_DataSource_IncorrectParameters
--- PASS: TestAccProject_DataSource_IncorrectParameters (0.01s)
=== RUN   TestAccAzureDevOpsProjects_DataSource_SingleProject
--- PASS: TestAccAzureDevOpsProjects_DataSource_SingleProject (9.95s)
=== RUN   TestAccAzureDevOpsProjects_DataSource_EmptyResult
--- PASS: TestAccAzureDevOpsProjects_DataSource_EmptyResult (2.79s)
=== RUN   TestAccResourceAgentQueue_CreateAndUpdate
--- PASS: TestAccResourceAgentQueue_CreateAndUpdate (10.45s)
=== RUN   TestAccAgentPool_CreateAndUpdate
--- PASS: TestAccAgentPool_CreateAndUpdate (5.25s)
=== RUN   TestAccBranchPolicyMinReviewers_CreateAndUpdate
--- PASS: TestAccBranchPolicyMinReviewers_CreateAndUpdate (18.10s)
=== RUN   TestAccBranchPolicyAutoReviewers_CreateAndUpdate
--- PASS: TestAccBranchPolicyAutoReviewers_CreateAndUpdate (20.02s)
=== RUN   TestAccBranchPolicyBuildValidation_CreateAndUpdate
--- PASS: TestAccBranchPolicyBuildValidation_CreateAndUpdate (21.45s)
=== RUN   TestAccBuildDefinition_Create_Update_Import
--- PASS: TestAccBuildDefinition_Create_Update_Import (32.64s)
=== RUN   TestAccBuildDefinitionBitbucket_Create
--- PASS: TestAccBuildDefinitionBitbucket_Create (13.33s)
=== RUN   TestAccBuildDefinition_WithVariables_CreateAndUpdate
--- PASS: TestAccBuildDefinition_WithVariables_CreateAndUpdate (17.22s)
=== RUN   TestAccGitPermissions_SetPermissions
--- PASS: TestAccGitPermissions_SetPermissions (16.83s)
=== RUN   TestAccGitRepo_CreateAndUpdate
--- PASS: TestAccGitRepo_CreateAndUpdate (13.20s)
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (0.01s)
=== RUN   TestAccGitRepo_RepoInitialization_Clean
--- PASS: TestAccGitRepo_RepoInitialization_Clean (13.56s)
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (11.12s)
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (15.86s)
=== RUN   TestAccGroupMembership_CreateAndRemove
--- SKIP: TestAccGroupMembership_CreateAndRemove (0.00s)
    resource_group_membership_test.go:30: Skipping test TestAccGroupMembership_CreateAndRemove: https://github.com/terraform-providers/terraform-provider-azuredevops/issues/174
=== RUN   TestAccGroupResource_CreateAndUpdate
--- SKIP: TestAccGroupResource_CreateAndUpdate (0.00s)
    resource_group_test.go:19: Skipping test TestAccGroupResource_CreateAndUpdate: transient failures cause inconsistent results: https://github.com/terraform-providers/terraform-provider-azuredevops/issues/174
=== RUN   TestAccProjectFeatures_EnableUpdateFeature
--- PASS: TestAccProjectFeatures_EnableUpdateFeature (12.26s)
=== RUN   TestAccProjectPermissions_SetPermissions
--- PASS: TestAccProjectPermissions_SetPermissions (15.05s)
=== RUN   TestAccProject_CreateAndUpdate
--- PASS: TestAccProject_CreateAndUpdate (14.34s)
=== RUN   TestAccProject_CreateAndUpdateWithFeatures
--- PASS: TestAccProject_CreateAndUpdateWithFeatures (14.38s)
=== RUN   TestAccResourceAuthorization_CRUD
--- PASS: TestAccResourceAuthorization_CRUD (15.25s)
=== RUN   TestAccResourceAuthorization_Definition_CRUD
--- PASS: TestAccResourceAuthorization_Definition_CRUD (18.03s)
=== RUN   TestAccServiceEndpointAws_basic
=== PAUSE TestAccServiceEndpointAws_basic
=== RUN   TestAccServiceEndpointAws_complete
=== PAUSE TestAccServiceEndpointAws_complete
=== RUN   TestAccServiceEndpointAws_update
=== PAUSE TestAccServiceEndpointAws_update
=== RUN   TestAccServiceEndpointAws_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointAws_requiresImportErrorStep
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate (22.00s)
=== RUN   TestAccServiceEndpointBitBucket_basic
=== PAUSE TestAccServiceEndpointBitBucket_basic
=== RUN   TestAccServiceEndpointBitBucket_complete
=== PAUSE TestAccServiceEndpointBitBucket_complete
=== RUN   TestAccServiceEndpointBitBucket_update
=== PAUSE TestAccServiceEndpointBitBucket_update
=== RUN   TestAccServiceEndpointBitBucket_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointBitBucket_RequiresImportErrorStep
=== RUN   TestAccServiceEndpointDockerRegistry_CreateAndUpdate
--- PASS: TestAccServiceEndpointDockerRegistry_CreateAndUpdate (14.29s)
=== RUN   TestAccServiceEndpointGitHub_PersonalTokenBasic
--- PASS: TestAccServiceEndpointGitHub_PersonalTokenBasic (11.63s)
=== RUN   TestAccServiceEndpointGitHub_PersonalTokenUpdate
--- PASS: TestAccServiceEndpointGitHub_PersonalTokenUpdate (16.27s)
=== RUN   TestAccServiceEndpointGitHub_OauthBasic
--- PASS: TestAccServiceEndpointGitHub_OauthBasic (11.79s)
=== RUN   TestAccServiceEndpointGitHub_OauthUpdate
--- PASS: TestAccServiceEndpointGitHub_OauthUpdate (15.27s)
=== RUN   TestAccServiceEndpointGitHub_CreateAndUpdate
--- PASS: TestAccServiceEndpointGitHub_CreateAndUpdate (15.94s)
=== RUN   TestAccServiceEndpointKubernetesForAzureSubscriptionCreateAndUpdate
--- PASS: TestAccServiceEndpointKubernetesForAzureSubscriptionCreateAndUpdate (18.29s)
=== RUN   TestAccServiceEndpointKubernetesForServiceAccountCreateAndUpdate
--- PASS: TestAccServiceEndpointKubernetesForServiceAccountCreateAndUpdate (16.76s)
=== RUN   TestAccServiceEndpointKubernetesForKubeconfigCreateAndUpdate
--- PASS: TestAccServiceEndpointKubernetesForKubeconfigCreateAndUpdate (15.60s)
=== RUN   TestAccUserEntitlement_Create
--- PASS: TestAccUserEntitlement_Create (7.94s)
=== RUN   TestAccVariableGroup_CreateAndUpdate
--- PASS: TestAccVariableGroup_CreateAndUpdate (18.68s)
=== RUN   TestAccVariableGroupKeyVault_CreateAndUpdate
--- PASS: TestAccVariableGroupKeyVault_CreateAndUpdate (14.38s)
=== CONT  TestAccServiceEndpointAws_basic
=== CONT  TestAccServiceEndpointBitBucket_RequiresImportErrorStep
--- FAIL: TestAccServiceEndpointAws_basic (9.71s)
    testing.go:673: Step 0 error: errors during apply:
        
        Error: Error creating service endpoint in Azure DevOps: Unable to find service connection type 'aws' using authentication scheme 'UsernamePassword'.
        
          on /tmp/tf-test370857941/main.tf line 10:
          (source code not available)
        
        
=== CONT  TestAccServiceEndpointBitBucket_update
--- PASS: TestAccServiceEndpointBitBucket_RequiresImportErrorStep (14.52s)
=== CONT  TestAccServiceEndpointBitBucket_complete
--- PASS: TestAccServiceEndpointBitBucket_update (16.41s)
=== CONT  TestAccServiceEndpointBitBucket_basic
--- PASS: TestAccServiceEndpointBitBucket_complete (11.79s)
=== CONT  TestAccServiceEndpointAws_requiresImportErrorStep
--- FAIL: TestAccServiceEndpointAws_requiresImportErrorStep (10.73s)
    testing.go:673: Step 0 error: errors during apply:
        
        Error: Error creating service endpoint in Azure DevOps: Unable to find service connection type 'aws' using authentication scheme 'UsernamePassword'.
        
          on /tmp/tf-test721270730/main.tf line 10:
          (source code not available)
        
        
=== CONT  TestAccServiceEndpointAws_update
--- PASS: TestAccServiceEndpointBitBucket_basic (13.20s)
=== CONT  TestAccServiceEndpointAws_complete
--- FAIL: TestAccServiceEndpointAws_update (9.99s)
    testing.go:673: Step 0 error: errors during apply:
        
        Error: Error creating service endpoint in Azure DevOps: Unable to find service connection type 'aws' using authentication scheme 'UsernamePassword'.
        
          on /tmp/tf-test144228219/main.tf line 10:
          (source code not available)
        
        
--- FAIL: TestAccServiceEndpointAws_complete (9.67s)
    testing.go:673: Step 0 error: errors during apply:
        
        Error: Error creating service endpoint in Azure DevOps: Unable to find service connection type 'aws' using authentication scheme 'UsernamePassword'.
        
          on /tmp/tf-test832658590/main.tf line 10:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/acceptancetests      628.025s
FAIL
GNUmakefile:49: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```