### PR TITLE
Location of golanci-lint is not always in gopath

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	$(GOPATH)/bin/golangci-lint run ./...
+	golangci-lint run ./...
 
 test: fmtcheck
 	go test -tags "all" -i $(UNITTEST) || exit 1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./...
+	@if command -v golangci-lint; then (golangci-lint run ./...); else ($(GOPATH)/bin/golangci-lint run ./...); fi
 
 test: fmtcheck
 	go test -tags "all" -i $(UNITTEST) || exit 1


### PR DESCRIPTION
golanci-lint can be installed by homebrew or as binary, so it's not always located inside gopath. It should be in the path however

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
/

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Any relevant logs, error output, etc?
/


## Other information
/