### PR TITLE
[WIP] Authentication for repositories for import

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -520,13 +520,11 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 	if len(initData) == 1 {
 		initValues := initData[0].(map[string]interface{})
 
-		authenticationSchema := initValues["source_authentication"].(schema.ResourceData)
-
 		initialization = &repoInitializationMeta{
 			initType:             initValues["init_type"].(string),
 			sourceType:           initValues["source_type"].(string),
 			sourceURL:            initValues["source_url"].(string),
-			sourceAuthentication: expandImportAuthentication(&authenticationSchema),
+			sourceAuthentication: expandImportAuthentication(d),
 		}
 
 		if strings.EqualFold(initialization.initType, "clean") {

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -145,7 +145,9 @@ func ResourceGitRepository() *schema.Resource {
 										MaxItems:      1,
 										AtLeastOneOf:  sourceAuthenticationKeys,
 										ConflictsWith: []string{"github"},
-										Elem:          se_resource.BitbucketSchemaFields(&schema.Resource{}),
+										Elem: se_resource.BitbucketSchemaFields(&schema.Resource{
+											Schema: map[string]*schema.Schema{},
+										}),
 									},
 									"github": {
 										Type:          schema.TypeSet,
@@ -153,7 +155,9 @@ func ResourceGitRepository() *schema.Resource {
 										MaxItems:      1,
 										AtLeastOneOf:  sourceAuthenticationKeys,
 										ConflictsWith: []string{"bitbucket"},
-										Elem:          se_resource.GitHubSchemaFields(&schema.Resource{}),
+										Elem: se_resource.GitHubSchemaFields(&schema.Resource{
+											Schema: map[string]*schema.Schema{},
+										}),
 									},
 								},
 							},

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -2,12 +2,13 @@ package git
 
 import (
 	"fmt"
-	se_sdk "github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
-	se_resource "github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
 	"log"
 	"math/rand"
 	"strings"
 	"time"
+
+	se_sdk "github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	se_resource "github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -2,7 +2,10 @@ package git
 
 import (
 	"fmt"
+	se_sdk "github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	se_resource "github.com/terraform-providers/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
 	"log"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -38,6 +41,8 @@ var RepoInitTypeValues = repoInitTypeValuesType{
 
 // ResourceGitRepository schema and implementation for git repo resource
 func ResourceGitRepository() *schema.Resource {
+	sourceAuthenticationKeys := []string{"bitbucket", "github"}
+
 	return &schema.Resource{
 		Create: resourceGitRepositoryCreate,
 		Read:   resourceGitRepositoryRead,
@@ -127,6 +132,31 @@ func ResourceGitRepository() *schema.Resource {
 							RequiredWith: []string{"initialization.0.source_type"},
 							ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 						},
+						"source_authentication": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bitbucket": {
+										Type:          schema.TypeSet,
+										Optional:      true,
+										MaxItems:      1,
+										AtLeastOneOf:  sourceAuthenticationKeys,
+										ConflictsWith: []string{"github"},
+										Elem:          se_resource.BitbucketSchemaFields(&schema.Resource{}),
+									},
+									"github": {
+										Type:          schema.TypeSet,
+										Optional:      true,
+										MaxItems:      1,
+										AtLeastOneOf:  sourceAuthenticationKeys,
+										ConflictsWith: []string{"bitbucket"},
+										Elem:          se_resource.GitHubSchemaFields(&schema.Resource{}),
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -136,9 +166,15 @@ func ResourceGitRepository() *schema.Resource {
 
 // A helper type that is used for transient info only used during repo creation
 type repoInitializationMeta struct {
-	initType   string
-	sourceType string
-	sourceURL  string
+	initType             string
+	sourceType           string
+	sourceURL            string
+	sourceAuthentication *repoImportAuthentication
+}
+
+type repoImportAuthentication struct {
+	bitbucketAuthentication *schema.ResourceData
+	githubAuthentication    *schema.ResourceData
 }
 
 func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
@@ -176,6 +212,18 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 			},
 			Repository: createdRepo,
 		}
+
+		if initialization.sourceAuthentication != nil {
+			serviceEndpointId, err := getImportRequestAuthorizationServiceEndpoint(initialization.sourceAuthentication, m.(*client.AggregatedClient), converter.String(projectID.String()))
+
+			if err != nil {
+				return fmt.Errorf("Error while creating service endpoint required for authentication to imported repository: %+v ", err)
+			}
+
+			importRequest.Parameters.ServiceEndpointId = serviceEndpointId
+			importRequest.Parameters.DeleteServiceEndpointAfterImportIsDone = converter.Bool(true)
+		}
+
 		_, importErr := createImportRequest(clients, importRequest, projectID.String(), *createdRepo.Name)
 		if importErr != nil {
 			return fmt.Errorf("Error import repository in Azure DevOps: %+v ", err)
@@ -200,6 +248,43 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(createdRepo.Id.String())
 	return resourceGitRepositoryRead(d, m)
+}
+
+func baseServiceEndpointForImportAuthentication(_ *schema.ResourceData) (*se_sdk.ServiceEndpoint, *string) {
+	return &se_sdk.ServiceEndpoint{
+		Name:        converter.String(fmt.Sprintf("terraform-repo-import-%d", rand.Int())),
+		Owner:       converter.String("library"),
+		Description: converter.String("Temporarily used for repository import by Terraform"),
+	}, nil
+}
+
+func getImportRequestAuthorizationServiceEndpoint(authInfo *repoImportAuthentication, clients *client.AggregatedClient, projectId *string) (*uuid.UUID, error) {
+	var serviceEndpoint *se_sdk.ServiceEndpoint
+
+	if authInfo.bitbucketAuthentication != nil {
+		var err error
+		serviceEndpoint, _, err = se_resource.ExpandServiceEndpointBitbucket(baseServiceEndpointForImportAuthentication, "initialization.source_authentication.bitbucket.")(authInfo.bitbucketAuthentication)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if authInfo.githubAuthentication != nil {
+		var err error
+		serviceEndpoint, _, err = se_resource.ExpandServiceEndpointGitHub(baseServiceEndpointForImportAuthentication, "initialization.source_authentication.github.")(authInfo.githubAuthentication)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	createdServiceEndpoint, err := se_resource.CreateServiceEndpoint(clients, serviceEndpoint, projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdServiceEndpoint.Id, nil
 }
 
 func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID fmt.Stringer) error {
@@ -434,10 +519,13 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 	if len(initData) == 1 {
 		initValues := initData[0].(map[string]interface{})
 
+		authenticationSchema := initValues["source_authentication"].(schema.ResourceData)
+
 		initialization = &repoInitializationMeta{
-			initType:   initValues["init_type"].(string),
-			sourceType: initValues["source_type"].(string),
-			sourceURL:  initValues["source_url"].(string),
+			initType:             initValues["init_type"].(string),
+			sourceType:           initValues["source_type"].(string),
+			sourceURL:            initValues["source_url"].(string),
+			sourceAuthentication: expandImportAuthentication(&authenticationSchema),
 		}
 
 		if strings.EqualFold(initialization.initType, "clean") {
@@ -449,4 +537,18 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 	}
 
 	return repo, initialization, &projectID, nil
+}
+
+func expandImportAuthentication(d *schema.ResourceData) *repoImportAuthentication {
+	authInfo := &repoImportAuthentication{}
+
+	if _, ok := d.GetOk("initialization.source_authentication.bitbucket"); ok {
+		authInfo.bitbucketAuthentication = d
+	}
+
+	if _, ok := d.GetOk("initialization.source_authentication.github"); ok {
+		authInfo.githubAuthentication = d
+	}
+
+	return authInfo
 }

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -18,6 +18,7 @@ const errMsgTfConfigRead = "Error reading terraform configuration: %+v"
 
 type flatFunc func(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string)
 type expandFunc func(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error)
+type serviceEndpointFunc func(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string)
 
 // genBaseServiceEndpointResource creates a Resource with the common parts
 // that all Service Endpoints require.
@@ -116,7 +117,7 @@ func makeUnprotectedSchema(r *schema.Resource, keyName, envVarName, description 
 }
 
 // Make the Azure DevOps API call to create the endpoint
-func createServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceendpoint.ServiceEndpoint, project *string) (*serviceendpoint.ServiceEndpoint, error) {
+func CreateServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceendpoint.ServiceEndpoint, project *string) (*serviceendpoint.ServiceEndpoint, error) {
 	if strings.EqualFold(*endpoint.Type, "github") && strings.EqualFold(*endpoint.Authorization.Scheme, "InstallationToken") {
 		return nil, fmt.Errorf("Github Apps must be created on Github and then can be imported")
 	}
@@ -164,7 +165,7 @@ func genServiceEndpointCreateFunc(flatFunc flatFunc, expandFunc expandFunc) func
 			return fmt.Errorf(errMsgTfConfigRead, err)
 		}
 
-		createdServiceEndpoint, err := createServiceEndpoint(clients, serviceEndpoint, projectID)
+		createdServiceEndpoint, err := CreateServiceEndpoint(clients, serviceEndpoint, projectID)
 		if err != nil {
 			return fmt.Errorf("Error creating service endpoint in Azure DevOps: %+v", err)
 		}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
@@ -43,7 +43,7 @@ func TestServiceEndpointGitHub_ExpandFlatten_Roundtrip(t *testing.T) {
 	configureAuthPersonal(resourceData)
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint, ghTestServiceEndpointProjectID)
 
-	serviceEndpointAfterRoundTrip, projectID, err := expandServiceEndpointGitHub(resourceData)
+	serviceEndpointAfterRoundTrip, projectID, err := ExpandServiceEndpointGitHub(doBaseExpansion, "")(resourceData)
 
 	require.Nil(t, err)
 	require.Equal(t, ghTestServiceEndpoint, *serviceEndpointAfterRoundTrip)


### PR DESCRIPTION
This adds support for authentication to GitHub or Bitbucket repositories for import. It is reusing code from the service connections and can easily be extended to support other types of git repositories as long as there is a service connection available for it.

Feel free to take this as is and finish it, you don't have to wait for me. Otherwise I'll work on adding tests and docs next week.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

You can now use authentication for repositories that you want to import.

Issue Number:
* fixes #142 
* fixes #45 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?
/

## Other information
/