### PR TITLE
Add origin & origin_id to data_group

### DIFF
--- a/azuredevops/internal/acceptancetests/data_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_test.go
@@ -28,6 +28,8 @@ func TestAccGroupDataSource_Read_HappyPath(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
 					resource.TestCheckResourceAttrSet(tfBuildDefNode, "id"),
 					resource.TestCheckResourceAttrSet(tfBuildDefNode, "descriptor"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "origin"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "origin_id"),
 				),
 			},
 		},

--- a/azuredevops/internal/service/graph/data_group.go
+++ b/azuredevops/internal/service/graph/data_group.go
@@ -33,6 +33,14 @@ func DataGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -66,6 +74,12 @@ func dataSourceGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(*targetGroup.Descriptor)
 	d.Set("descriptor", *targetGroup.Descriptor)
+	if targetGroup.Origin != nil {
+		d.Set("origin", *targetGroup.Origin)
+	}
+	if targetGroup.OriginId != nil {
+		d.Set("origin_id", *targetGroup.OriginId)
+	}
 	return nil
 }
 

--- a/website/docs/d/data_group.html.markdown
+++ b/website/docs/d/data_group.html.markdown
@@ -43,6 +43,8 @@ The following attributes are exported:
 
 - `id` - The ID for this resource is the group descriptor. See below.
 - `descriptor` - The Descriptor is the primary way to reference the graph subject. This field will uniquely identify the same graph subject across both Accounts and Organizations.
+- `origin` - The type of source provider for the origin identifier (ex:AD, AAD, MSA)
+- `origin_id` - The unique identifier from the system of origin. Typically a sid, object id or Guid. Linking and unlinking operations can cause this value to change for a user because the user is not backed by a different provider and has a different unique id in the new provider.
 
 ## Relevant Links
 


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Adding the ability to get the origin_id. This id is used when referencing the group from other resources.
Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->