### PR TITLE
docs: add hint to import repos via repo name

### DIFF
--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -92,7 +92,12 @@ In addition to all arguments above, except `initialization`, the following attri
 
 ## Import
 
-Azure DevOps Repositories can be imported using the repo Guid e.g.
+Azure DevOps Repositories can be imported using the repo name or by the repo Guid e.g.
+
+```sh
+$ terraform import azuredevops_git_repository.repository projectName/repoName
+```
+or
 
 ```sh
 $ terraform import azuredevops_git_repository.repository projectName/00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Small documentation update that importing repos is possible via name too. This is especially useful as the guid isn't easy retrievable on a first sight.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->