### PR TITLE
Refactoring of permission resources and their corresponding helper methods

### DIFF
--- a/azuredevops/internal/service/permissions/resource_git_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions_test.go
@@ -35,24 +35,24 @@ var gitBranchNameInValid = "@@invalid@@"
 
 func TestGitPermissions_CreateGitToken(t *testing.T) {
 	var d *schema.ResourceData
-	var token *string
+	var token string
 	var err error
 
 	d = getGitPermissionsResource(t, gitProjectID, "", "")
 	token, err = createGitToken(d, nil)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
-	assert.Equal(t, gitTokenProject, *token)
+	assert.Equal(t, gitTokenProject, token)
 
 	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "")
 	token, err = createGitToken(d, nil)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
-	assert.Equal(t, gitTokenRepository, *token)
+	assert.Equal(t, gitTokenRepository, token)
 
 	d = getGitPermissionsResource(t, "", gitRepositoryID, "")
 	token, err = createGitToken(d, nil)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 }
 
@@ -79,19 +79,19 @@ func TestGitPermissions_CreateGitTokenWithBranch(t *testing.T) {
 		Times(1)
 
 	var d *schema.ResourceData
-	var token *string
+	var token string
 	var err error
 
 	d = getGitPermissionsResource(t, gitProjectID, "", gitBranchNameValid)
 	token, err = createGitToken(d, clients)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 
 	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitBranchNameValid)
 	token, err = createGitToken(d, clients)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
-	assert.Equal(t, gitTokenBranch, *token)
+	assert.Equal(t, gitTokenBranch, token)
 }
 
 func TestGitPermissions_CreateGitTokenWithBranch_HandleError(t *testing.T) {
@@ -112,7 +112,7 @@ func TestGitPermissions_CreateGitTokenWithBranch_HandleError(t *testing.T) {
 
 	d := getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitBranchNameValid)
 	token, err := createGitToken(d, clients)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, errMsg)
 }

--- a/azuredevops/internal/service/permissions/resource_git_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions_test.go
@@ -39,19 +39,19 @@ func TestGitPermissions_CreateGitToken(t *testing.T) {
 	var err error
 
 	d = getGitPermissionsResource(t, gitProjectID, "", "")
-	token, err = createGitToken(nil, d)
+	token, err = createGitToken(d, nil)
 	assert.NotNil(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenProject, *token)
 
 	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "")
-	token, err = createGitToken(nil, d)
+	token, err = createGitToken(d, nil)
 	assert.NotNil(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenRepository, *token)
 
 	d = getGitPermissionsResource(t, "", gitRepositoryID, "")
-	token, err = createGitToken(nil, d)
+	token, err = createGitToken(d, nil)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 }
@@ -83,12 +83,12 @@ func TestGitPermissions_CreateGitTokenWithBranch(t *testing.T) {
 	var err error
 
 	d = getGitPermissionsResource(t, gitProjectID, "", gitBranchNameValid)
-	token, err = createGitToken(clients, d)
+	token, err = createGitToken(d, clients)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 
 	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitBranchNameValid)
-	token, err = createGitToken(clients, d)
+	token, err = createGitToken(d, clients)
 	assert.NotNil(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenBranch, *token)
@@ -111,7 +111,7 @@ func TestGitPermissions_CreateGitTokenWithBranch_HandleError(t *testing.T) {
 		Times(1)
 
 	d := getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitBranchNameValid)
-	token, err := createGitToken(clients, d)
+	token, err := createGitToken(d, clients)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, errMsg)

