### PR TITLE
Rename project_id and project_name to project_identifier for data source azuredevops_project

### DIFF
--- a/azuredevops/internal/acceptancetests/data_project_test.go
+++ b/azuredevops/internal/acceptancetests/data_project_test.go
@@ -23,12 +23,12 @@ func TestAccProject_DataSource(t *testing.T) {
 	}{
 		{
 			Name:                "Get project with id",
-			Identifier:          "project_id",
+			Identifier:          "project_identifier",
 			IdentifierOnProject: "id",
 		},
 		{
 			Name:                "Get project with name",
-			Identifier:          "project_id",
+			Identifier:          "project_identifier",
 			IdentifierOnProject: "project_name",
 		},
 	}
@@ -66,24 +66,6 @@ func TestAccProject_DataSource(t *testing.T) {
 	}
 }
 
-func TestAccProject_DataSource_ErrorWhenNoFieldsSet(t *testing.T) {
-	dataProject := `data "azuredevops_project" "project" {
-		project_name = "name"
-		project_id = "id"
-	}`
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testutils.PreCheck(t, nil) },
-		Providers: testutils.GetProviders(),
-		Steps: []resource.TestStep{
-			{
-				Config:      dataProject,
-				ExpectError: regexp.MustCompile(`config is invalid: "project_id": conflicts with project_name`),
-			},
-		},
-	})
-}
-
 func TestAccProject_DataSource_ErrorWhenBothNameAndIdSet(t *testing.T) {
 	dataProject := `data "azuredevops_project" "project" {}`
 
@@ -93,7 +75,7 @@ func TestAccProject_DataSource_ErrorWhenBothNameAndIdSet(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      dataProject,
-				ExpectError: regexp.MustCompile(`Either project_id or project_name must be set`),
+				ExpectError: regexp.MustCompile(`config is invalid: Missing required argument: The argument "project_identifier" is required, but no definition was found.`),
 			},
 		},
 	})
@@ -103,7 +85,7 @@ func TestAccProject_DataSource_ErrorWhenDescriptionSet(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	dataProject := fmt.Sprintf(`
 	data "azuredevops_project" "project" {
-		project_name = "%s"
+		project_identifier = "%s"
 		description = "A project description"
 	}`, projectName)
 

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -131,7 +131,7 @@ func HclProjectsDataSourceWithStateAndInvalidName() string {
 func HclProjectGitRepository(projectName string, gitRepoName string) string {
 	return fmt.Sprintf(`
 data "azuredevops_project" "project" {
-	project_name = "%s"
+	project_identifier = "%s"
 }
 
 data "azuredevops_git_repository" "repository" {
@@ -144,7 +144,7 @@ data "azuredevops_git_repository" "repository" {
 func HclProjectGitRepositories(projectName string, gitRepoName string) string {
 	return fmt.Sprintf(`
 data "azuredevops_project" "project" {
-	project_name = azuredevops_project.project.project_name
+	project_identifier = azuredevops_project.project.project_name
 }
 
 data "azuredevops_git_repositories" "repositories" {

--- a/azuredevops/internal/service/core/data_project.go
+++ b/azuredevops/internal/service/core/data_project.go
@@ -11,23 +11,43 @@ import (
 
 // DataProject schema and implementation for project data source
 func DataProject() *schema.Resource {
-	baseSchema := ResourceProject()
-	for k, v := range baseSchema.Schema {
-		baseSchema.Schema[k] = &schema.Schema{
-			Type:     v.Type,
-			Computed: true,
-		}
-	}
-
-	baseSchema.Schema["project_identifier"] = &schema.Schema{
-		Type:         schema.TypeString,
-		Required:     true,
-		ValidateFunc: validation.StringIsNotWhiteSpace,
-	}
-
 	return &schema.Resource{
-		Read:   dataProjectRead,
-		Schema: baseSchema.Schema,
+		Read: dataProjectRead,
+		Schema: map[string]*schema.Schema{
+			"project_identifier": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version_control": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"work_item_template": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"process_template_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"features": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
 	}
 }
 

--- a/website/docs/d/data_project.html.markdown
+++ b/website/docs/d/data_project.html.markdown
@@ -13,7 +13,7 @@ Use this data source to access information about an existing Project within Azur
 
 ```hcl
 data "azuredevops_project" "p" {
-  project_name = "Sample Project"
+  project_identify = "Sample Project"
 }
 
 output "id" {
@@ -45,13 +45,13 @@ output "process_template_id" {
 
 The following arguments are supported:
 
-- `project_name` - (Required if `project_id` not set) Name of the Project.
-- `project_id` - (Required if `project_name` not set) Id of the Project.
+- `project_identify` - (Required) Name or ID of the Project.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+`project_name` - The name of the referenced project
 `description` - The description of the referenced project
 `visibility` - The visibility of the referenced project
 `version_control` - The version control of the referenced project

--- a/website/docs/d/data_project.html.markdown
+++ b/website/docs/d/data_project.html.markdown
@@ -13,7 +13,7 @@ Use this data source to access information about an existing Project within Azur
 
 ```hcl
 data "azuredevops_project" "p" {
-  project_identify = "Sample Project"
+  project_identifier = "Sample Project"
 }
 
 output "id" {
@@ -45,7 +45,7 @@ output "process_template_id" {
 
 The following arguments are supported:
 
-- `project_identify` - (Required) Name or ID of the Project.
+- `project_identifier` - (Required) Name or ID of the Project.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #173 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [x] Yes
- [ ] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
@EliiseS  I was thinking if we could replace the `project_id` and `project_name` with `project_identifer`, project read API accept both `projectID` and `projectName` as project identifer,  I unified  the projectID and projectName into one param: projectIdentifier. What's your thinking?

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->