### PR TITLE
Add ACR service connection resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
@@ -1,0 +1,51 @@
+// +build all resource_serviceendpoint_azurecr
+// +build !exclude_serviceendpoints
+
+package acceptancetests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+// validates that an apply followed by another apply (i.e., resource update) will be reflected in AzDO and the
+// underlying terraform state.
+func TestAccServiceEndpointAzureCR_CreateAndUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointNameFirst := testutils.GenerateResourceName()
+	serviceEndpointNameSecond := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_serviceendpoint_azurecr"
+	tfSvcEpNode := resourceType + ".serviceendpoint"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.HclServiceEndpointAzureCRResource(projectName, serviceEndpointNameFirst),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_spn_tenantid"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_subscription_id"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_subscription_name"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameFirst),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst),
+				),
+			},
+			{
+				Config: testutils.HclServiceEndpointAzureCRResource(projectName, serviceEndpointNameSecond),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_spn_tenantid"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_subscription_id"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurecr_subscription_name"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameSecond),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameSecond),
+				),
+			},
+		},
+	})
+}

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -188,13 +188,30 @@ resource "azuredevops_serviceendpoint_github" "serviceendpoint" {
 }
 
 // HclServiceEndpointDockerRegistryResource HCL describing an AzDO service endpoint
