### PR TITLE
Add support for other git service connections

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
@@ -1,0 +1,38 @@
+package serviceendpoint
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/model"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// ResourceServiceEndpointBitBucket schema and implementation for bitbucket service endpoint resource
+func ResourceServiceEndpointBitBucket() *schema.Resource {
+	r := genBaseServiceEndpointResource(flattenServiceEndpointBitBucket, expandServiceEndpointBitBucket)
+	makeUnprotectedSchema(r, "username", "AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", "The bitbucket username which should be used.")
+	makeProtectedSchema(r, "password", "AZDO_BITBUCKET_SERVICE_CONNECTION_PASSWORD", "The bitbucket password whi|ch should be used.")
+	return r
+}
+
+func expandServiceEndpointBitBucket(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
+	serviceEndpoint, projectID := doBaseExpansion(d)
+	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+		Parameters: &map[string]string{
+			"username": d.Get("username").(string),
+			"password": d.Get("password").(string),
+		},
+		Scheme: converter.String("UsernamePassword"),
+	}
+	serviceEndpoint.Type = converter.String(string("git"))
+	serviceEndpoint.Url = converter.String("")
+	return serviceEndpoint, projectID, nil
+}
+
+func flattenServiceEndpointBitBucket(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
+	doBaseFlattening(d, serviceEndpoint, projectID)
+	d.Set("username", (*serviceEndpoint.Authorization.Parameters)["username"])
+	tfhelper.HelpFlattenSecret(d, "password")
+	d.Set("password", (*serviceEndpoint.Authorization.Parameters)["password"])
+}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
@@ -10,9 +10,9 @@ import (
 // ResourceServiceEndpointOtherGit schema and implementation for bitbucket service endpoint resource
 func ResourceServiceEndpointOtherGit() *schema.Resource {
 	r := genBaseServiceEndpointResource(flattenServiceEndpointOtherGit, expandServiceEndpointOtherGit)
-	makeUnprotectedSchema(r, "username", "AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", "The bitbucket username which should be used.")
+	makeUnprotectedSchema(r, "username", "AZDO_OTHER_GIT_SERVICE_CONNECTION_USERNAME", "The bitbucket username which should be used.")
 	makeUnprotectedSchema(r, "url", "AZDO_OTHER_GIT_SERVICE_CONNECTION_URL", "The HTTPS URL for the repo.")
-	makeProtectedSchema(r, "password", "AZDO_BITBUCKET_SERVICE_CONNECTION_PASSWORD", "The bitbucket password whi|ch should be used.")
+	makeProtectedSchema(r, "password", "AZDO_OTHER_GIT_SERVICE_CONNECTION_PASSWORD", "The bitbucket password whi|ch should be used.")
 	return r
 }
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_other_git.go
@@ -3,20 +3,20 @@ package serviceendpoint
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/model"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
 
-// ResourceServiceEndpointBitBucket schema and implementation for bitbucket service endpoint resource
-func ResourceServiceEndpointBitBucket() *schema.Resource {
-	r := genBaseServiceEndpointResource(flattenServiceEndpointBitBucket, expandServiceEndpointBitBucket)
+// ResourceServiceEndpointOtherGit schema and implementation for bitbucket service endpoint resource
+func ResourceServiceEndpointOtherGit() *schema.Resource {
+	r := genBaseServiceEndpointResource(flattenServiceEndpointOtherGit, expandServiceEndpointOtherGit)
 	makeUnprotectedSchema(r, "username", "AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", "The bitbucket username which should be used.")
+	makeUnprotectedSchema(r, "url", "AZDO_OTHER_GIT_SERVICE_CONNECTION_URL", "The HTTPS URL for the repo.")
 	makeProtectedSchema(r, "password", "AZDO_BITBUCKET_SERVICE_CONNECTION_PASSWORD", "The bitbucket password whi|ch should be used.")
 	return r
 }
 
-func expandServiceEndpointBitBucket(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
+func expandServiceEndpointOtherGit(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
 	serviceEndpoint, projectID := doBaseExpansion(d)
 	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
 		Parameters: &map[string]string{
@@ -26,11 +26,11 @@ func expandServiceEndpointBitBucket(d *schema.ResourceData) (*serviceendpoint.Se
 		Scheme: converter.String("UsernamePassword"),
 	}
 	serviceEndpoint.Type = converter.String(string("git"))
-	serviceEndpoint.Url = converter.String("")
+	serviceEndpoint.Url = converter.String(d.Get("url").(string))
 	return serviceEndpoint, projectID, nil
 }
 
-func flattenServiceEndpointBitBucket(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
+func flattenServiceEndpointOtherGit(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
 	doBaseFlattening(d, serviceEndpoint, projectID)
 	d.Set("username", (*serviceEndpoint.Authorization.Parameters)["username"])
 	tfhelper.HelpFlattenSecret(d, "password")

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -33,6 +33,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_aws":              serviceendpoint.ResourceServiceEndpointAws(),
 			"azuredevops_serviceendpoint_azurerm":          serviceendpoint.ResourceServiceEndpointAzureRM(),
 			"azuredevops_serviceendpoint_bitbucket":        serviceendpoint.ResourceServiceEndpointBitBucket(),
+			"azuredevops_serviceendpoint_other_git":        serviceendpoint.ResourceServiceEndpointOtherGit(),
 			"azuredevops_serviceendpoint_dockerregistry":   serviceendpoint.ResourceServiceEndpointDockerRegistry(),
 			"azuredevops_serviceendpoint_azurecr":          serviceendpoint.ResourceServiceEndpointAzureCR(),
 			"azuredevops_serviceendpoint_github":           serviceendpoint.ResourceServiceEndpointGitHub(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -23,6 +23,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_azurerm",
 		"azuredevops_serviceendpoint_azurecr",
 		"azuredevops_serviceendpoint_bitbucket",
+		"azuredevops_serviceendpoint_other_git",
 		"azuredevops_serviceendpoint_kubernetes",
 		"azuredevops_serviceendpoint_aws",
 		"azuredevops_variable_group",


### PR DESCRIPTION
@curiousbug and implemented support for other git service connections.

It can be used in this way

```
resource "azuredevops_serviceendpoint_other_git" "myOtherGitServiceConnection" {
  project_id            = azuredevops_project.project.id
  username              = "git_user"
  password              = "git_pass"
  service_endpoint_name = "myOtherGitServiceConnection1"
  description           = "myOtherGitServiceConnection1"
  url                   = "https://code.mygitserver.net/scm/foobar/my-repo.git"
}
```

We still have to add tests.