### PR TITLE
Replaced static email in branchpolicy tests

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -5,6 +5,7 @@ package acceptancetests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 	minReviewerTfNode := "azuredevops_branch_policy_min_reviewers.p"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		PreCheck:  func() { testutils.PreCheck(t, &[]string{"AZDO_TEST_AAD_USER_EMAIL"}) },
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
@@ -191,7 +192,8 @@ func getBuildValidationHcl(enabled bool, blocking bool, displayName string, vali
 
 func getProjectRepoBuildUserEntitlementResource() string {
 	projectAndRepo := testutils.HclGitRepoResource(testutils.GenerateResourceName(), testutils.GenerateResourceName(), "Clean")
-	userEntitlement := testutils.HclUserEntitlementResource("acc@test.com")
+	userPrincipalName := os.Getenv("AZDO_TEST_AAD_USER_EMAIL")
+	userEntitlement := testutils.HclUserEntitlementResource(userPrincipalName)
 	buildDef := testutils.HclBuildDefinitionResource(
 		"Sample Build Definition",
 		`\\`,


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~I have updated the documentation accordingly.~~
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Replaced static email with using AZDO_TEST_AAD_USER_EMAIL in `azuredevops/internal/acceptancetests/resource_branchpolicy_test.go`

Issue Number: N/A

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->