### PR TITLE
add support for appcenter service connections

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_appcenter.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_appcenter.go
@@ -1,0 +1,34 @@
+package serviceendpoint
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// ResourceServiceEndpointAppcenter schema and implementation for bitbucket service endpoint resource
+func ResourceServiceEndpointAppcenter() *schema.Resource {
+	r := genBaseServiceEndpointResource(flattenServiceEndpointAppcenter, expandServiceEndpointAppcenter)
+	makeProtectedSchema(r, "apitoken", "AZDO_APPCENTER_SERVICE_CONNECTION_API_TOKEN", "The API token to connect to app center.")
+	return r
+}
+
+func expandServiceEndpointAppcenter(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
+	serviceEndpoint, projectID := doBaseExpansion(d)
+	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+		Parameters: &map[string]string{
+			"apitoken": d.Get("apitoken").(string),
+		},
+		Scheme: converter.String("Token"),
+	}
+	serviceEndpoint.Type = converter.String(string("vsmobilecenter"))
+	serviceEndpoint.Url = converter.String("https://api.appcenter.ms/v0.1")
+	return serviceEndpoint, projectID, nil
+}
+
+func flattenServiceEndpointAppcenter(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
+	doBaseFlattening(d, serviceEndpoint, projectID)
+	tfhelper.HelpFlattenSecret(d, "apitoken")
+	d.Set("apitoken", (*serviceEndpoint.Authorization.Parameters)["apitoken"])
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -33,6 +33,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_aws":              serviceendpoint.ResourceServiceEndpointAws(),
 			"azuredevops_serviceendpoint_azurerm":          serviceendpoint.ResourceServiceEndpointAzureRM(),
 			"azuredevops_serviceendpoint_bitbucket":        serviceendpoint.ResourceServiceEndpointBitBucket(),
+			"azuredevops_serviceendpoint_appcenter":        serviceendpoint.ResourceServiceEndpointAppcenter(),
 			"azuredevops_serviceendpoint_dockerregistry":   serviceendpoint.ResourceServiceEndpointDockerRegistry(),
 			"azuredevops_serviceendpoint_azurecr":          serviceendpoint.ResourceServiceEndpointAzureCR(),
 			"azuredevops_serviceendpoint_github":           serviceendpoint.ResourceServiceEndpointGitHub(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -23,7 +23,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_azurerm",
 		"azuredevops_serviceendpoint_azurecr",
 		"azuredevops_serviceendpoint_bitbucket",
-                "azuredevops_serviceendpoint_appcenter",
+		"azuredevops_serviceendpoint_appcenter",
 		"azuredevops_serviceendpoint_kubernetes",
 		"azuredevops_serviceendpoint_aws",
 		"azuredevops_variable_group",

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -23,6 +23,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_azurerm",
 		"azuredevops_serviceendpoint_azurecr",
 		"azuredevops_serviceendpoint_bitbucket",
+                "azuredevops_serviceendpoint_appcenter",
 		"azuredevops_serviceendpoint_kubernetes",
 		"azuredevops_serviceendpoint_aws",
 		"azuredevops_variable_group",


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Added appcenter service connection support.
https://docs.microsoft.com/en-us/appcenter/distribution/vsts-deploy

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

This change adds support for app center service connections.

Usage:

```
resource "azuredevops_serviceendpoint_appcenter" "paul-ios" {
 project_id            = azuredevops_project.project.id
 service_endpoint_name = "foo-org-appcenter"
 description           = "appcenter connection for foo-org"
 apitoken              = "xxxxxxxxx"
}
```

I copied `resource_serviceendpoint_bitbucket.go` and modifed accordingly. I noticed that the Bitbucket service connection itself has no tests, and I'm myself not too sure how to write a test for it since it requires an additional service. Could you point me in the right direction?