### PR TITLE
Enable cluster_admin in Kubernetes service connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist
 
 #GoLand Editor configuration
 .idea
+
+.DS_Store

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -69,6 +69,12 @@ func makeSchemaAzureSubscription(r *schema.Resource) {
 					Default:     "default",
 					Description: "accessed namespace",
 				},
+				"cluster_admin": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Enable Cluster Admin",
+				},
 			},
 		},
 	}
@@ -186,6 +192,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 			"azureSubscriptionName": configuration["subscription_name"].(string),
 			"clusterId":             clusterID,
 			"namespace":             configuration["namespace"].(string),
+			"clusterAdmin":          fmt.Sprintf("%v", configuration["cluster_admin"].(bool)),
 		}
 	case "Kubeconfig":
 		configurationRaw := d.Get(resourceBlockKubeconfig).(*schema.Set).List()
@@ -263,6 +270,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 			"cluster_name":      clusterIDSplit[clusterNameIndex],
 			"resourcegroup_id":  clusterIDSplit[resourceGroupIDIndex],
 			"namespace":         (*serviceEndpoint.Data)["namespace"],
+			"cluster_admin":     (*serviceEndpoint.Data)["cluster_admin"],
 		}
 		configItemList := make([]map[string]interface{}, 1)
 		configItemList[0] = configItems

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -262,6 +262,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 				clusterNameIndex = k + 1
 			}
 		}
+		clusterAdmin, _ := strconv.ParseBool((*serviceEndpoint.Data)["cluster_admin"])
 		configItems := map[string]interface{}{
 			"azure_environment": (*serviceEndpoint.Authorization.Parameters)["azureEnvironment"],
 			"tenant_id":         (*serviceEndpoint.Authorization.Parameters)["azureTenantId"],
@@ -270,7 +271,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 			"cluster_name":      clusterIDSplit[clusterNameIndex],
 			"resourcegroup_id":  clusterIDSplit[resourceGroupIDIndex],
 			"namespace":         (*serviceEndpoint.Data)["namespace"],
-			"cluster_admin":     (*serviceEndpoint.Data)["cluster_admin"],
+			"cluster_admin":     clusterAdmin,
 		}
 		configItemList := make([]map[string]interface{}, 1)
 		configItemList[0] = configItems

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -72,8 +72,8 @@ func makeSchemaAzureSubscription(r *schema.Resource) {
 				"cluster_admin": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     false,
 					ForceNew:    true,
+					Default:     false,
 					Description: "Enable Cluster Admin",
 				},
 			},
@@ -263,11 +263,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 				clusterNameIndex = k + 1
 			}
 		}
-		clusterAdmin, err := strconv.ParseBool((*serviceEndpoint.Data)["clusterAdmin"])
-		if err != nil {
-			err = fmt.Errorf("error converting cluster_admin attribute string into a bool %w", err)
-			fmt.Println(err)
-		}
+		clusterAdmin, _ := strconv.ParseBool((*serviceEndpoint.Data)["clusterAdmin"])
 		configItems := map[string]interface{}{
 			"azure_environment": (*serviceEndpoint.Authorization.Parameters)["azureEnvironment"],
 			"tenant_id":         (*serviceEndpoint.Authorization.Parameters)["azureTenantId"],

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -73,6 +73,7 @@ func makeSchemaAzureSubscription(r *schema.Resource) {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Default:     false,
+					ForceNew:    true,
 					Description: "Enable Cluster Admin",
 				},
 			},
@@ -192,7 +193,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 			"azureSubscriptionName": configuration["subscription_name"].(string),
 			"clusterId":             clusterID,
 			"namespace":             configuration["namespace"].(string),
-			"clusterAdmin":          fmt.Sprintf("%v", configuration["cluster_admin"].(bool)),
+			"clusterAdmin":          strconv.FormatBool(configuration["cluster_admin"].(bool)),
 		}
 	case "Kubeconfig":
 		configurationRaw := d.Get(resourceBlockKubeconfig).(*schema.Set).List()
@@ -262,7 +263,10 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 				clusterNameIndex = k + 1
 			}
 		}
-		clusterAdmin, _ := strconv.ParseBool((*serviceEndpoint.Data)["cluster_admin"])
+		clusterAdmin, err := strconv.ParseBool((*serviceEndpoint.Data)["clusterAdmin"])
+		if err != nil {
+			fmt.Errorf("Error converting cluster_admin attribute string into a bool")
+		}
 		configItems := map[string]interface{}{
 			"azure_environment": (*serviceEndpoint.Authorization.Parameters)["azureEnvironment"],
 			"tenant_id":         (*serviceEndpoint.Authorization.Parameters)["azureTenantId"],

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -265,7 +265,8 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 		}
 		clusterAdmin, err := strconv.ParseBool((*serviceEndpoint.Data)["clusterAdmin"])
 		if err != nil {
-			fmt.Errorf("Error converting cluster_admin attribute string into a bool")
+			err = fmt.Errorf("error converting cluster_admin attribute string into a bool %w", err)
+			fmt.Println(err)
 		}
 		configItems := map[string]interface{}{
 			"azure_environment": (*serviceEndpoint.Authorization.Parameters)["azureEnvironment"],

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
@@ -52,6 +52,7 @@ func createkubernetesTestServiceEndpointForAzureSubscription() *serviceendpoint.
 		"azureSubscriptionName": "kubernetes_TEST_subscription_name",
 		"clusterId":             "/subscriptions/kubernetes_TEST_subscription_id/resourcegroups/kubernetes_TEST_resource_group_id/providers/Microsoft.ContainerService/managedClusters/kubernetes_TEST_cluster_name",
 		"namespace":             "default",
+		"clusterAdmin":          "false",
 	}
 
 	return &serviceEndpoint

--- a/website/docs/r/serviceendpoint_kubernetes.html.markdown
+++ b/website/docs/r/serviceendpoint_kubernetes.html.markdown
@@ -95,6 +95,7 @@ The following arguments are supported:
   - `tenant_id` - (Required) The id of the tenant used by the subscription.
   - `resourcegroup_id` - (Required) The resource group name, to which the Kubernetes cluster is deployed.
   - `namespace` - (Optional) The Kubernetes namespace. Default value is "default".
+  - `cluster_admin` - (Optional) Set this option to allow use cluster admin credentials.
 - `kubeconfig` - (Optional) The configuration for authorization_type="Kubeconfig".
   - `kube_config` - (Required) The content of the kubeconfig in yaml notation to be used to communicate with the API-Server of Kubernetes.
   - `accept_untrusted_certs` - (Optional) Set this option to allow clients to accept a self-signed certificate.


### PR DESCRIPTION

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Allow to enable and disable cluster_admin in Kubernetes service connections with Azure subscription authentication type.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/216

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->