### PR TITLE
Update build definition when remote agent pool is delete and recreate…

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -323,10 +323,16 @@ func flattenBuildDefinition(d *schema.ResourceData, buildDefinition *build.Build
 	d.SetId(strconv.Itoa(*buildDefinition.Id))
 
 	d.Set("project_id", projectID)
-	d.Set("name", *buildDefinition.Name)
-	d.Set("path", *buildDefinition.Path)
+	d.Set("name", buildDefinition.Name)
+	d.Set("path", buildDefinition.Path)
 	d.Set("repository", flattenRepository(buildDefinition))
-	d.Set("agent_pool_name", *buildDefinition.Queue.Pool.Name)
+
+	pool := buildDefinition.Queue.Pool
+	if pool != nil {
+		d.Set("agent_pool_name", pool.Name)
+	} else {
+		d.Set("agent_pool_name", "") //trick for state diff
+	}
 
 	d.Set("variable_groups", flattenVariableGroups(buildDefinition))
 	d.Set(bdVariable, flattenBuildVariables(d, buildDefinition))


### PR DESCRIPTION
… with the same name

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #124  .  After delete and recreate the agent pool. Terraform  can detect the changes in `terraform plan`, execute the `terrafom apply` command can update the build definition.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->