### PR TITLE
Do not set a default agent pool name

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -325,7 +325,10 @@ func flattenBuildDefinition(d *schema.ResourceData, buildDefinition *build.Build
 	d.Set("name", *buildDefinition.Name)
 	d.Set("path", *buildDefinition.Path)
 	d.Set("repository", flattenRepository(buildDefinition))
-	d.Set("agent_pool_name", *buildDefinition.Queue.Pool.Name)
+
+	if buildDefinition.Queue != nil && buildDefinition.Queue.Pool != nil {
+		d.Set("agent_pool_name", *buildDefinition.Queue.Pool.Name)
+	}
 
 	d.Set("variable_groups", flattenVariableGroups(buildDefinition))
 	d.Set(bdVariable, flattenBuildVariables(d, buildDefinition))

--- a/website/docs/r/build_definition.html.markdown
+++ b/website/docs/r/build_definition.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 - `project_id` - (Required) The project ID or project name.
 - `name` - (Optional) The name of the build definition.
 - `path` - (Optional) The folder path of the build definition.
-- `agent_pool_name` - (Optional) The agent pool that should execute the build. Defaults to `Hosted Ubuntu 1604`.
+- `agent_pool_name` - (Optional) The agent pool that should execute the build.
 - `repository` - (Required) A `repository` block as documented below.
 - `ci_trigger` - (Optional) Continuous Integration trigger.
 - `pull_request_trigger` - (Optional) Pull Request Integration Integration trigger.


### PR DESCRIPTION
Only set the name of the agent pool if set by the user and don't set the default Ubuntu 16.04 pool. The pool is not required by the API so it shouldn't be required by the provider either.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The agent pool name was optional, but it tried to use Ubuntu 16.04 when the user didn't set it. This is not required by the API so the provider should not try to set the Ubuntu pool.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?
/

## Other information
/