### PR TITLE
Add git repository file

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -26,7 +26,7 @@ func TestAccGitRepoFile_CreateAndUpdate(t *testing.T) {
 	gitRepoName := testutils.GenerateResourceName()
 	tfRepoFileNode := "azuredevops_git_repository_file.file"
 
-	branch := "refs/heads/main"
+	branch := "refs/heads/master"
 	file := "foo.txt"
 	contentFirst := "bar"
 	contentSecond := "baz"
@@ -97,7 +97,7 @@ func checkGitRepoFileNotExists(fileName string) resource.TestCheckFunc {
 			RepositoryId: &repo.Primary.ID,
 			Path:         &fileName,
 		})
-		if err != nil && strings.Contains(err.Error(), "could not be found in the repository") {
+		if err != nil && !strings.Contains(err.Error(), "could not be found in the repository") {
 			return err
 		}
 

--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -1,0 +1,147 @@
+// +build all core resource_git_repository_file
+// +build !exclude_resource_git_repository_file
+
+package acceptancetests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// TestAccGitRepoFile_CreateUpdateDelete verifies that a file can
+// be added to a repository and the contents can be updated
+func TestAccGitRepoFile_CreateAndUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+	tfRepoFileNode := "azuredevops_git_repository_file.file"
+
+	branch := "master"
+	file := "foo.txt"
+	contentFirst := "bar"
+	contentSecond := "baz"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.HclGitRepoFileResource(projectName, gitRepoName, "Clean", branch, file, contentFirst),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfRepoFileNode, "file", file),
+					resource.TestCheckResourceAttr(tfRepoFileNode, "content", contentFirst),
+					resource.TestCheckResourceAttr(tfRepoFileNode, "branch", fmt.Sprintf("refs/heads/%s", branch)),
+					resource.TestCheckResourceAttrSet(tfRepoFileNode, "commit_message"),
+					checkGitRepoFileContent(contentFirst),
+				),
+			},
+			{
+				Config: testutils.HclGitRepoFileResource(projectName, gitRepoName, "Clean", branch, file, contentSecond),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfRepoFileNode, "file", file),
+					resource.TestCheckResourceAttr(tfRepoFileNode, "content", contentSecond),
+					resource.TestCheckResourceAttr(tfRepoFileNode, "branch", fmt.Sprintf("refs/heads/%s", branch)),
+					resource.TestCheckResourceAttrSet(tfRepoFileNode, "commit_message"),
+					checkGitRepoFileContent(contentSecond),
+				),
+			},
+			{
+				Config: testutils.HclGitRepoResource(projectName, gitRepoName, "Clean"),
+				Check: resource.ComposeTestCheckFunc(
+					checkGitRepoFileNotExists(file),
+				),
+			},
+		},
+	})
+}
+
+// TestAccGitRepo_Create_IncorrectBranch verifies a file
+// can't be added to a non existant branch
+func TestAccGitRepo_Create_IncorrectBranch(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testutils.HclGitRepoFileResource(projectName, gitRepoName, "Clean", "foobar", "foo", "bar"),
+				ExpectError: regexp.MustCompile(`errors during apply: Branch "foobar" does not exist`),
+			},
+		},
+	})
+}
+
+func checkGitRepoFileNotExists(fileName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+
+		repo, ok := s.RootModule().Resources["azuredevops_git_repository.repository"]
+		if !ok {
+			return fmt.Errorf("Did not find a repo definition in the TF state")
+		}
+
+		ctx := context.Background()
+		_, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
+			RepositoryId: &repo.Primary.ID,
+			Path:         &fileName,
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "could not be found in the repository") {
+				return nil
+			}
+
+			return err
+		}
+
+		return fmt.Errorf("file does exist: %v", fileName)
+	}
+}
+
+func checkGitRepoFileContent(expectedContent string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+
+		gitFile, ok := s.RootModule().Resources["azuredevops_git_repository_file.file"]
+		if !ok {
+			return fmt.Errorf("Did not find a repo definition in the TF state")
+		}
+
+		fileID := gitFile.Primary.ID
+		comps := strings.Split(fileID, "/")
+		repoID := comps[0]
+		file := comps[1]
+
+		ctx := context.Background()
+		r, err := clients.GitReposClient.GetItemContent(ctx, git.GetItemContentArgs{
+			RepositoryId: &repoID,
+			Path:         &file,
+		})
+		if err != nil {
+			return err
+		}
+
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(r)
+		if err != nil {
+			return err
+		}
+
+		if buf.String() != expectedContent {
+			return fmt.Errorf("Unexpected git file content: %v", buf.String())
+		}
+
+		return nil
+	}
+}

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -39,6 +39,19 @@ func HclForkedGitRepoResource(projectName string, gitRepoName string, gitForkedR
 	return fmt.Sprintf("%s\n%s", gitRepoResource, azureGitRepoResource)
 }
 
