### PR TITLE
Add Support for GitHub enterprise as a build definition repository type

### DIFF
--- a/azuredevops/internal/model/repo.go
+++ b/azuredevops/internal/model/repo.go
@@ -4,14 +4,16 @@ package model
 type RepoType string
 
 type repoTypeValuesType struct {
-	GitHub    RepoType
-	TfsGit    RepoType
-	Bitbucket RepoType
+	GitHub           RepoType
+	TfsGit           RepoType
+	Bitbucket        RepoType
+	GitHubEnterprise RepoType
 }
 
 // RepoTypeValues enum of the type of the repository
 var RepoTypeValues = repoTypeValuesType{
-	GitHub:    "GitHub",
-	TfsGit:    "TfsGit",
-	Bitbucket: "Bitbucket",
+	GitHub:           "GitHub",
+	TfsGit:           "TfsGit",
+	Bitbucket:        "Bitbucket",
+	GitHubEnterprise: "GitHubEnterprise",
 }

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -161,6 +161,7 @@ func ResourceBuildDefinition() *schema.Resource {
 								string(model.RepoTypeValues.GitHub),
 								string(model.RepoTypeValues.TfsGit),
 								string(model.RepoTypeValues.Bitbucket),
+								string(model.RepoTypeValues.GitHubEnterprise),
 							}, false),
 						},
 						"branch_name": {
@@ -169,6 +170,11 @@ func ResourceBuildDefinition() *schema.Resource {
 							Default:  "master",
 						},
 						"service_connection_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"github_enterprise_url": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "",
@@ -830,6 +836,11 @@ func expandBuildDefinition(d *schema.ResourceData) (*build.BuildDefinition, stri
 	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.Bitbucket)) {
 		repoURL = fmt.Sprintf("https://bitbucket.org/%s.git", repoID)
 		repoAPIURL = fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s", repoID)
+	}
+	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.GitHubEnterprise)) {
+		githubEnterpriseURL := repository["github_enterprise_url"].(string)
+		repoURL = fmt.Sprintf("%s/%s.git", githubEnterpriseURL, repoID)
+		repoAPIURL = fmt.Sprintf("%s/api/v3/repos/%s", githubEnterpriseURL, repoID)
 	}
 
 	ciTriggers := expandBuildDefinitionTriggerList(

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -920,6 +920,9 @@ func validateServiceConnectionIDExistsIfNeeded(d *schema.ResourceData) error {
 	if strings.EqualFold(repoType, string(model.RepoTypeValues.Bitbucket)) && serviceConnectionID == "" {
 		return errors.New("bitbucket repositories need a referenced service connection ID")
 	}
+	if strings.EqualFold(repoType, string(model.RepoTypeValues.GitHubEnterprise)) && serviceConnectionID == "" {
+		return errors.New("GitHub Enterprise repositories need a referenced service connection ID")
+	}
 	return nil
 }
 

--- a/website/docs/r/build_definition.html.markdown
+++ b/website/docs/r/build_definition.html.markdown
@@ -11,6 +11,7 @@ Manages a Build Definition within Azure DevOps.
 
 ## Example Usage
 
+### Tfs
 ```hcl
 resource "azuredevops_project" "project" {
   project_name       = "Sample Project"
@@ -72,6 +73,29 @@ resource "azuredevops_build_definition" "build" {
 }
 ```
 
+### GitHub Enterprise
+```hcl
+resource "azuredevops_build_definition" "sample_dotnetcore_app_release" {
+  project_id = azuredevops_project.project.id
+  name       = "Sample Build Definition"
+  path       = "\\ExampleFolder"
+
+  ci_trigger {
+    use_yaml = true
+  }
+
+  repository {
+    repo_type             = "GitHubEnterprise"
+    repo_id               = "<GitHub Org>/<Repo Name>"
+    github_enterprise_url = "https://github.company.com"
+    branch_name           = "master"
+    yml_path              = "azure-pipelines.yml"
+    service_connection_id = "..."
+  }
+
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -98,9 +122,10 @@ The following arguments are supported:
 
 - `branch_name` - (Optional) The branch name for which builds are triggered. Defaults to `master`.
 - `repo_id` - (Required) The id of the repository. For `TfsGit` repos, this is simply the ID of the repository. For `Github` repos, this will take the form of `<GitHub Org>/<Repo Name>`. For `Bitbucket` repos, this will take the form of `<Workspace ID>/<Repo Name>`.
-- `repo_type` - (Optional) The repository type. Valid values: `GitHub` or `TfsGit` or `Bitbucket`. Defaults to `Github`.
-- `service_connection_id` - (Optional) The service connection ID. Used if the `repo_type` is `GitHub`.
+- `repo_type` - (Optional) The repository type. Valid values: `GitHub` or `TfsGit` or `Bitbucket` or `GitHub Enterprise`. Defaults to `Github`. If `repo_type` is `GitHubEnterprise`, must use existing project and GitHub Enterprise service connection.
+- `service_connection_id` - (Optional) The service connection ID. Used if the `repo_type` is `GitHub` or `GitHubEnterprise`.
 - `yml_path` - (Required) The path of the Yaml file describing the build definition.
+- `github_enterprise_url` - (Optional) The Github Enterprise URL. Used if `repo_type` is `GithubEnterprise`.
 
 `ci_trigger` block supports the following:
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Add Support for GitHub enterprise as a build definition repository type.

Under the `repository` block in the `azuredevops_build_definition` resource, you can now specify `GitHubEnterprise` as the `repo_type` and specify the Github Enterprise URL using the `github_enterprise_url` .

Example:
```hcl
resource "azuredevops_build_definition" "sample_dotnetcore_app_release" {
  project_id = azuredevops_project.project.id
  name       = "Sample Build Definition"
  path       = "\\ExampleFolder"

  ci_trigger {
    use_yaml = true
  }

  repository {
    repo_type             = "GitHubEnterprise"
    repo_id               = "<GitHub Org>/<Repo Name>"
    github_enterprise_url = "https://github.company.com"
    branch_name           = "master"
    yml_path              = "azure-pipelines.yml"
    service_connection_id = "..."
  }

}
```

Issue Number: #35 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->