### PR TITLE
Add support for azuredevops_branch_policy_merge_types

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -226,6 +226,53 @@ func TestAccBranchPolicyCommentResolution_CreateAndUpdate(t *testing.T) {
 	})
 }
 
+func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
+	buildValidationTfNode := "azuredevops_branch_policy_merge_types.p"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: getMergeTypesHcl(true, true, true, true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "true"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_and_fast_forward", "true"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_basic_no_fast_forward", "true"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_with_merge", "true"),
+				),
+			}, {
+				Config: getMergeTypesHcl(false, false, false, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "false"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_and_fast_forward", "false"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_basic_no_fast_forward", "false"),
+					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_with_merge", "false"),
+				),
+			}, {
+				ResourceName:      buildValidationTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(buildValidationTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func getMergeTypesHcl(enabled bool, blocking bool, allowSquash bool, allowRebase bool, allowNoFastForward bool, allowRebaseMerge bool) string {
+	settings := fmt.Sprintf(
+		`
+		allow_squash = %t
+		allow_rebase_and_fast_forward = %t
+		allow_basic_no_fast_forward = %t
+		allow_rebase_with_merge = %t
+		`, allowSquash, allowRebase, allowNoFastForward, allowRebaseMerge,
+	)
+
+	return getBranchPolicyHcl("azuredevops_branch_policy_merge_types", enabled, blocking, settings)
+}
+
 func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settings string) string {
 	branchPolicy := fmt.Sprintf(`
 	resource "%s" "p" {

--- a/azuredevops/internal/service/policy/common.go
+++ b/azuredevops/internal/service/policy/common.go
@@ -30,6 +30,7 @@ var (
 	AutoReviewers     = uuid.MustParse("fd2167ab-b0be-447a-8ec8-39368250530e")
 	WorkItemLinking   = uuid.MustParse("40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e")
 	CommentResolution = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
+	MergeTypes        = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4916e5d171ab")
 )
 
 // Keys for schema elements

--- a/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 )

--- a/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
@@ -51,12 +51,6 @@ func ResourceBranchPolicyMergeTypes() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1),
 			}
 		}
-		if conflicts, ok := metaField.Field(i).Tag.Lookup("ConflictsWith"); ok {
-			if _, ok := settingsSchema[conflicts]; ok {
-				settingsSchema[conflicts].ConflictsWith = []string{SchemaSettings + ".0." + tfName}
-				settingsSchema[tfName].ConflictsWith = []string{SchemaSettings + ".0." + conflicts}
-			}
-		}
 	}
 	return resource
 }
@@ -88,9 +82,6 @@ func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyCo
 		if tipe.Field(i).Type == reflect.TypeOf(true) {
 			settings[tfName] = ps.Field(i).Bool()
 		}
-		if tipe.Field(i).Type == reflect.TypeOf(0) {
-			settings[tfName] = ps.Field(i).Int()
-		}
 	}
 
 	d.Set(SchemaSettings, settingsList)
@@ -119,9 +110,6 @@ func mergeTypesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.Pol
 		}
 		if tipe.Field(i).Type == reflect.TypeOf(true) {
 			policySettings[apiName] = settings[tfName].(bool)
-		}
-		if tipe.Field(i).Type == reflect.TypeOf(0) {
-			policySettings[apiName] = settings[tfName].(int)
 		}
 	}
 

--- a/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
@@ -1,0 +1,129 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+)
+
+type mergeTypePolicySettings struct {
+	AllowSquash        bool `json:"allowSquash" tf:"allow_squash"`
+	AllowRebase        bool `json:"allowRebase" tf:"allow_rebase_and_fast_forward"`
+	AllowNoFastForward bool `json:"allowNoFastForward" tf:"allow_basic_no_fast_forward"`
+	AllowRebaseMerge   bool `json:"allowRebaseMerge" tf:"allow_rebase_with_merge"`
+}
+
+// ResourceBranchPolicyMinReviewers schema and implementation for min reviewer policy resource
+func ResourceBranchPolicyMergeTypes() *schema.Resource {
+	resource := genBasePolicyResource(&policyCrudArgs{
+		FlattenFunc: mergeTypesFlattenFunc,
+		ExpandFunc:  mergeTypesExpandFunc,
+		PolicyType:  MergeTypes,
+	})
+
+	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
+
+	// Dynamically create the schema based on the mergeTypePolicySettings tags
+	metaField := reflect.TypeOf(mergeTypePolicySettings{})
+	// Loop through the fields, adding schema for each one.
+	for i := 0; i < metaField.NumField(); i++ {
+		tfName := metaField.Field(i).Tag.Get("tf")
+		if _, ok := settingsSchema[tfName]; ok {
+			continue // skip those which are already set
+		}
+		if metaField.Field(i).Type == reflect.TypeOf(true) {
+			settingsSchema[tfName] = &schema.Schema{
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			}
+		}
+		if metaField.Field(i).Type == reflect.TypeOf(0) {
+			settingsSchema[tfName] = &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			}
+		}
+		if conflicts, ok := metaField.Field(i).Tag.Lookup("ConflictsWith"); ok {
+			if _, ok := settingsSchema[conflicts]; ok {
+				settingsSchema[conflicts].ConflictsWith = []string{SchemaSettings + ".0." + tfName}
+				settingsSchema[tfName].ConflictsWith = []string{SchemaSettings + ".0." + conflicts}
+			}
+		}
+	}
+	return resource
+}
+
+// API to TF
+func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	err := baseFlattenFunc(d, policyConfig, projectID)
+	if err != nil {
+		return err
+	}
+	policyAsJSON, err := json.Marshal(policyConfig.Settings)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
+	}
+
+	policySettings := mergeTypePolicySettings{}
+	err = json.Unmarshal(policyAsJSON, &policySettings)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
+	}
+
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	tipe := reflect.TypeOf(policySettings)
+	for i := 0; i < tipe.NumField(); i++ {
+		tfName := tipe.Field(i).Tag.Get("tf")
+		ps := reflect.ValueOf(policySettings)
+		if tipe.Field(i).Type == reflect.TypeOf(true) {
+			settings[tfName] = ps.Field(i).Bool()
+		}
+		if tipe.Field(i).Type == reflect.TypeOf(0) {
+			settings[tfName] = ps.Field(i).Int()
+		}
+	}
+
+	d.Set(SchemaSettings, settingsList)
+	return nil
+}
+
+// From TF to API
+func mergeTypesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	policyConfig, projectID, err := baseExpandFunc(d, typeID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+
+	tipe := reflect.TypeOf(mergeTypePolicySettings{})
+	for i := 0; i < tipe.NumField(); i++ {
+		tags := tipe.Field(i).Tag
+		apiName := tags.Get("json")
+		tfName := tags.Get("tf")
+		if _, ok := policySettings[apiName]; ok {
+			continue
+		}
+		if tipe.Field(i).Type == reflect.TypeOf(true) {
+			policySettings[apiName] = settings[tfName].(bool)
+		}
+		if tipe.Field(i).Type == reflect.TypeOf(0) {
+			policySettings[apiName] = settings[tfName].(int)
+		}
+	}
+
+	return policyConfig, projectID, nil
+}

--- a/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_merge_types.go
@@ -44,13 +44,6 @@ func ResourceBranchPolicyMergeTypes() *schema.Resource {
 				Optional: true,
 			}
 		}
-		if metaField.Field(i).Type == reflect.TypeOf(0) {
-			settingsSchema[tfName] = &schema.Schema{
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			}
-		}
 	}
 	return resource
 }

--- a/azuredevops/internal/service/policy/resource_branchpolicy_merge_types_test.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_merge_types_test.go
@@ -1,0 +1,51 @@
+// +build all resource_branchpolicy_merge_types
+// +build !exclude_resource_branchpolicy_merge_types
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// verifies that the flatten/expand round trip path produces repeatable results
+func TestBranchPolicyMergeTypes_ExpandFlatten_Roundtrip(t *testing.T) {
+	var projectID = uuid.New().String()
+	var randomUUID = uuid.New()
+	var testPolicy = &policy.PolicyConfiguration{
+		Id:         converter.Int(1),
+		IsEnabled:  converter.Bool(true),
+		IsBlocking: converter.Bool(true),
+		Type: &policy.PolicyTypeRef{
+			Id: &randomUUID,
+		},
+		Settings: map[string]interface{}{
+			"scope": []map[string]interface{}{
+				{
+					"repositoryId": "test-repo-id",
+					"refName":      "test-ref-name",
+					"matchKind":    "test-match-kind",
+				},
+			},
+			"allowSquash":        true,
+			"allowRebase":        true,
+			"allowNoFastForward": true,
+			"allowRebaseMerge":   true,
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyMergeTypes().Schema, nil)
+	err := mergeTypesFlattenFunc(resourceData, testPolicy, &projectID)
+	require.Nil(t, err)
+	expandedPolicy, expandedProjectID, err := mergeTypesExpandFunc(resourceData, randomUUID)
+	require.Nil(t, err)
+
+	require.Equal(t, testPolicy, expandedPolicy)
+	require.Equal(t, projectID, *expandedProjectID)
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -26,6 +26,7 @@ func Provider() *schema.Provider {
 			"azuredevops_branch_policy_auto_reviewers":     policy.ResourceBranchPolicyAutoReviewers(),
 			"azuredevops_branch_policy_work_item_linking":  policy.ResourceBranchPolicyWorkItemLinking(),
 			"azuredevops_branch_policy_comment_resolution": policy.ResourceBranchPolicyCommentResolution(),
+			"azuredevops_branch_policy_merge_types":        policy.ResourceBranchPolicyMergeTypes(),
 			"azuredevops_build_definition":                 build.ResourceBuildDefinition(),
 			"azuredevops_project":                          core.ResourceProject(),
 			"azuredevops_project_features":                 core.ResourceProjectFeatures(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -17,6 +17,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_branch_policy_auto_reviewers",
 		"azuredevops_branch_policy_work_item_linking",
 		"azuredevops_branch_policy_comment_resolution",
+		"azuredevops_branch_policy_merge_types",
 		"azuredevops_project",
 		"azuredevops_project_features",
 		"azuredevops_serviceendpoint_github",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -83,6 +83,9 @@
                   <a href="/docs/providers/azuredevops/r/branch_policy_build_validation.html">azuredevops_branch_policy_build_validation</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/branch_policy_merge_types.html">azuredevops_branch_policy_min_reviewers</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_min_reviewers.html">azuredevops_branch_policy_min_reviewers</a>
                 </li>
                 <li>

--- a/website/docs/r/branch_policy_merge_types.html.markdown
+++ b/website/docs/r/branch_policy_merge_types.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_branch_policy_merge_types"
+description: |-
+  Enforces the merge types allowed on a branch.
+---
+
+# azuredevops_branch_policy_merge_types
+
+Branch policy for merge types allowed on a specified branch.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "p" {
+  name = "Sample Project"
+}
+
+resource "azuredevops_git_repository" "r" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Repo"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_branch_policy_merge_types" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    allow_squash                  = true
+    allow_rebase_and_fast_forward = true
+    allow_basic_no_fast_forward   = true
+    allow_rebase_with_merge       = true
+    
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = azuredevops_git_repository.r.default_branch
+      match_type     = "Exact"
+    }
+
+    scope {
+      repository_id  = null               # All repositories in the project
+      repository_ref = "refs/heads/releases"
+      match_type     = "Prefix"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The ID of the project in which the policy will be created.
+- `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
+- `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+- `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
+
+A `settings` block supports the following:
+
+- `allow_squash` - (Optional) Allow squash merge. Defaults to `false`
+- `allow_rebase_and_fast_forward` - (Optional) Allow rebase with fast forward. Defaults to `false`.
+- `allow_basic_no_fast_forward` - (Optional) Allow basic merge with no fast forward. Defaults to `false`.
+- `allow_rebase_with_merge` - (Optional) Allow rebase with merge commit. Defaults to `false`.
+
+- `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
+
+A `settings` `scope` block supports the following:
+
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
+- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of branch policy configuration.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 5.1 - Policy Configurations](https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-5.1)
+
+## Import
+
+Azure DevOps Branch Policies can be imported using the project ID and policy configuration ID:
+
+```sh
+$ terraform import azuredevops_branch_policy_merge_types.p 00000000-0000-0000-0000-000000000000/0
+```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Add support for restricting branch policy merge types

Issue Number: fixes #300 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->