+// HclGitRepoFileResource HCl describing a file in an AzDO GIT repository
+func HclGitRepoFileResource(projectName, gitRepoName, initType, branch, file, content string) string {
+	gitRepoFileResource := fmt.Sprintf(`
+	resource "azuredevops_git_repository_file" "file" {
+		repository_id = azuredevops_git_repository.repository.id
+		file          = "%s"
+		content       = "%s"
+		branch        = "refs/heads/%s"
+	}`, file, content, branch)
+	gitRepoResource := HclGitRepoResource(projectName, gitRepoName, initType)
+	return fmt.Sprintf("%s\n%s", gitRepoFileResource, gitRepoResource)
+}
+
 // HclGroupDataSource HCL describing an AzDO Group Data Source
 func HclGroupDataSource(projectName string, groupName string) string {
 	if projectName == "" {

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -46,7 +46,7 @@ func HclGitRepoFileResource(projectName, gitRepoName, initType, branch, file, co
 		repository_id = azuredevops_git_repository.repository.id
 		file          = "%s"
 		content       = "%s"
-		branch        = "refs/heads/%s"
+		branch        = "%s"
 	}`, file, content, branch)
 	gitRepoResource := HclGitRepoResource(projectName, gitRepoName, initType)
 	return fmt.Sprintf("%s\n%s", gitRepoFileResource, gitRepoResource)

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -183,7 +183,6 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 
 		_, err = clients.GitReposClient.CreatePush(ctx, *args)
 		if err != nil {
-			// Retry if commit has already occured
 			if utils.ResponseContainsStatusMessage(err, "has already been updated by another client") {
 				return resource.RetryableError(err)
 			} else {

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -236,7 +236,7 @@ func resourceGitRepositoryFileUpdate(d *schema.ResourceData, m interface{}) erro
 		return nil
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return resourceGitRepositoryFileRead(d, m)

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -323,7 +323,7 @@ func resourceGitRepositoryFileDelete(d *schema.ResourceData, m interface{}) erro
 		},
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -23,10 +23,10 @@ func ResourceGitRepositoryFile() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), ":")
-				branch := "refs/heads/main"
+				branch := "refs/heads/master"
 
 				if len(parts) > 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"main\") or <repository>/<file path>:<branch>")
+					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"master\") or <repository>/<file path>:<branch>")
 				}
 
 				if len(parts) == 2 {
@@ -69,8 +69,8 @@ func ResourceGitRepositoryFile() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "The branch name, defaults to \"refs/heads/main\"",
-				Default:     "refs/heads/main",
+				Description: "The branch name, defaults to \"refs/heads/master\"",
+				Default:     "refs/heads/master",
 			},
 			"commit_message": {
 				Type:        schema.TypeString,
@@ -342,6 +342,7 @@ func checkRepositoryBranchExists(c *client.AggregatedClient, repo, branch string
 
 // checkRepositoryFileExists tests if a file exists in a repository.
 func checkRepositoryFileExists(c *client.AggregatedClient, repo, file, branch string) error {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
 	ctx := context.Background()
 	_, err := c.GitReposClient.GetItem(ctx, git.GetItemArgs{
 		RepositoryId: &repo,
@@ -351,13 +352,14 @@ func checkRepositoryFileExists(c *client.AggregatedClient, repo, file, branch st
 		},
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil
 }
 
 func getLastCommitId(c *client.AggregatedClient, repo, branch string) (string, error) {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
 	ctx := context.Background()
 	commits, err := c.GitReposClient.GetCommits(ctx, git.GetCommitsArgs{
 		RepositoryId: &repo,

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -183,7 +183,12 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 
 		_, err = clients.GitReposClient.CreatePush(ctx, *args)
 		if err != nil {
-			return resource.NonRetryableError(err)
+			// Retry if commit has already occured
+			if utils.ResponseContainsStatusMessage(err, "has already been updated by another client") {
+				return resource.RetryableError(err)
+			} else {
+				return resource.NonRetryableError(err)
+			}
 		}
 
 		return nil

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -1,0 +1,370 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+)
+
+func ResourceGitRepositoryFile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitRepositoryFileCreate,
+		Read:   resourceGitRepositoryFileRead,
+		Update: resourceGitRepositoryFileUpdate,
+		Delete: resourceGitRepositoryFileDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				parts := strings.Split(d.Id(), ":")
+				branch := "main"
+
+				if len(parts) > 2 {
+					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"master\") or <repository>/<file path>:<branch>")
+				}
+
+				if len(parts) == 2 {
+					branch = parts[1]
+				}
+
+				clients := m.(*client.AggregatedClient)
+				repo, file := splitRepoFilePath(parts[0])
+				if err := checkRepositoryFileExists(clients, repo, file, branch); err != nil {
+					return nil, err
+				}
+
+				d.SetId(fmt.Sprintf("%s/%s", repo, file))
+				d.Set("branch", branch)
+				d.Set("overwrite_on_create", false)
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The repository name",
+			},
+			"file": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The file path to manage",
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The file's content",
+			},
+			"branch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The branch name, defaults to \"master\"",
+				Default:     "main",
+			},
+			"commit_message": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The commit message when creating or updating the file",
+			},
+			"commit_author": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The commit author name, defaults to the authenticated user's name",
+			},
+			"commit_email": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The commit author email address, defaults to the authenticated user's email address",
+			},
+			"object_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The blob object id of the file",
+			},
+			"overwrite_on_create": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable overwriting existing files, defaults to \"false\"",
+				Default:     false,
+			},
+		},
+	}
+}
+
+func resourceGitRepositoryPushArgs(d *schema.ResourceData, changeType git.VersionControlChangeType) (*git.CreatePushArgs, error) {
+	var message string
+	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
+		message = commitMessage.(string)
+	}
+
+	var objectID string
+	if fileObjectID, hasObjectID := d.GetOk("object_id"); hasObjectID {
+		objectID = fileObjectID.(string)
+	}
+
+	commitAuthor, hasCommitAuthor := d.GetOk("commit_author")
+	commitEmail, hasCommitEmail := d.GetOk("commit_email")
+
+	if hasCommitAuthor && !hasCommitEmail {
+		return nil, fmt.Errorf("Cannot set commit_author without setting commit_email")
+	}
+
+	if hasCommitEmail && !hasCommitAuthor {
+		return nil, fmt.Errorf("Cannot set commit_email without setting commit_author")
+	}
+
+	var author *git.GitUserDate
+	if hasCommitAuthor && hasCommitEmail {
+		name := commitAuthor.(string)
+		email := commitEmail.(string)
+		author = &git.GitUserDate{Name: &name, Email: &email}
+	}
+
+	repo := d.Get("repo").(string)
+	content := d.Get("content").(string)
+	file := d.Get("file").(string)
+	branch := d.Get("branch").(string)
+
+	change := &git.GitChange{
+		ChangeType: &changeType,
+		Item: git.GitItem{
+			Path: &file,
+		},
+		NewContent: &git.ItemContent{
+			Content:     &content,
+			ContentType: &git.ItemContentTypeValues.RawText,
+		},
+	}
+
+	args := &git.CreatePushArgs{
+		RepositoryId: &repo,
+		Push: &git.GitPush{
+			RefUpdates: &[]git.GitRefUpdate{
+				{
+					Name:        &branch,
+					OldObjectId: &objectID,
+				},
+			},
+			Commits: &[]git.GitCommitRef{
+				{
+					Author:  author,
+					Comment: &message,
+					Changes: &[]interface{}{change},
+				},
+			},
+		},
+	}
+
+	return args, nil
+}
+
+func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) error {
+	ctx := context.Background()
+	clients := m.(*client.AggregatedClient)
+
+	repo := d.Get("repository").(string)
+	file := d.Get("file").(string)
+	branch := d.Get("branch").(string)
+
+	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+		return err
+	}
+
+	args, err := resourceGitRepositoryPushArgs(d, git.VersionControlChangeTypeValues.Add)
+	if err != nil {
+		return err
+	}
+
+	if (*args.Push.Commits)[0].Comment == nil {
+		m := fmt.Sprintf("Add %s", file)
+		(*args.Push.Commits)[0].Comment = &m
+	}
+
+	item, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
+		RepositoryId: &repo,
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) == false {
+			return err
+		}
+	}
+
+	if item.Content != nil {
+		if d.Get("overwrite_on_create").(bool) {
+			(*args.Push.RefUpdates)[0].OldObjectId = item.ObjectId
+		} else {
+			return fmt.Errorf("Refusing to overwrite existing file. Configure `overwrite_on_create` to `true` to override.")
+		}
+	}
+
+	// Create a new or overwritten file
+	_, err = clients.GitReposClient.CreatePush(ctx, *args)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", repo, file))
+
+	return resourceGitRepositoryFileRead(d, m)
+}
+
+func boolPointer(val bool) *bool {
+	return &val
+}
+
+func splitRepoFilePath(path string) (string, string) {
+	parts := strings.Split(path, "/")
+	return parts[0], strings.Join(parts[1:], "/")
+}
+
+func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error {
+	ctx := context.Background()
+	clients := m.(*client.AggregatedClient)
+
+	repo, file := splitRepoFilePath(d.Id())
+	branch := d.Get("branch").(string)
+
+	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+		return err
+	}
+
+	item, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
+		RepositoryId:      &repo,
+		Path:              &file,
+		VersionDescriptor: &git.GitVersionDescriptor{Version: &branch},
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("content", item.Content)
+	d.Set("repository", repo)
+	d.Set("file", file)
+	d.Set("object_id", item.ObjectId)
+
+	commit, err := clients.GitReposClient.GetCommit(ctx, git.GetCommitArgs{
+		RepositoryId: &repo,
+		CommitId:     item.CommitId,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("commit_author", commit.Author.Name)
+	d.Set("commit_email", commit.Author.Email)
+	d.Set("commit_message", commit.Comment)
+
+	return nil
+}
+
+func resourceGitRepositoryFileUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	ctx := context.Background()
+
+	repo := d.Get("repository").(string)
+	file := d.Get("file").(string)
+	branch := d.Get("branch").(string)
+
+	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+		return err
+	}
+
+	args, err := resourceGitRepositoryPushArgs(d, git.VersionControlChangeTypeValues.Edit)
+	if err != nil {
+		return err
+	}
+
+	if *(*args.Push.Commits)[0].Comment == fmt.Sprintf("Add %s", file) {
+		m := fmt.Sprintf("Update %s", file)
+		(*args.Push.Commits)[0].Comment = &m
+	}
+
+	_, err = clients.GitReposClient.CreatePush(ctx, *args)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitRepositoryFileRead(d, m)
+}
+
+func resourceGitRepositoryFileDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	ctx := context.Background()
+
+	repo := d.Get("repository").(string)
+	file := d.Get("file").(string)
+	branch := d.Get("branch").(string)
+	objectID := d.Get("object_id").(string)
+	message := fmt.Sprintf("Delete %s", file)
+
+	change := &git.GitChange{
+		ChangeType: &git.VersionControlChangeTypeValues.Delete,
+		Item: git.GitItem{
+			Path: &file,
+		},
+	}
+
+	_, err := clients.GitReposClient.CreatePush(ctx, git.CreatePushArgs{
+		RepositoryId: &repo,
+		Push: &git.GitPush{
+			RefUpdates: &[]git.GitRefUpdate{
+				{
+					Name:        &branch,
+					OldObjectId: &objectID,
+				},
+			},
+			Commits: &[]git.GitCommitRef{
+				{
+					Comment: &message,
+					Changes: &[]interface{}{change},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil
+	}
+
+	return nil
+}
+
+// checkRepositoryBranchExists tests if a branch exists in a repository.
+func checkRepositoryBranchExists(c *client.AggregatedClient, repo, branch string) error {
+	ctx := context.Background()
+	c.GitReposClient.GetBranch(ctx, git.GetBranchArgs{
+		RepositoryId: &repo,
+		Name:         &branch,
+	})
+
+	return nil
+}
+
+// checkRepositoryFileExists tests if a file exists in a repository.
+func checkRepositoryFileExists(c *client.AggregatedClient, repo, file, branch string) error {
+	ctx := context.Background()
+	_, err := c.GitReposClient.GetItem(ctx, git.GetItemArgs{
+		RepositoryId: &repo,
+		Path:         &file,
+	})
+	if err != nil {
+		return nil
+	}
+
+	return nil
+}

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -197,7 +197,6 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", repo, file))
-
 	return resourceGitRepositoryFileRead(d, m)
 }
 
@@ -231,7 +230,7 @@ func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error 
 		}
 
 		d.Set("content", item.Content)
-		d.Set("repository", repo)
+		d.Set("repository_id", repo)
 		d.Set("file", file)
 
 		commit, err := clients.GitReposClient.GetCommit(ctx, git.GetCommitArgs{

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -92,91 +92,45 @@ func ResourceGitRepositoryFile() *schema.Resource {
 	}
 }
 
-func resourceGitRepositoryPushArgs(d *schema.ResourceData, objectID string, changeType git.VersionControlChangeType) (*git.CreatePushArgs, error) {
-	var message *string
-	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
-		cm := commitMessage.(string)
-		message = &cm
-	}
-
-	repo := d.Get("repository_id").(string)
-	content := d.Get("content").(string)
-	file := d.Get("file").(string)
-	branch := d.Get("branch").(string)
-
-	change := git.GitChange{
-		ChangeType: &changeType,
-		Item: git.GitItem{
-			Path: &file,
-		},
-		NewContent: &git.ItemContent{
-			Content:     &content,
-			ContentType: &git.ItemContentTypeValues.RawText,
-		},
-	}
-
-	args := &git.CreatePushArgs{
-		RepositoryId: &repo,
-		Push: &git.GitPush{
-			RefUpdates: &[]git.GitRefUpdate{
-				{
-					Name:        &branch,
-					OldObjectId: &objectID,
-				},
-			},
-			Commits: &[]git.GitCommitRef{
-				{
-					Comment: message,
-					Changes: &[]interface{}{change},
-				},
-			},
-		},
-	}
-
-	return args, nil
-}
-
 func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) error {
 	ctx := context.Background()
 	clients := m.(*client.AggregatedClient)
 
-	repo := d.Get("repository_id").(string)
+	repoId := d.Get("repository_id").(string)
 	file := d.Get("file").(string)
 	branch := d.Get("branch").(string)
 	overwriteOnCreate := d.Get("overwrite_on_create").(bool)
 
-	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+	if err := checkRepositoryBranchExists(clients, repoId, branch); err != nil {
 		return err
 	}
-
-	changeType := git.VersionControlChangeTypeValues.Add
-	item, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
-		RepositoryId: &repo,
+	repoItem, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
+		RepositoryId: &repoId,
 		Path:         &file,
 	})
 	if err != nil && !utils.ResponseWasNotFound(err) {
 		return err
 	}
 
-	if item != nil {
+	// Change type should be edit if overwrite is enabled when file exists
+	changeType := git.VersionControlChangeTypeValues.Add
+	if repoItem != nil {
 		if !overwriteOnCreate {
 			return fmt.Errorf("Refusing to overwrite existing file. Configure `overwrite_on_create` to `true` to override.")
 		}
-
 		changeType = git.VersionControlChangeTypeValues.Edit
 	}
 
+	// Need to retry creating the file as multiple updates could happen at the same time
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		objectID, err := getLastCommitId(clients, repo, branch)
+		objectID, err := getLastCommitId(clients, repoId, branch)
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-
 		args, err := resourceGitRepositoryPushArgs(d, objectID, changeType)
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-
 		if (*args.Push.Commits)[0].Comment == nil {
 			m := fmt.Sprintf("Add %s", file)
 			(*args.Push.Commits)[0].Comment = &m
@@ -186,18 +140,16 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 		if err != nil {
 			if utils.ResponseContainsStatusMessage(err, "has already been updated by another client") {
 				return resource.RetryableError(err)
-			} else {
-				return resource.NonRetryableError(err)
 			}
+			return resource.NonRetryableError(err)
 		}
-
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", repo, file))
+	d.SetId(fmt.Sprintf("%s/%s", repoId, file))
 	return resourceGitRepositoryFileRead(d, m)
 }
 
@@ -205,80 +157,86 @@ func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error 
 	ctx := context.Background()
 	clients := m.(*client.AggregatedClient)
 
-	repo, file := splitRepoFilePath(d.Id())
+	repoId, file := splitRepoFilePath(d.Id())
 	branch := d.Get("branch").(string)
 
-	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+	if err := checkRepositoryBranchExists(clients, repoId, branch); err != nil {
 		return err
 	}
 
-	return resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
-		branch = strings.TrimPrefix(branch, "refs/heads/")
-		item, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
-			RepositoryId:   &repo,
-			Path:           &file,
-			IncludeContent: converter.Bool(true),
-			VersionDescriptor: &git.GitVersionDescriptor{
-				Version:     &branch,
-				VersionType: &git.GitVersionTypeValues.Branch,
-			},
-		})
-		if err != nil {
-			if utils.ResponseWasNotFound(err) {
-				d.SetId("")
-				return resource.NonRetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-
-		d.Set("content", item.Content)
-		d.Set("repository_id", repo)
-		d.Set("file", file)
-
-		commit, err := clients.GitReposClient.GetCommit(ctx, git.GetCommitArgs{
-			RepositoryId: &repo,
-			CommitId:     item.CommitId,
-		})
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		d.Set("commit_message", commit.Comment)
-
-		return nil
+	// Get the repository item if it exists
+	repoItem, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
+		RepositoryId:   &repoId,
+		Path:           &file,
+		IncludeContent: converter.Bool(true),
+		VersionDescriptor: &git.GitVersionDescriptor{
+			Version:     converter.String(shortBranchName(branch)),
+			VersionType: &git.GitVersionTypeValues.Branch,
+		},
 	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return err
+		}
+		return err
+	}
+
+	d.Set("content", repoItem.Content)
+	d.Set("repository_id", repoItem)
+	d.Set("file", file)
+
+	commit, err := clients.GitReposClient.GetCommit(ctx, git.GetCommitArgs{
+		RepositoryId: &repoId,
+		CommitId:     repoItem.CommitId,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("commit_message", commit.Comment)
+
+	return nil
 }
 
 func resourceGitRepositoryFileUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	ctx := context.Background()
 
-	repo := d.Get("repository_id").(string)
+	repoId := d.Get("repository_id").(string)
 	file := d.Get("file").(string)
 	branch := d.Get("branch").(string)
 
-	if err := checkRepositoryBranchExists(clients, repo, branch); err != nil {
+	if err := checkRepositoryBranchExists(clients, repoId, branch); err != nil {
 		return err
 	}
 
-	objectID, err := getLastCommitId(clients, repo, branch)
+	// Need to retry creating the file as multiple updates could happen at the same time
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		objectID, err := getLastCommitId(clients, repoId, branch)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		args, err := resourceGitRepositoryPushArgs(d, objectID, git.VersionControlChangeTypeValues.Edit)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		if *(*args.Push.Commits)[0].Comment == fmt.Sprintf("Add %s", file) {
+			m := fmt.Sprintf("Update %s", file)
+			(*args.Push.Commits)[0].Comment = &m
+		}
+
+		_, err = clients.GitReposClient.CreatePush(ctx, *args)
+		if err != nil {
+			if utils.ResponseContainsStatusMessage(err, "has already been updated by another client") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
-		return err
-	}
-
-	args, err := resourceGitRepositoryPushArgs(d, objectID, git.VersionControlChangeTypeValues.Edit)
-	if err != nil {
-		return err
-	}
-
-	if *(*args.Push.Commits)[0].Comment == fmt.Sprintf("Add %s", file) {
-		m := fmt.Sprintf("Update %s", file)
-		(*args.Push.Commits)[0].Comment = &m
-	}
-
-	_, err = clients.GitReposClient.CreatePush(ctx, *args)
-	if err != nil {
-		return err
+		return nil
 	}
 
 	return resourceGitRepositoryFileRead(d, m)
@@ -288,12 +246,12 @@ func resourceGitRepositoryFileDelete(d *schema.ResourceData, m interface{}) erro
 	clients := m.(*client.AggregatedClient)
 	ctx := context.Background()
 
-	repo := d.Get("repository_id").(string)
+	repoId := d.Get("repository_id").(string)
 	file := d.Get("file").(string)
 	branch := d.Get("branch").(string)
 	message := fmt.Sprintf("Delete %s", file)
 
-	objectID, err := getLastCommitId(clients, repo, branch)
+	objectID, err := getLastCommitId(clients, repoId, branch)
 	if err != nil {
 		return err
 	}
@@ -306,7 +264,7 @@ func resourceGitRepositoryFileDelete(d *schema.ResourceData, m interface{}) erro
 	}
 
 	_, err = clients.GitReposClient.CreatePush(ctx, git.CreatePushArgs{
-		RepositoryId: &repo,
+		RepositoryId: &repoId,
 		Push: &git.GitPush{
 			RefUpdates: &[]git.GitRefUpdate{
 				{
@@ -330,43 +288,40 @@ func resourceGitRepositoryFileDelete(d *schema.ResourceData, m interface{}) erro
 }
 
 // checkRepositoryBranchExists tests if a branch exists in a repository.
-func checkRepositoryBranchExists(c *client.AggregatedClient, repo, branch string) error {
-	branch = strings.TrimPrefix(branch, "refs/heads/")
+func checkRepositoryBranchExists(c *client.AggregatedClient, repoId, branch string) error {
 	ctx := context.Background()
 	_, err := c.GitReposClient.GetBranch(ctx, git.GetBranchArgs{
-		RepositoryId: &repo,
-		Name:         &branch,
+		RepositoryId: &repoId,
+		Name:         converter.String(shortBranchName(branch)),
 	})
 	return err
 }
 
 // checkRepositoryFileExists tests if a file exists in a repository.
-func checkRepositoryFileExists(c *client.AggregatedClient, repo, file, branch string) error {
-	branch = strings.TrimPrefix(branch, "refs/heads/")
+func checkRepositoryFileExists(c *client.AggregatedClient, repoId, file, branch string) error {
 	ctx := context.Background()
 	_, err := c.GitReposClient.GetItem(ctx, git.GetItemArgs{
-		RepositoryId: &repo,
+		RepositoryId: &repoId,
 		Path:         &file,
 		VersionDescriptor: &git.GitVersionDescriptor{
-			Version: &branch,
+			Version: converter.String(shortBranchName(branch)),
 		},
 	})
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
-func getLastCommitId(c *client.AggregatedClient, repo, branch string) (string, error) {
-	branch = strings.TrimPrefix(branch, "refs/heads/")
+// getLastCommitId returns the last commit id in the given branhc and repository.
+func getLastCommitId(c *client.AggregatedClient, repoId, branch string) (string, error) {
 	ctx := context.Background()
 	commits, err := c.GitReposClient.GetCommits(ctx, git.GetCommitsArgs{
-		RepositoryId: &repo,
+		RepositoryId: &repoId,
 		Top:          converter.Int(1),
 		SearchCriteria: &git.GitQueryCommitsCriteria{
 			ItemVersion: &git.GitVersionDescriptor{
-				Version: &branch,
+				Version: converter.String(shortBranchName(branch)),
 			},
 		},
 	})
@@ -376,6 +331,55 @@ func getLastCommitId(c *client.AggregatedClient, repo, branch string) (string, e
 	return *(*commits)[0].CommitId, nil
 }
 
+// resourceGitRepositoryPushArgs returns args used to commit and push changes.
+func resourceGitRepositoryPushArgs(d *schema.ResourceData, objectID string, changeType git.VersionControlChangeType) (*git.CreatePushArgs, error) {
+	var message *string
+	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
+		cm := commitMessage.(string)
+		message = &cm
+	}
+
+	repo := d.Get("repository_id").(string)
+	content := d.Get("content").(string)
+	file := d.Get("file").(string)
+	branch := d.Get("branch").(string)
+
+	change := git.GitChange{
+		ChangeType: &changeType,
+		Item: git.GitItem{
+			Path: &file,
+		},
+		NewContent: &git.ItemContent{
+			Content:     &content,
+			ContentType: &git.ItemContentTypeValues.RawText,
+		},
+	}
+	args := &git.CreatePushArgs{
+		RepositoryId: &repo,
+		Push: &git.GitPush{
+			RefUpdates: &[]git.GitRefUpdate{
+				{
+					Name:        &branch,
+					OldObjectId: &objectID,
+				},
+			},
+			Commits: &[]git.GitCommitRef{
+				{
+					Comment: message,
+					Changes: &[]interface{}{change},
+				},
+			},
+		},
+	}
+	return args, nil
+}
+
+// shortBranchName removes the branch prefix which some API endpoints require.
+func shortBranchName(branch string) string {
+	return strings.TrimPrefix(branch, "refs/heads/")
+}
+
+// splitRepoFilePath splits the resource ID into separate repository id and file path components.
 func splitRepoFilePath(path string) (string, string) {
 	parts := strings.Split(path, "/")
 	return parts[0], strings.Join(parts[1:], "/")

--- a/azuredevops/internal/service/git/resource_git_repository_file_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file_test.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortBranchName(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput string
+	}{
+		{name: "basic", input: "refs/heads/master", expectedOutput: "master"},
+		{name: "none", input: "master", expectedOutput: "master"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := shortBranchName(tt.input)
+			require.Equal(t, tt.expectedOutput, output)
+		})
+	}
+}
+
+func TestSplitRepoFilePath(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		expectedRepoId   string
+		expectedFilePath string
+	}{
+		{name: "basic", input: "foo/bar", expectedRepoId: "foo", expectedFilePath: "bar"},
+		{name: "nested", input: "foo/bar/baz.txt", expectedRepoId: "foo", expectedFilePath: "bar/baz.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoId, filePath := splitRepoFilePath(tt.input)
+			require.Equal(t, tt.expectedRepoId, repoId)
+			require.Equal(t, tt.expectedFilePath, filePath)
+		})
+	}
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_generic":                serviceendpoint.ResourceServiceEndpointGeneric(),
 			"azuredevops_serviceendpoint_generic_git":            serviceendpoint.ResourceServiceEndpointGenericGit(),
 			"azuredevops_git_repository":                         git.ResourceGitRepository(),
+			"azuredevops_git_repository_file":                    git.ResourceGitRepositoryFile(),
 			"azuredevops_user_entitlement":                       memberentitlementmanagement.ResourceUserEntitlement(),
 			"azuredevops_group_membership":                       graph.ResourceGroupMembership(),
 			"azuredevops_agent_pool":                             taskagent.ResourceAgentPool(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -47,6 +47,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_repository_policy_reserved_names",
 		"azuredevops_repository_policy_check_credentials",
 		"azuredevops_git_repository",
+		"azuredevops_git_repository_file",
 		"azuredevops_user_entitlement",
 		"azuredevops_group_membership",
 		"azuredevops_group",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -119,6 +119,9 @@
                   <a href="/docs/providers/azuredevops/r/git_repository.html">azuredevops_git_repository</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/git_repository_file.html">azuredevops_git_repository_file</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/group.html">azuredevops_group</a>
                 </li>
                 <li>

--- a/website/docs/r/git_repository_file.html.markdown
+++ b/website/docs/r/git_repository_file.html.markdown
@@ -30,7 +30,7 @@ resource "azuredevops_git_repository_file" "repo_file" {
   repository_id       = azuredevops_git_repository.repo.id
   file                = ".gitignore"
   content             = "**/*.tfstate"
-  branch              = "master"
+  branch              = "refs/heads/master"
   commit_message      = "First commit"
   overwrite_on_create = false
 }
@@ -50,16 +50,16 @@ The following arguments are supported:
 
 ## Import
 
-Repository files can be imported using a combination of the `repo` and `file`, e.g.
+Repository files can be imported using a combination of the `repositroy ID` and `file`, e.g.
 
 ```sh
-terraform import azuredevops_git_repository_file.repo_file example/.gitignore
+terraform import azuredevops_git_repository_file.repo_file 00000000-0000-0000-0000-000000000000/.gitignore
 ```
 
 To import a file from a branch other than `master`, append `:` and the branch name, e.g.
 
 ```sh
-terraform import azuredevops_git_repository_file.repo_file example/.gitignore:dev
+terraform import azuredevops_git_repository_file.repo_file 00000000-0000-0000-0000-000000000000/.gitignore:refs/heads/dev
 ```
 
 ## Relevant Links

--- a/website/docs/r/git_repository_file.html.markdown
+++ b/website/docs/r/git_repository_file.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 - `repository_id` - (Required) The ID of the Git repository.
 - `file` - (Required) The path of the file to manage.
 - `content` - (Required) The file content.
-- `branch` - (Optional) Git branch (defaults to `master`). The branch must already exist, it will not be created if it
+- `branch` - (Optional) Git branch (defaults to `refs/heads/master`). The branch must already exist, it will not be created if it
   does not already exist.
 - `commit_message` - (Optional) Commit message when adding or updating the managed file.
 - `overwrite_on_create` - (Optional) Enable overwriting existing files (defaults to `false`).
@@ -59,7 +59,7 @@ terraform import azuredevops_git_repository_file.repo_file 00000000-0000-0000-00
 To import a file from a branch other than `master`, append `:` and the branch name, e.g.
 
 ```sh
-terraform import azuredevops_git_repository_file.repo_file 00000000-0000-0000-0000-000000000000/.gitignore:refs/heads/dev
+terraform import azuredevops_git_repository_file.repo_file 00000000-0000-0000-0000-000000000000/.gitignore:refs/heads/master
 ```
 
 ## Relevant Links

--- a/website/docs/r/git_repository_file.html.markdown
+++ b/website/docs/r/git_repository_file.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_git_repository_file"
+description: |- Manage files within an Azure DevOps Git repository.
+---
+
+# azuredevops_git_repository_file
+
+Manage files within an Azure DevOps Git repository.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "project" {
+  name               = "Sample Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "repo" {
+  project_id = azuredevops_project.project.id
+  name       = "Sample Git Repository"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_git_repository_file" "repo_file" {
+  repository_id       = azuredevops_git_repository.repo.id
+  file                = ".gitignore"
+  content             = "**/*.tfstate"
+  branch              = "master"
+  commit_message      = "First commit"
+  overwrite_on_create = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `repository_id` - (Required) The ID of the Git repository.
+- `file` - (Required) The path of the file to manage.
+- `content` - (Required) The file content.
+- `branch` - (Optional) Git branch (defaults to `master`). The branch must already exist, it will not be created if it
+  does not already exist.
+- `commit_message` - (Optional) Commit message when adding or updating the managed file.
+- `overwrite_on_create` - (Optional) Enable overwriting existing files (defaults to `false`).
+
+## Import
+
+Repository files can be imported using a combination of the `repo` and `file`, e.g.
+
+```sh
+terraform import azuredevops_git_repository_file.repo_file example/.gitignore
+```
+
+To import a file from a branch other than `master`, append `:` and the branch name, e.g.
+
+```sh
+terraform import azuredevops_git_repository_file.repo_file example/.gitignore:dev
+```
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 5.1 - Git API](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/?view=azure-devops-rest-5.1)


### PR DESCRIPTION
This change adds a new resource type called `azuredevops_git_repository_file` which allows users to add files to the repositories they have created. Behavior wise it mimic the file resource in the GitHub provider, so that people who have used it should feel like this is familiar. 

The resource does not actually care about commit history but instead aims to make sure that the specified content in the specified file is present. If it is not it will update the content with a new commit.

Fixes #23 