### PR TITLE
Adds support for changing group display names.

### DIFF
--- a/azuredevops/internal/service/graph/resource_group.go
+++ b/azuredevops/internal/service/graph/resource_group.go
@@ -71,7 +71,6 @@ func ResourceGroup() *schema.Resource {
 				Type:          schema.TypeString,
 				ValidateFunc:  validation.NoZeroValues,
 				Optional:      true,
-				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"origin_id", "mail"},
 			},
@@ -277,18 +276,34 @@ func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	// using: PATCH https://vssps.dev.azure.com/{organization}/_apis/graph/groups/{groupDescriptor}?api-version=5.1-preview.1
 	// d.Get("descriptor").(string) => {groupDescriptor}
 
+	var operations []webapi.JsonPatchOperation
+	
+	if d.HasChange("display_name") {
+		displayName := d.Get("display_name")
+		patchDisplayNameOperation := webapi.JsonPatchOperation {
+			Op:    &webapi.OperationValues.Replace,
+			From:  nil,
+			Path:  converter.String("/displayName"),
+			Value: displayName.(string),
+		}
+		operations = append(operations, patchDisplayNameOperation)
+	}
+	
 	if d.HasChange("description") {
 		description := d.Get("description")
+		patchDescriptionOperation := webapi.JsonPatchOperation {
+			Op:    &webapi.OperationValues.Replace,
+			From:  nil,
+			Path:  converter.String("/description"),
+			Value: description.(string),
+		}
+		operations = append(operations, patchDescriptionOperation)
+	}
+	
+	if (len(operations) > 0) {
 		uptGroupArgs := graph.UpdateGroupArgs{
 			GroupDescriptor: converter.String(d.Id()),
-			PatchDocument: &[]webapi.JsonPatchOperation{
-				{
-					Op:    &webapi.OperationValues.Replace,
-					From:  nil,
-					Path:  converter.String("/description"),
-					Value: description.(string),
-				},
-			},
+			PatchDocument: &operations,
 		}
 
 		_, err := clients.GraphClient.UpdateGroup(clients.Ctx, uptGroupArgs)

--- a/azuredevops/internal/service/graph/resource_group.go
+++ b/azuredevops/internal/service/graph/resource_group.go
@@ -277,10 +277,10 @@ func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	// d.Get("descriptor").(string) => {groupDescriptor}
 
 	var operations []webapi.JsonPatchOperation
-	
+
 	if d.HasChange("display_name") {
 		displayName := d.Get("display_name")
-		patchDisplayNameOperation := webapi.JsonPatchOperation {
+		patchDisplayNameOperation := webapi.JsonPatchOperation{
 			Op:    &webapi.OperationValues.Replace,
 			From:  nil,
 			Path:  converter.String("/displayName"),
@@ -288,10 +288,10 @@ func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 		operations = append(operations, patchDisplayNameOperation)
 	}
-	
+
 	if d.HasChange("description") {
 		description := d.Get("description")
-		patchDescriptionOperation := webapi.JsonPatchOperation {
+		patchDescriptionOperation := webapi.JsonPatchOperation{
 			Op:    &webapi.OperationValues.Replace,
 			From:  nil,
 			Path:  converter.String("/description"),
@@ -299,11 +299,11 @@ func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 		operations = append(operations, patchDescriptionOperation)
 	}
-	
-	if (len(operations) > 0) {
+
+	if len(operations) > 0 {
 		uptGroupArgs := graph.UpdateGroupArgs{
 			GroupDescriptor: converter.String(d.Id()),
-			PatchDocument: &operations,
+			PatchDocument:   &operations,
 		}
 
 		_, err := clients.GraphClient.UpdateGroup(clients.Ctx, uptGroupArgs)


### PR DESCRIPTION
I need groups to not be destroyed and recreated upon name changes to allow developers to alter their group names. The API supports this, so I've modified the provider to support it.

I have tested this change against a live Azure DevOps instance. I have tested editing the name and description one at a time, and both at once. 

***I have not added additional tests since the current test file for group is largely commented out and references a broken graph implementation in the API.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.***
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The change allows edits of group display names without a destroy and recreate.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?

Here's the output from a terraform run against my Azure DevOps.
```
  # azuredevops_group.group will be updated in-place
  ~ resource "azuredevops_group" "group" {
      ~ description    = "Test Description Modified" -> "Test Description"
      ~ display_name   = "Test Name Changed" -> "Test Name"
        id             = "*******************************************************"
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azuredevops_group.group: Modifying... [id=*******************************************************]
azuredevops_group.group: Modifications complete after 0s [id=*******************************************************]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
I confirmed the changes in the browser after each run.

## Other information
