### PR TITLE
Variable groups dont error if they dont exist

### DIFF
--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -211,6 +211,10 @@ func resourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 		}
 		return fmt.Errorf("Error looking up variable group given ID (%v) and project ID (%v): %v", variableGroupID, projectID, err)
 	}
+	if variableGroup.Id == nil {
+		d.SetId("")
+		return nil
+	}
 
 	err = flattenVariableGroup(d, variableGroup, &projectID)
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

You get a terraform error:

```
Error: rpc error: code = Unavailable desc = transport is closing
```

This is because the `taskagentClient.GetVariableGroup` code does not actually return an error when it can't find a variable group, it just returns an empty `VariableGroup` object.

This PR checks if the `Id` returned is nil and treats it the same way as if the expected error was returned

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->