### PR TITLE
Add ignore client error errors parameter

### DIFF
--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -79,6 +79,12 @@ func Provider() *schema.Provider {
 				Description: "The personal access token which should be used.",
 				Sensitive:   true,
 			},
+			"ignore_client_errors": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true errors occuring when initializing client will be ignored.",
+			},
 		},
 	}
 
@@ -96,8 +102,12 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			terraformVersion = "0.11+compatible"
 		}
 
-		client, err := client.GetAzdoClient(d.Get("personal_access_token").(string), d.Get("org_service_url").(string), terraformVersion)
+		c, err := client.GetAzdoClient(d.Get("personal_access_token").(string), d.Get("org_service_url").(string), terraformVersion)
+		if err != nil && d.Get("ignore_client_errors").(bool) {
+			err = nil
+			c = &client.AggregatedClient{}
+		}
 
-		return client, err
+		return c, err
 	}
 }


### PR DESCRIPTION
There are situations when resources are conditionally created, meaning that the provider is not actually used even if it is present in the Terraform HCL. This is common if someone is using conditional modules that are only imported if a feature is enabled. The current provider init method creates a client object with the given PAT. The issue with doing this is that when the client is created it will verify the PAT and return an error if it is invalid. 

So if a Azure DevOps resource is present but has a count of 0 the provider will still require that a valid PAT is present. Without being able to ignore this error it becomes impossible to create a generic module that includes resources from this provider as it will always require the PAT.

This behavior is not present in other providers which defer the validation of the token to when any of the CRUD functions are called on a function, allowing for the module design described above.

This change will not break any existing deployments as it defaults to false, the normal behavior, so it is an opt in feature.