### PR TITLE
Search for Project Collection Groups with Group datasource

### DIFF
--- a/azuredevops/internal/acceptancetests/data_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_test.go
@@ -35,3 +35,25 @@ func TestAccGroupDataSource_Read_HappyPath(t *testing.T) {
 		},
 	})
 }
+
+func TestAccGroupDataSource_Read_ProjectCollectionAdministrators(t *testing.T) {
+	group := "Project Collection Administrators"
+	tfBuildDefNode := "data.azuredevops_group.group"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.HclGroupDataSource("", group),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "name"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "descriptor"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "origin"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "origin_id"),
+				),
+			},
+		},
+	})
+}

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -41,6 +41,12 @@ func HclForkedGitRepoResource(projectName string, gitRepoName string, gitForkedR
 
 // HclGroupDataSource HCL describing an AzDO Group Data Source
 func HclGroupDataSource(projectName string, groupName string) string {
+	if projectName == "" {
+		return fmt.Sprintf(`
+data "azuredevops_group" "group" {
+	name       = "%s"
+}`, groupName)
+	}
 	dataSource := fmt.Sprintf(`
 data "azuredevops_group" "group" {
 	project_id = azuredevops_project.project.id

--- a/azuredevops/internal/service/graph/data_group.go
+++ b/azuredevops/internal/service/graph/data_group.go
@@ -25,7 +25,6 @@ func DataGroup() *schema.Resource {
 			"project_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"descriptor": {

--- a/website/docs/d/data_group.html.markdown
+++ b/website/docs/d/data_group.html.markdown
@@ -48,7 +48,7 @@ output "collection_group_descriptor" {
 The following arguments are supported:
 
 - `name` - (Required) The Group Name.
-- `project_id` - (Optional) The Project Id. If no project Id is specified the project collection groups will be searched.
+- `project_id` - (Optional) The Project ID. If no project Id is specified the project collection groups will be searched.
 
 ## Attributes Reference
 

--- a/website/docs/d/data_group.html.markdown
+++ b/website/docs/d/data_group.html.markdown
@@ -48,7 +48,7 @@ output "collection_group_descriptor" {
 The following arguments are supported:
 
 - `name` - (Required) The Group Name.
-- `project_id` - (Optional) The Project ID. If no project Id is specified the project collection groups will be searched.
+- `project_id` - (Optional) The Project ID. If no project ID is specified the project collection groups will be searched.
 
 ## Attributes Reference
 

--- a/website/docs/d/data_group.html.markdown
+++ b/website/docs/d/data_group.html.markdown
@@ -28,14 +28,27 @@ output "group_id" {
 output "group_descriptor" {
   value = data.azuredevops_group.test.descriptor
 }
+
+data "azuredevops_group" "test-collection-group" {
+  name       = "Project Collection Administrators"
+}
+
+output "collection_group_id" {
+  value = data.azuredevops_group.test-collection-group.id
+}
+
+output "collection_group_descriptor" {
+  value = data.azuredevops_group.test-collection-group.descriptor
+}
+
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-- `project_id` - (Required) The Project Id.
 - `name` - (Required) The Group Name.
+- `project_id` - (Optional) The Project Id. If no project Id is specified the project collection groups will be searched.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The PR contains a change to the Group datasource , so that it's possible to search for project collection groups and not only for groups located inside a project.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->