### PR TITLE
Add compatible with GitHub App service connection

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -32,12 +32,12 @@ func ResourceServiceEndpointGitHub() *schema.Resource {
 	patHashKey, patHashSchema := tfhelper.GenerateSecreteMemoSchema(personalAccessToken)
 	authPersonal.Schema[patHashKey] = patHashSchema
 	r.Schema["auth_personal"] = &schema.Schema{
-		Type:         schema.TypeSet,
-		Optional:     true,
-		MinItems:     1,
-		MaxItems:     1,
-		Elem:         authPersonal,
-		ExactlyOneOf: []string{"auth_personal", "auth_oauth"},
+		Type:          schema.TypeSet,
+		Optional:      true,
+		MinItems:      1,
+		MaxItems:      1,
+		Elem:          authPersonal,
+		ConflictsWith: []string{"auth_oauth"},
 	}
 
 	r.Schema["auth_oauth"] = &schema.Schema{
@@ -53,7 +53,7 @@ func ResourceServiceEndpointGitHub() *schema.Resource {
 				},
 			},
 		},
-		ExactlyOneOf: []string{"auth_personal", "auth_oauth"},
+		ConflictsWith: []string{"auth_personal"},
 	}
 
 	return r


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #326 
Change the `auth_...` constraint so that `azuredevops_serviceendpoint_github` can import GitHub app service connection which  cannot be create with `azuredevops_serviceendpoint_github` but can be imported.

GitHub app service connection is created based on `Projects settings-> Boards -> GitHub connections`.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->