--- a/azuredevops/internal/service/permissions/resource_project_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_project_permissions_test.go
@@ -23,18 +23,18 @@ var projectToken = fmt.Sprintf("$PROJECT:vstfs:///Classification/TeamProject/%s"
 
 func TestProjectPermissions_CreateProjectToken(t *testing.T) {
 	var d *schema.ResourceData
-	var token *string
+	var token string
 	var err error
 
 	d = getProjecPermissionsResource(t, projectID)
 	token, err = createProjectToken(d, nil)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
-	assert.Equal(t, projectToken, *token)
+	assert.Equal(t, projectToken, token)
 
 	d = getProjecPermissionsResource(t, "")
 	token, err = createProjectToken(d, nil)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 }
 

--- a/azuredevops/internal/service/permissions/resource_project_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_project_permissions_test.go
@@ -27,13 +27,13 @@ func TestProjectPermissions_CreateProjectToken(t *testing.T) {
 	var err error
 
 	d = getProjecPermissionsResource(t, projectID)
-	token, err = createProjectToken(d)
+	token, err = createProjectToken(d, nil)
 	assert.NotNil(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, projectToken, *token)
 
 	d = getProjecPermissionsResource(t, "")
-	token, err = createProjectToken(d)
+	token, err = createProjectToken(d, nil)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 }

--- a/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
@@ -3,6 +3,7 @@ package permissions
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/ahmetb/go-linq"
@@ -42,21 +43,12 @@ func ResourceWorkItemQueryPermissions() *schema.Resource {
 func ResourceWorkItemQueryPermissionsCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, err := securityhelper.NewSecurityNamespace(clients.Ctx,
-		securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders,
-		clients.SecurityClient,
-		clients.IdentityClient)
+	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
 
-	aclToken, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
-	if err != nil {
-		return err
-	}
-
-	err = securityhelper.SetPrincipalPermissions(d, sn, aclToken, nil, false)
-	if err != nil {
+	if err := securityhelper.SetPrincipalPermissions(d, sn, aclToken, nil, false); err != nil {
 		return err
 	}
 
@@ -66,15 +58,7 @@ func ResourceWorkItemQueryPermissionsCreateOrUpdate(d *schema.ResourceData, m in
 func ResourceWorkItemQueryPermissionsRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, err := securityhelper.NewSecurityNamespace(clients.Ctx,
-		securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders,
-		clients.SecurityClient,
-		clients.IdentityClient)
-	if err != nil {
-		return err
-	}
-
-	aclToken, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
@@ -82,6 +66,11 @@ func ResourceWorkItemQueryPermissionsRead(d *schema.ResourceData, m interface{})
 	principalPermissions, err := securityhelper.GetPrincipalPermissions(d, sn, aclToken)
 	if err != nil {
 		return err
+	}
+	if principalPermissions == nil {
+		d.SetId("")
+		log.Printf("[INFO] Permissions for ACL token %q not found. Removing from state", *aclToken)
+		return nil
 	}
 
 	d.Set("permissions", principalPermissions.Permissions)
@@ -91,28 +80,19 @@ func ResourceWorkItemQueryPermissionsRead(d *schema.ResourceData, m interface{})
 func ResourceWorkItemQueryPermissionsDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, err := securityhelper.NewSecurityNamespace(clients.Ctx,
-		securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders,
-		clients.SecurityClient,
-		clients.IdentityClient)
+	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
 
-	aclToken, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
-	if err != nil {
-		return err
-	}
-
-	err = securityhelper.SetPrincipalPermissions(d, sn, aclToken, &securityhelper.PermissionTypeValues.NotSet, true)
-	if err != nil {
+	if err := securityhelper.SetPrincipalPermissions(d, sn, aclToken, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
 	d.SetId("")
 	return nil
 }
 
-func createWorkItemQueryToken(context context.Context, wiqClient workitemtracking.Client, d *schema.ResourceData) (*string, error) {
+func createWorkItemQueryToken(d *schema.ResourceData, clients *client.AggregatedClient) (*string, error) {
 	projectID, ok := d.GetOk("project_id")
 	if !ok {
 		return nil, fmt.Errorf("Failed to get 'project_id' from schema")
@@ -120,7 +100,7 @@ func createWorkItemQueryToken(context context.Context, wiqClient workitemtrackin
 	aclToken := fmt.Sprintf("$/%s", projectID.(string))
 	path, ok := d.GetOk("path")
 	if ok {
-		idList, err := getQueryIDsFromPath(context, wiqClient, projectID.(string), path.(string))
+		idList, err := getQueryIDsFromPath(clients.Ctx, clients.WorkItemTrackingClient, projectID.(string), path.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
@@ -43,12 +43,12 @@ func ResourceWorkItemQueryPermissions() *schema.Resource {
 func ResourceWorkItemQueryPermissionsCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
 
-	if err := securityhelper.SetPrincipalPermissions(d, sn, aclToken, nil, false); err != nil {
+	if err := securityhelper.SetPrincipalPermissions(d, sn, nil, false); err != nil {
 		return err
 	}
 
@@ -58,18 +58,18 @@ func ResourceWorkItemQueryPermissionsCreateOrUpdate(d *schema.ResourceData, m in
 func ResourceWorkItemQueryPermissionsRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
 
-	principalPermissions, err := securityhelper.GetPrincipalPermissions(d, sn, aclToken)
+	principalPermissions, err := securityhelper.GetPrincipalPermissions(d, sn)
 	if err != nil {
 		return err
 	}
 	if principalPermissions == nil {
 		d.SetId("")
-		log.Printf("[INFO] Permissions for ACL token %q not found. Removing from state", *aclToken)
+		log.Printf("[INFO] Permissions for ACL token %q not found. Removing from state", sn.GetToken())
 		return nil
 	}
 
@@ -80,34 +80,34 @@ func ResourceWorkItemQueryPermissionsRead(d *schema.ResourceData, m interface{})
 func ResourceWorkItemQueryPermissionsDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	sn, aclToken, err := securityhelper.InitializeSecurityNamespaceAndToken(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.WorkItemQueryFolders, createWorkItemQueryToken)
 	if err != nil {
 		return err
 	}
 
-	if err := securityhelper.SetPrincipalPermissions(d, sn, aclToken, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
+	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
 	d.SetId("")
 	return nil
 }
 
-func createWorkItemQueryToken(d *schema.ResourceData, clients *client.AggregatedClient) (*string, error) {
+func createWorkItemQueryToken(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
 	projectID, ok := d.GetOk("project_id")
 	if !ok {
-		return nil, fmt.Errorf("Failed to get 'project_id' from schema")
+		return "", fmt.Errorf("Failed to get 'project_id' from schema")
 	}
 	aclToken := fmt.Sprintf("$/%s", projectID.(string))
 	path, ok := d.GetOk("path")
 	if ok {
 		idList, err := getQueryIDsFromPath(clients.Ctx, clients.WorkItemTrackingClient, projectID.(string), path.(string))
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
 		aclToken = fmt.Sprintf("%s/%s", aclToken, strings.Join(*idList, "/"))
 	}
-	return &aclToken, nil
+	return aclToken, nil
 }
 
 func getQueryIDsFromPath(context context.Context, wiqClient workitemtracking.Client, projectID string, path string) (*[]string, error) {

--- a/azuredevops/internal/service/permissions/resource_workitemquery_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_workitemquery_permissions_test.go
@@ -35,7 +35,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ProjectGlobal(t *test
 	}
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
 	assert.NotNil(t, token)
 	ref := fmt.Sprintf("$/%s", wiqProjectID)
@@ -66,7 +66,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_SharedQueries(t *test
 		Times(1)
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
 	assert.NotNil(t, token)
 	ref := fmt.Sprintf("$/%s/%s", wiqProjectID, wiqSharedQueryID)
@@ -95,7 +95,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_HandleError(t *testin
 		Times(1)
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, errMsg)
@@ -143,7 +143,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_HandleErrorInPath(t *
 		Times(1)
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, token)
 	assert.NotNil(t, err)
 }
@@ -191,7 +191,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ChildDoesNotExist(t *
 		Times(1)
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder/child")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.NotNil(t, err)
 	assert.Nil(t, token)
 }
@@ -239,7 +239,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ValidToken(t *testing
 		Times(1)
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder")
-	token, err := createWorkItemQueryToken(clients.Ctx, clients.WorkItemTrackingClient, d)
+	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
 	assert.NotNil(t, token)
 	ref := fmt.Sprintf("$/%s/%s/%s", wiqProjectID, wiqSharedQueryID, wiqFldrID)

--- a/azuredevops/internal/service/permissions/resource_workitemquery_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_workitemquery_permissions_test.go
@@ -37,9 +37,9 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ProjectGlobal(t *test
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "")
 	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	ref := fmt.Sprintf("$/%s", wiqProjectID)
-	assert.Equal(t, ref, *token)
+	assert.Equal(t, ref, token)
 }
 
 func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_SharedQueries(t *testing.T) {
@@ -68,9 +68,9 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_SharedQueries(t *test
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/")
 	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	ref := fmt.Sprintf("$/%s/%s", wiqProjectID, wiqSharedQueryID)
-	assert.Equal(t, ref, *token)
+	assert.Equal(t, ref, token)
 }
 
 func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_HandleError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_HandleError(t *testin
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/")
 	token, err := createWorkItemQueryToken(d, clients)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, errMsg)
 }
@@ -144,7 +144,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_HandleErrorInPath(t *
 
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder")
 	token, err := createWorkItemQueryToken(d, clients)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 	assert.NotNil(t, err)
 }
 
@@ -193,7 +193,7 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ChildDoesNotExist(t *
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder/child")
 	token, err := createWorkItemQueryToken(d, clients)
 	assert.NotNil(t, err)
-	assert.Nil(t, token)
+	assert.Empty(t, token)
 }
 
 func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ValidToken(t *testing.T) {
@@ -241,9 +241,9 @@ func TestWorkItemQueryPermissions_CreateWorkItemQueryToken_ValidToken(t *testing
 	d := getWorkItemQueryPermissionsResource(t, wiqProjectID, "/folder")
 	token, err := createWorkItemQueryToken(d, clients)
 	assert.Nil(t, err)
-	assert.NotNil(t, token)
+	assert.NotEmpty(t, token)
 	ref := fmt.Sprintf("$/%s/%s/%s", wiqProjectID, wiqSharedQueryID, wiqFldrID)
-	assert.Equal(t, ref, *token)
+	assert.Equal(t, ref, token)
 }
 
 func getWorkItemQueryPermissionsResource(t *testing.T, projectID string, path string) *schema.ResourceData {

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -247,8 +247,11 @@ func (sn *SecurityNamespace) getAccessControlList(token *string, descriptorList 
 	if err != nil {
 		return nil, err
 	}
-	if acl == nil || len(*acl) != 1 {
-		return nil, fmt.Errorf("Failed to load current ACL for token [%s]. Result set is nil or contains more than one ACL", *token)
+	if acl == nil || len(*acl) <= 0 {
+		return nil, nil
+	}
+	if len(*acl) != 1 {
+		return nil, fmt.Errorf("Failed to load current ACL for token [%s]. Result set contains more than one ACL", *token)
 	}
 	return &(*acl)[0], nil
 }
@@ -323,6 +326,9 @@ func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrinci
 	acl, err := sn.getAccessControlList(token, &descriptorList)
 	if err != nil {
 		return err
+	}
+	if acl == nil {
+		return fmt.Errorf("Failed to load ACL for token %q", *token)
 	}
 	aceMap := *acl.AcesDictionary
 
@@ -427,7 +433,9 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(token *string, principal *[
 	if err != nil {
 		return nil, err
 	}
-
+	if acl == nil {
+		return nil, nil
+	}
 	idMap := map[string]identity.Identity{}
 	linq.From(*idList).
 		ToMapBy(&idMap,
@@ -475,6 +483,9 @@ func (sn *SecurityNamespace) RemovePrincipalPermissions(token *string, principal
 	acl, err := sn.getAccessControlList(token, nil)
 	if err != nil {
 		return err
+	}
+	if acl == nil {
+		return nil
 	}
 
 	val := linq.From(*idList).

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/ahmetb/go-linq"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/identity"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/security"
+	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
@@ -181,25 +183,37 @@ type SecurityNamespace struct {
 	securityClient security.Client
 	identityClient identity.Client
 	actions        *map[string]security.ActionDefinition
+	token          string
 }
 
+type TokenCreatorFunc func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error)
+
 // NewSecurityNamespace Creates a new instance of a security namespace
-func NewSecurityNamespace(context context.Context, namespaceID SecurityNamespaceID, securityClient security.Client, identityClient identity.Client) (*SecurityNamespace, error) {
-	if nil == context {
+func NewSecurityNamespace(d *schema.ResourceData, clients *client.AggregatedClient, namespaceID SecurityNamespaceID, tokenCreator TokenCreatorFunc) (*SecurityNamespace, error) {
+	if nil == clients.Ctx {
 		return nil, fmt.Errorf("context is nil")
 	}
-	if nil == securityClient {
+	if nil == clients.SecurityClient {
 		return nil, fmt.Errorf("securityClient is nil")
 	}
-	if nil == identityClient {
+	if nil == clients.IdentityClient {
 		return nil, fmt.Errorf("identityClient is nil")
 	}
 	sn := new(SecurityNamespace)
-	sn.context = context
+	sn.context = clients.Ctx
 	sn.namespaceID = uuid.UUID(namespaceID)
-	sn.securityClient = securityClient
-	sn.identityClient = identityClient
+	sn.securityClient = clients.SecurityClient
+	sn.identityClient = clients.IdentityClient
+	token, err := tokenCreator(d, clients)
+	if err != nil {
+		return nil, err
+	}
+	sn.token = token
 	return sn, nil
+}
+
+func (sn *SecurityNamespace) GetToken() string {
+	return sn.token
 }
 
 func (sn *SecurityNamespace) getActionDefinitions() (*map[string]security.ActionDefinition, error) {
@@ -223,7 +237,7 @@ func (sn *SecurityNamespace) getActionDefinitions() (*map[string]security.Action
 	return sn.actions, nil
 }
 
-func (sn *SecurityNamespace) getAccessControlList(token *string, descriptorList *[]string) (*security.AccessControlList, error) {
+func (sn *SecurityNamespace) getAccessControlList(descriptorList *[]string) (*security.AccessControlList, error) {
 	var descriptors *string = nil
 	if descriptorList != nil && len(*descriptorList) > 0 {
 		val := linq.From(*descriptorList).
@@ -239,7 +253,7 @@ func (sn *SecurityNamespace) getAccessControlList(token *string, descriptorList 
 	bTrue := true
 	acl, err := sn.securityClient.QueryAccessControlLists(sn.context, security.QueryAccessControlListsArgs{
 		SecurityNamespaceId: &sn.namespaceID,
-		Token:               token,
+		Token:               &sn.token,
 		Descriptors:         descriptors,
 		IncludeExtendedInfo: &bTrue,
 	})
@@ -251,7 +265,7 @@ func (sn *SecurityNamespace) getAccessControlList(token *string, descriptorList 
 		return nil, nil
 	}
 	if len(*acl) != 1 {
-		return nil, fmt.Errorf("Failed to load current ACL for token [%s]. Result set contains more than one ACL", *token)
+		return nil, fmt.Errorf("Failed to load current ACL for token [%s]. Result set contains more than one ACL", sn.token)
 	}
 	return &(*acl)[0], nil
 }
@@ -283,12 +297,9 @@ func (sn *SecurityNamespace) getIndentitiesFromSubjects(principal *[]string) (*[
 }
 
 // SetPrincipalPermissions sets ACLs for specifc token inside a security namespace
-func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrincipalPermission, token *string) error {
+func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrincipalPermission) error {
 	if nil == permissionList || len(*permissionList) <= 0 {
 		return fmt.Errorf("permissionMap is nil or empty")
-	}
-	if nil == token || len(*token) <= 0 {
-		return fmt.Errorf("token is nil or empty")
 	}
 
 	permissionMap := map[string]SetPrincipalPermission{}
@@ -323,12 +334,12 @@ func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrinci
 		}).
 		ToSlice(&descriptorList)
 
-	acl, err := sn.getAccessControlList(token, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	if err != nil {
 		return err
 	}
 	if acl == nil {
-		return fmt.Errorf("Failed to load ACL for token %q", *token)
+		return fmt.Errorf("Failed to load ACL for token %q", sn.token)
 	}
 	aceMap := *acl.AcesDictionary
 
@@ -390,7 +401,7 @@ func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrinci
 			Merge                *bool                          `json:"merge,omitempty"`
 			AccessControlEntries *[]security.AccessControlEntry `json:"accessControlEntries,omitempty"`
 		}{
-			Token:                token,
+			Token:                &sn.token,
 			Merge:                &bMerge,
 			AccessControlEntries: &[]security.AccessControlEntry{*aceItem},
 		}
@@ -408,11 +419,7 @@ func (sn *SecurityNamespace) SetPrincipalPermissions(permissionList *[]SetPrinci
 }
 
 // GetPrincipalPermissions returns an array of PrincipalPermission for a Security Namespace token an a list of principals
-func (sn *SecurityNamespace) GetPrincipalPermissions(token *string, principal *[]string) (*[]PrincipalPermission, error) {
-	if nil == token || len(*token) <= 0 {
-		return nil, fmt.Errorf("token is nil or empty")
-	}
-
+func (sn *SecurityNamespace) GetPrincipalPermissions(principal *[]string) (*[]PrincipalPermission, error) {
 	actions, err := sn.getActionDefinitions()
 	if err != nil {
 		return nil, err
@@ -429,7 +436,7 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(token *string, principal *[
 			return *elem.(identity.Identity).Descriptor
 		}).
 		ToSlice(&descriptorList)
-	acl, err := sn.getAccessControlList(token, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	if err != nil {
 		return nil, err
 	}
@@ -471,16 +478,12 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(token *string, principal *[
 }
 
 // RemovePrincipalPermissions removes all permissions for given principals and a Security Namespace token
-func (sn *SecurityNamespace) RemovePrincipalPermissions(token *string, principal *[]string) error {
-	if nil == token || len(*token) <= 0 {
-		return fmt.Errorf("token is nil or empty")
-	}
-
+func (sn *SecurityNamespace) RemovePrincipalPermissions(principal *[]string) error {
 	idList, err := sn.getIndentitiesFromSubjects(principal)
 	if err != nil {
 		return err
 	}
-	acl, err := sn.getAccessControlList(token, nil)
+	acl, err := sn.getAccessControlList(nil)
 	if err != nil {
 		return err
 	}
@@ -504,7 +507,7 @@ func (sn *SecurityNamespace) RemovePrincipalPermissions(token *string, principal
 	log.Printf("[TRACE]RemovePrincipalPermissions: removing the following principals from the ACL %s", val)
 	bRet, err := sn.securityClient.RemoveAccessControlEntries(sn.context, security.RemoveAccessControlEntriesArgs{
 		SecurityNamespaceId: &sn.namespaceID,
-		Token:               token,
+		Token:               &sn.token,
 		Descriptors:         &val,
 	})
 	if err != nil {

--- a/azuredevops/internal/service/permissions/utils/namespaces_test.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/identity"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/security"
 	"github.com/stretchr/testify/assert"
@@ -304,7 +305,9 @@ func TestSecurityNamespace_GetActionDefinitions_HandleError(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -332,7 +335,9 @@ func TestSecurityNamespace_GetActionDefinitions_EnsureExistingValuesUnchanged(t 
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -369,7 +374,9 @@ func TestSecurityNamespace_GetActionDefinitions_EmptyResultError(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -398,7 +405,9 @@ func TestSecurityNamespace_GetActionDefinitions_ValidMapping(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -433,7 +442,9 @@ func TestSecurityNamespace_GetAccessControlList_HandleError(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -449,7 +460,7 @@ func TestSecurityNamespace_GetAccessControlList_HandleError(t *testing.T) {
 		Return(nil, fmt.Errorf(errMsg)).
 		Times(1)
 
-	acl, err := sn.getAccessControlList(&projectAccessToken, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	assert.NotNil(t, err)
 	assert.Nil(t, acl)
 	assert.EqualError(t, err, errMsg)
@@ -466,7 +477,9 @@ func TestSecurityNamespace_GetAccessControlList_EmptyResult(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return projectAccessToken, nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -488,7 +501,7 @@ func TestSecurityNamespace_GetAccessControlList_EmptyResult(t *testing.T) {
 		Return(&projectAccessControlListEmpty, nil).
 		Times(1)
 
-	acl, err := sn.getAccessControlList(&projectAccessToken, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	assert.Nil(t, err)
 	assert.Nil(t, acl)
 }
@@ -504,7 +517,9 @@ func TestSecurityNamespace_GetAccessControlList_NilResult(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return projectAccessToken, nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -526,7 +541,7 @@ func TestSecurityNamespace_GetAccessControlList_NilResult(t *testing.T) {
 		Return(nil, nil).
 		Times(1)
 
-	acl, err := sn.getAccessControlList(&projectAccessToken, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	assert.Nil(t, err)
 	assert.Nil(t, acl)
 }
@@ -542,7 +557,9 @@ func TestSecurityNamespace_GetAccessControlList_VerifyReturn(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return projectAccessToken, nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -564,7 +581,7 @@ func TestSecurityNamespace_GetAccessControlList_VerifyReturn(t *testing.T) {
 		Return(&projectAccessControlList, nil).
 		Times(1)
 
-	acl, err := sn.getAccessControlList(&projectAccessToken, &descriptorList)
+	acl, err := sn.getAccessControlList(&descriptorList)
 	assert.Nil(t, err)
 	assert.NotNil(t, acl)
 	assert.Equal(t, &projectAccessControlList[0], acl)
@@ -581,7 +598,9 @@ func TestSecurityNamespaces_GetIndentitiesFromSubjects_HandleError(t *testing.T)
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -614,7 +633,9 @@ func TestSecurityNamespaces_GetIndentitiesFromSubjects_HandleEmptyReturn(t *test
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -649,7 +670,9 @@ func TestSecurityNamespace_GetIndentitiesFromSubjects_VerifyReturn(t *testing.T)
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -686,7 +709,9 @@ func TestSecurityNamespace_GetPrincipalPermissions_Verify(t *testing.T) {
 		Ctx:            context.Background(),
 	}
 
-	sn, err := NewSecurityNamespace(clients.Ctx, SecurityNamespaceIDValues.Project, clients.SecurityClient, clients.IdentityClient)
+	sn, err := NewSecurityNamespace(nil, clients, SecurityNamespaceIDValues.Project, func(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+		return "@@accTest@@", nil
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
 
@@ -721,8 +746,7 @@ func TestSecurityNamespace_GetPrincipalPermissions_Verify(t *testing.T) {
 		Return(&projectAccessControlList, nil).
 		Times(1)
 
-	token := "GO/UNITTEST/TOKEN"
-	perms, err := sn.GetPrincipalPermissions(&token, &subjectDescriptorList)
+	perms, err := sn.GetPrincipalPermissions(&subjectDescriptorList)
 	assert.NotNil(t, perms)
 	assert.Nil(t, err)
 	assert.Len(t, *perms, len(subjectDescriptorList))


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~I have updated the documentation accordingly.~~
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR provides the following:

* refactored the implementation of `SecurityNamespace` and the according helper functions for a much cleaner code in the various permission resources. This refactoring will again reduce the effort for new permission management resources in the future.
* all permission resources will now clear the `Id` on a `Read` operation, when the connected ACLs could **not** be found, which will remove the object from the state and will give Terraform the chance to recreate the resource.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. --> 