### PR TITLE
Support import of git_repository resource

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/suppress"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
 
 // RepoInitType strategy for initializing the repo
@@ -39,13 +40,11 @@ var RepoInitTypeValues = repoInitTypeValuesType{
 // ResourceGitRepository schema and implementation for git repo resource
 func ResourceGitRepository() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGitRepositoryCreate,
-		Read:   resourceGitRepositoryRead,
-		Update: resourceGitRepositoryUpdate,
-		Delete: resourceGitRepositoryDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Create:   resourceGitRepositoryCreate,
+		Read:     resourceGitRepositoryRead,
+		Update:   resourceGitRepositoryUpdate,
+		Delete:   resourceGitRepositoryDelete,
+		Importer: tfhelper.ImportProjectQualifiedResource(),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:             schema.TypeString,

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -43,7 +43,9 @@ func ResourceGitRepository() *schema.Resource {
 		Read:   resourceGitRepositoryRead,
 		Update: resourceGitRepositoryUpdate,
 		Delete: resourceGitRepositoryDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:             schema.TypeString,
@@ -356,6 +358,7 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
+
 	d.SetId("")
 	return nil
 }
@@ -365,7 +368,6 @@ func deleteGitRepository(clients *client.AggregatedClient, repoID string) error 
 	if err != nil {
 		return fmt.Errorf("Invalid repositoryId UUID: %s", repoID)
 	}
-
 	return clients.GitReposClient.DeleteRepository(clients.Ctx, git.DeleteRepositoryArgs{
 		RepositoryId: &uuid,
 	})

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,6 @@
 # Debugging your Terraform Provider
 
-Terraform runs providers in their own processes and they only run for a fraction of a second before exiting. Terraform captures stdout and stderr from the provider. This architecture tends to limit the debugging techniques available. The note describes a coupler of techniques that might be useful.
+Terraform runs providers in their own processes and they only run for a fraction of a second before exiting. Terraform captures stdout and stderr from the provider. This architecture tends to limit the debugging techniques available. The note describes a couple of techniques that might be useful.
 
 ## Option 1 - Avoid debugging in Terraform
 

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -92,7 +92,7 @@ In addition to all arguments above, except `initialization`, the following attri
 
 ## Import
 
-Azure DevOps Repositores can be imported using the repo Guid e.g.
+Azure DevOps Repositories can be imported using the repo Guid e.g.
 
 ```sh
 $ terraform import azuredevops_git_repository.repository projectName/00000000-0000-0000-0000-000000000000

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -89,3 +89,11 @@ In addition to all arguments above, except `initialization`, the following attri
 ## Relevant Links
 
 - [Azure DevOps Service REST API 5.1 - Git Repositories](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/repositories?view=azure-devops-rest-5.1)
+
+## Import
+
+Azure DevOps Repositores can be imported using the repo Guid e.g.
+
+```sh
+$ terraform import azuredevops_git_repository.repository 00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -95,5 +95,5 @@ In addition to all arguments above, except `initialization`, the following attri
 Azure DevOps Repositores can be imported using the repo Guid e.g.
 
 ```sh
-$ terraform import azuredevops_git_repository.repository 00000000-0000-0000-0000-000000000000
+$ terraform import azuredevops_git_repository.repository projectName/00000000-0000-0000-0000-000000000000
 ```


### PR DESCRIPTION
* Added support for importing resources
* Added documentation to import resource for git repo

## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

git_repository resource does not support importing state. 

Issue Number: #43 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

Does not support importing with a slug for the repo using project/repo but will post an update in the next week or so that does this with appropriate unit tests.