### PR TITLE
Fix create build definition with Github failed 

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -843,6 +843,7 @@ func expandBuildDefinition(d *schema.ResourceData) (*build.BuildDefinition, stri
 
 	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.GitHub)) {
 		repoURL = fmt.Sprintf("https://github.com/%s.git", repoID)
+		repoAPIURL = fmt.Sprintf("https://api.github.com/repos/%s", repoID)
 	}
 	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.Bitbucket)) {
 		repoURL = fmt.Sprintf("https://bitbucket.org/%s.git", repoID)

--- a/azuredevops/internal/service/build/resource_build_definition_test.go
+++ b/azuredevops/internal/service/build/resource_build_definition_test.go
@@ -103,7 +103,7 @@ var testBuildDefinition = build.BuildDefinition{
 		Type:          converter.String("GitHub"),
 		Properties: &map[string]string{
 			"connectedServiceId": "ServiceConnectionID",
-			"apiUrl":             "",
+			"apiUrl":             "https://api.github.com/repos/RepoId",
 		},
 	},
 	Process: &build.YamlProcess{


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #72 #65 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
I can't create acceptance test for this scenario:
1.  The test case need a real GitHub service connection and real repository,  this will bind the test case to a specific  GitHub PAT and repository.
2. Mock test won't send the real request to GitHub, can't be used to verify the request. The request is verify by service side.

[Community post](https://developercommunity.visualstudio.com/content/problem/1109420/cannot-create-build-definition-for-github.html)
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->