### PR TITLE
Variable group allow access inconsistent

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -27,9 +27,6 @@ func TestAccVariableGroup_CreateAndUpdate(t *testing.T) {
 	vargroupNameSecond := testutils.GenerateResourceName()
 	vargroupNameNoSecret := testutils.GenerateResourceName()
 
-	allowAccessTrue := true
-	allowAccessFalse := false
-
 	tfVarGroupNode := "azuredevops_variable_group.vg"
 
 	resource.Test(t, resource.TestCase{
@@ -38,25 +35,25 @@ func TestAccVariableGroup_CreateAndUpdate(t *testing.T) {
 		CheckDestroy: checkVariableGroupDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.HclVariableGroupResourceWithProject(projectName, vargroupNameFirst, allowAccessTrue),
+				Config: testutils.HclVariableGroupResourceWithProject(projectName, vargroupNameFirst, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameFirst),
-					checkVariableGroupExists(vargroupNameFirst, allowAccessTrue),
+					checkVariableGroupExists(vargroupNameFirst, true),
 				),
 			}, {
-				Config: testutils.HclVariableGroupResourceWithProject(projectName, vargroupNameSecond, allowAccessFalse),
+				Config: testutils.HclVariableGroupResourceWithProject(projectName, vargroupNameSecond, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameSecond),
-					checkVariableGroupExists(vargroupNameSecond, allowAccessFalse),
+					checkVariableGroupExists(vargroupNameSecond, false),
 				),
 			}, {
-				Config: testutils.HclVariableGroupResourceNoSecretsWithProject(projectName, vargroupNameNoSecret, allowAccessFalse),
+				Config: testutils.HclVariableGroupResourceNoSecretsWithProject(projectName, vargroupNameNoSecret, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
 					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vargroupNameNoSecret),
-					checkVariableGroupExists(vargroupNameNoSecret, allowAccessFalse),
+					checkVariableGroupExists(vargroupNameNoSecret, false),
 				),
 			}, {
 				// Resource Acceptance Testing https://www.terraform.io/docs/extend/resources/import.html#resource-acceptance-testing-implementation

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -537,11 +537,12 @@ func deleteDefinitionResourceAuth(clients *client.AggregatedClient, variableGrou
 
 // Convert AzDO data structure allow_access to internal Terraform data structure
 func flattenAllowAccess(d *schema.ResourceData, definitionResource *[]build.DefinitionResourceReference) {
-	var allowAccess bool
-	if len(*definitionResource) > 0 {
-		allowAccess = *(*definitionResource)[0].Authorized
-	} else {
-		allowAccess = false
+	vgId := d.Id()
+	var allowAccess = false
+	for _, authResource := range *definitionResource {
+		if vgId == *authResource.Id {
+			allowAccess = *authResource.Authorized
+		}
 	}
 	d.Set(vgAllowAccess, allowAccess)
 }

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -539,9 +539,11 @@ func deleteDefinitionResourceAuth(clients *client.AggregatedClient, variableGrou
 func flattenAllowAccess(d *schema.ResourceData, definitionResource *[]build.DefinitionResourceReference) {
 	vgId := d.Id()
 	var allowAccess = false
-	for _, authResource := range *definitionResource {
-		if vgId == *authResource.Id {
-			allowAccess = *authResource.Authorized
+	if definitionResource != nil {
+		for _, authResource := range *definitionResource {
+			if vgId == *authResource.Id {
+				allowAccess = *authResource.Authorized
+			}
 		}
 	}
 	d.Set(vgAllowAccess, allowAccess)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #153 
Authorization resource can get from the [Authorizedresources ](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/authorizedresources/list?view=azure-devops-rest-5.1). If resource grant the permission to resources, this authorization definition can be found in the API response. Otherwise means the resource was not authorize to pipelines.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->