-func HclServiceEndpointDockerRegistryResource(projectName string, serviceEndpointName string /*, username string, password string*/) string {
+func HclServiceEndpointDockerRegistryResource(projectName string, serviceEndpointName string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_dockerregistry" "serviceendpoint" {
 	project_id             = azuredevops_project.project.id
 	service_endpoint_name  = "%s"
 
-}`, serviceEndpointName /*, username, password*/)
+}`, serviceEndpointName)
+
+	projectResource := HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
+}
+
+// HclServiceEndpointAzureCRResource HCL describing an AzDO service endpoint
+func HclServiceEndpointAzureCRResource(projectName string, serviceEndpointName string) string {
+	serviceEndpointResource := fmt.Sprintf(`
+	resource "azuredevops_serviceendpoint_azurecr" "serviceendpoint" {
+		project_id                = azuredevops_project.project.id
+		service_endpoint_name     = "%s"
+		azurecr_spn_tenantid      = "9c59cbe5-2ca1-4516-b303-8968a070edd2"
+		azurecr_subscription_id   = "3b0fee91-c36d-4d70-b1e9-fc4b9d608c3d"
+		azurecr_subscription_name = "Microsoft Azure DEMO"
+		resource_group            = "testrg"
+		azurecr_name              = "testacr"
+	  }`, serviceEndpointName)
 
 	projectResource := HclProjectResource(projectName)
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -203,15 +203,15 @@ resource "azuredevops_serviceendpoint_dockerregistry" "serviceendpoint" {
 // HclServiceEndpointAzureCRResource HCL describing an AzDO service endpoint
 func HclServiceEndpointAzureCRResource(projectName string, serviceEndpointName string) string {
 	serviceEndpointResource := fmt.Sprintf(`
-	resource "azuredevops_serviceendpoint_azurecr" "serviceendpoint" {
-		project_id                = azuredevops_project.project.id
-		service_endpoint_name     = "%s"
-		azurecr_spn_tenantid      = "9c59cbe5-2ca1-4516-b303-8968a070edd2"
-		azurecr_subscription_id   = "3b0fee91-c36d-4d70-b1e9-fc4b9d608c3d"
-		azurecr_subscription_name = "Microsoft Azure DEMO"
-		resource_group            = "testrg"
-		azurecr_name              = "testacr"
-	  }`, serviceEndpointName)
+resource "azuredevops_serviceendpoint_azurecr" "serviceendpoint" {
+	project_id                = azuredevops_project.project.id
+	service_endpoint_name     = "%s"
+	azurecr_spn_tenantid      = "9c59cbe5-2ca1-4516-b303-8968a070edd2"
+	azurecr_subscription_id   = "3b0fee91-c36d-4d70-b1e9-fc4b9d608c3d"
+	azurecr_subscription_name = "Microsoft Azure DEMO"
+	resource_group            = "testrg"
+	azurecr_name              = "testacr"
+}`, serviceEndpointName)
 
 	projectResource := HclProjectResource(projectName)
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -1,0 +1,77 @@
+package serviceendpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// ResourceServiceEndpointACR schema and implementation for ACR service endpoint resource
+func ResourceServiceEndpointAzureCR() *schema.Resource {
+	r := genBaseServiceEndpointResource(flattenServiceEndpointAzureCR, expandServiceEndpointAzureCR)
+	makeUnprotectedSchema(r, "azurecr_spn_tenantid", "ACR_TENANT_ID", "The service principal tenant id which should be used.")
+	makeUnprotectedSchema(r, "azurecr_subscription_id", "ACR_SUBSCRIPTION_ID", "The Azure subscription Id which should be used.")
+	makeUnprotectedSchema(r, "azurecr_subscription_name", "ACR_SUBSCRIPTION_NAME", "The Azure subscription name which should be used.")
+
+	r.Schema["resource_group"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Scope Resource Group",
+	}
+
+	r.Schema["azurecr_name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		DefaultFunc: schema.EnvDefaultFunc("AZDO_AZURECR_SERVICE_CONNECTION_REGISTRY", nil),
+		Description: "The AzureContainerRegistry registry which should be used.",
+	}
+
+	return r
+}
+
+// Convert internal Terraform data structure to an AzDO data structure
+func expandServiceEndpointAzureCR(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
+	serviceEndpoint, projectID := doBaseExpansion(d)
+	subscription_id := d.Get("azurecr_subscription_id")
+	scope := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s",
+		subscription_id, d.Get("resource_group"), d.Get("azurecr_name"),
+	)
+	login_server := fmt.Sprintf("%s.azurecr.io", d.Get("azurecr_name"))
+	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+		Parameters: &map[string]string{
+			"authenticationType": "spnKey",
+			"tenantId":           d.Get("azurecr_spn_tenantid").(string),
+			"loginServer":        login_server,
+			"scope":              scope,
+		},
+		Scheme: converter.String("ServicePrincipal"),
+	}
+	serviceEndpoint.Data = &map[string]string{
+		"registryId":       scope,
+		"subscriptionId":   subscription_id.(string),
+		"subscriptionName": d.Get("azurecr_subscription_name").(string),
+		"registrytype":     "ACR",
+	}
+	serviceEndpoint.Type = converter.String("dockerregistry")
+	azurecr_url := fmt.Sprintf("https://%s", login_server)
+	serviceEndpoint.Url = converter.String(azurecr_url)
+
+	return serviceEndpoint, projectID, nil
+}
+
+// Convert AzDO data structure to internal Terraform data structure
+func flattenServiceEndpointAzureCR(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
+	doBaseFlattening(d, serviceEndpoint, projectID)
+	d.Set("azurecr_spn_tenantid", (*serviceEndpoint.Authorization.Parameters)["tenantId"])
+	d.Set("azurecr_subscription_id", (*serviceEndpoint.Data)["subscriptionId"])
+	d.Set("azurecr_subscription_name", (*serviceEndpoint.Data)["subscriptionName"])
+
+	scope := (*serviceEndpoint.Authorization.Parameters)["scope"]
+	s := strings.SplitN(scope, "/", -1)
+	d.Set("resource_group", s[4])
+	d.Set("azurecr_name", s[8])
+}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -35,30 +35,30 @@ func ResourceServiceEndpointAzureCR() *schema.Resource {
 // Convert internal Terraform data structure to an AzDO data structure
 func expandServiceEndpointAzureCR(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
 	serviceEndpoint, projectID := doBaseExpansion(d)
-	subscription_id := d.Get("azurecr_subscription_id")
+	subscriptionId := d.Get("azurecr_subscription_id")
 	scope := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s",
-		subscription_id, d.Get("resource_group"), d.Get("azurecr_name"),
+		subscriptionId, d.Get("resource_group"), d.Get("azurecr_name"),
 	)
-	login_server := fmt.Sprintf("%s.azurecr.io", d.Get("azurecr_name"))
+	loginServer := fmt.Sprintf("%s.azurecr.io", d.Get("azurecr_name"))
 	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
 		Parameters: &map[string]string{
 			"authenticationType": "spnKey",
 			"tenantId":           d.Get("azurecr_spn_tenantid").(string),
-			"loginServer":        login_server,
+			"loginServer":        loginServer,
 			"scope":              scope,
 		},
 		Scheme: converter.String("ServicePrincipal"),
 	}
 	serviceEndpoint.Data = &map[string]string{
 		"registryId":       scope,
-		"subscriptionId":   subscription_id.(string),
+		"subscriptionId":   subscriptionId.(string),
 		"subscriptionName": d.Get("azurecr_subscription_name").(string),
 		"registrytype":     "ACR",
 	}
 	serviceEndpoint.Type = converter.String("dockerregistry")
-	azurecr_url := fmt.Sprintf("https://%s", login_server)
-	serviceEndpoint.Url = converter.String(azurecr_url)
+	azurecrUrl := fmt.Sprintf("https://%s", loginServer)
+	serviceEndpoint.Url = converter.String(azurecrUrl)
 
 	return serviceEndpoint, projectID, nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
@@ -1,0 +1,162 @@
+// +build all resource_serviceendpoint_azurecr
+// +build !exclude_serviceendpoints
+
+package serviceendpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/stretchr/testify/require"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+var azureCRTestServiceEndpointID = uuid.New()
+var azureCRRandomServiceEndpointProjectID = uuid.New().String()
+var azureCRTestServiceEndpointProjectID = &azureCRRandomServiceEndpointProjectID
+var subscription_id = "42125daf-72fd-417c-9ea7-080690625ad3"
+var scope = fmt.Sprintf(
+	"/subscriptions/%s/resourceGroups/testrg/providers/Microsoft.ContainerRegistry/registries/testacr",
+	subscription_id,
+)
+
+var azureCRTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
+	Authorization: &serviceendpoint.EndpointAuthorization{
+		Parameters: &map[string]string{
+			"authenticationType": "spnKey",
+			"tenantId":           "aba07645-051c-44b4-b806-c34d33f3dcd1", //fake value
+			"loginServer":        "testacr.azurecr.io",
+			"scope":              scope,
+		},
+		Scheme: converter.String("ServicePrincipal"),
+	},
+	Data: &map[string]string{
+		"registryId":       scope,
+		"subscriptionId":   subscription_id,
+		"subscriptionName": "testS",
+		"registrytype":     "ACR",
+	},
+	Id:          &azureCRTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("dockerregistry"),
+	Url:         converter.String("https://testacr.azurecr.io"),
+}
+
+// verifies that the flatten/expand round trip yields the same service endpoint
+func TestServiceEndpointAzureCR_ExpandFlatten_Roundtrip(t *testing.T) {
+	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointAzureCR().Schema, nil)
+	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint, azureCRTestServiceEndpointProjectID)
+
+	serviceEndpointAfterRoundTrip, projectID, err := expandServiceEndpointAzureCR(resourceData)
+
+	require.Equal(t, azureCRTestServiceEndpoint, *serviceEndpointAfterRoundTrip)
+	require.Equal(t, azureCRTestServiceEndpointProjectID, projectID)
+	require.Nil(t, err)
+}
+
+// verifies that if an error is produced on create, the error is not swallowed
+func TestServiceEndpointAzureCR_Create_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServiceEndpointAzureCR()
+	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint, azureCRTestServiceEndpointProjectID)
+
+	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+	expectedArgs := serviceendpoint.CreateServiceEndpointArgs{Endpoint: &azureCRTestServiceEndpoint, Project: azureCRTestServiceEndpointProjectID}
+	buildClient.
+		EXPECT().
+		CreateServiceEndpoint(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("CreateServiceEndpoint() Failed")).
+		Times(1)
+
+	err := r.Create(resourceData, clients)
+	require.Contains(t, err.Error(), "CreateServiceEndpoint() Failed")
+}
+
+// verifies that if an error is produced on a read, it is not swallowed
+func TestServiceEndpointAzureCR_Read_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServiceEndpointAzureCR()
+	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint, azureCRTestServiceEndpointProjectID)
+
+	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+	expectedArgs := serviceendpoint.GetServiceEndpointDetailsArgs{EndpointId: azureCRTestServiceEndpoint.Id, Project: azureCRTestServiceEndpointProjectID}
+	buildClient.
+		EXPECT().
+		GetServiceEndpointDetails(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("GetServiceEndpoint() Failed")).
+		Times(1)
+
+	err := r.Read(resourceData, clients)
+	require.Contains(t, err.Error(), "GetServiceEndpoint() Failed")
+}
+
+// verifies that if an error is produced on a delete, it is not swallowed
+func TestServiceEndpointAzureCR_Delete_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServiceEndpointAzureCR()
+	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint, azureCRTestServiceEndpointProjectID)
+
+	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+	expectedArgs := serviceendpoint.DeleteServiceEndpointArgs{EndpointId: azureCRTestServiceEndpoint.Id, Project: azureCRTestServiceEndpointProjectID}
+	buildClient.
+		EXPECT().
+		DeleteServiceEndpoint(clients.Ctx, expectedArgs).
+		Return(errors.New("DeleteServiceEndpoint() Failed")).
+		Times(1)
+
+	err := r.Delete(resourceData, clients)
+	require.Contains(t, err.Error(), "DeleteServiceEndpoint() Failed")
+}
+
+// verifies that if an error is produced on an update, it is not swallowed
+func TestServiceEndpointAzureCR_Update_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServiceEndpointAzureCR()
+	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint, azureCRTestServiceEndpointProjectID)
+
+	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+	expectedArgs := serviceendpoint.UpdateServiceEndpointArgs{
+		Endpoint:   &azureCRTestServiceEndpoint,
+		EndpointId: azureCRTestServiceEndpoint.Id,
+		Project:    azureCRTestServiceEndpointProjectID,
+	}
+
+	buildClient.
+		EXPECT().
+		UpdateServiceEndpoint(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("UpdateServiceEndpoint() Failed")).
+		Times(1)
+
+	err := r.Update(resourceData, clients)
+	require.Contains(t, err.Error(), "UpdateServiceEndpoint() Failed")
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -31,6 +31,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_azurerm":        serviceendpoint.ResourceServiceEndpointAzureRM(),
 			"azuredevops_serviceendpoint_bitbucket":      serviceendpoint.ResourceServiceEndpointBitBucket(),
 			"azuredevops_serviceendpoint_dockerregistry": serviceendpoint.ResourceServiceEndpointDockerRegistry(),
+			"azuredevops_serviceendpoint_azurecr":        serviceendpoint.ResourceServiceEndpointAzureCR(),
 			"azuredevops_serviceendpoint_github":         serviceendpoint.ResourceServiceEndpointGitHub(),
 			"azuredevops_serviceendpoint_kubernetes":     serviceendpoint.ResourceServiceEndpointKubernetes(),
 			"azuredevops_git_repository":                 git.ResourceGitRepository(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -19,6 +19,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_github",
 		"azuredevops_serviceendpoint_dockerregistry",
 		"azuredevops_serviceendpoint_azurerm",
+		"azuredevops_serviceendpoint_azurecr",
 		"azuredevops_serviceendpoint_bitbucket",
 		"azuredevops_serviceendpoint_kubernetes",
 		"azuredevops_serviceendpoint_aws",

--- a/website/docs/r/serviceendpoint_azurecr.html.markdown
+++ b/website/docs/r/serviceendpoint_azurecr.html.markdown
@@ -21,8 +21,8 @@ resource "azuredevops_project" "project" {
 
 # azure container registry service connection
 resource "azuredevops_serviceendpoint_azurecr" "azurecr" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "Sample AzureCR"
+  project_id             = azuredevops_project.project.id
+  service_endpoint_name  = "Sample AzureCR"
   resource_group            = "sample-rg"
   azurecr_spn_tenantid      = "72f987tg-95f1-87af-91bh-2d8jd091db47"
   azurecr_name              = "sampleAcr"
@@ -37,12 +37,12 @@ The following arguments are supported:
 
 - `project_id` - (Required) The project ID or project name.
 - `service_endpoint_name` - (Required) The name you will use to refer to this service connection in task inputs.
-- `description` - (Optional) The name you will use to refer to this service connection in task inputs.
 - `resource_group` - (Required) The resource group to which the container registry belongs.
 - `azurecr_spn_tenantid` - (Required) The tenant id of the service principal.
 - `azurecr_name` - (Required) The Azure container registry name.
 - `azurecr_subscription_id` - (Required) The subscription id of the Azure targets.
 - `azurecr_subscription_name` - (Required) The subscription name of the Azure targets.
+- `description` - (Optional) The name you will use to refer to this service connection in task inputs.
 
 ## Attributes Reference
 

--- a/website/docs/r/serviceendpoint_azurecr.html.markdown
+++ b/website/docs/r/serviceendpoint_azurecr.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_serviceendpoint_azurecr"
+description: |-
+  Manages a Azure Container Registry service endpoint within Azure DevOps organization.
+---
+
+# azuredevops_serviceendpoint_azurecr
+
+Manages a Azure Container Registry service endpoint within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "project" {
+  project_name       = "Sample Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+# azure container registry service connection
+resource "azuredevops_serviceendpoint_azurecr" "azurecr" {
+	project_id             = azuredevops_project.project.id
+	service_endpoint_name  = "Sample AzureCR"
+  resource_group            = "sample-rg"
+  azurecr_spn_tenantid      = "72f987tg-95f1-87af-91bh-2d8jd091db47"
+  azurecr_name              = "sampleAcr"
+  azurecr_subscription_id   = "f7ooi795-c577-6210-9886-a5e898uue3gc"
+  azurecr_subscription_name = "sample"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The project ID or project name.
+- `service_endpoint_name` - (Required) The name you will use to refer to this service connection in task inputs.
+- `description` - (Optional) The name you will use to refer to this service connection in task inputs.
+- `resource_group` - (Required) The resource group to which the container registry belongs.
+- `azurecr_spn_tenantid` - (Required) The tenant id of the service principal.
+- `azurecr_name` - (Required) The Azure container registry name.
+- `azurecr_subscription_id` - (Required) The subscription id of the Azure targets.
+- `azurecr_subscription_name` - (Required) The subscription name of the Azure targets.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The ID of the service endpoint.
+- `project_id` - The project ID or project name.
+- `service_endpoint_name` - The Service Endpoint name.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 5.1 - Service Endpoints](https://docs.microsoft.com/en-us/rest/api/azure/devops/serviceendpoint/endpoints?view=azure-devops-rest-5.1)
+- [Azure Container Registry REST API](https://docs.microsoft.com/en-us/rest/api/containerregistry/)


### PR DESCRIPTION
So that an ACR service connection resource can be defined in
Terraform.

## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Added `azuredevops_serviceendpoint_azurecr`, which allows to create an ACR service connection.

Issue Number: #33 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->