### PR TITLE
Branch policy status check

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
@@ -1,0 +1,216 @@
+// +build all resource_branchpolicy_status_check_acceptance_test policy
+// +build !exclude_resource_branchpolicy_status_check_acceptance_test !exclude_policy
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccBranchPolicyStatusCheckBasic(t *testing.T) {
+	statusCheckTfNode := "azuredevops_branch_policy_status_check.p"
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclBranchPolicyStatusCheckResourceBasic(projectName, repoName, "update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "update")),
+			}, {
+				ResourceName:      statusCheckTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(statusCheckTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBranchPolicyStatusCheckComplete(t *testing.T) {
+	statusCheckTfNode := "azuredevops_branch_policy_status_check.p"
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclBranchPolicyStatusCheckResourceComplete(projectName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(statusCheckTfNode, "settings.0.author_id"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "Release"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "true"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "conditional"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.display_name", "PreCheck"),
+				),
+			}, {
+				ResourceName:      statusCheckTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(statusCheckTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBranchPolicyStatusCheckUpdate(t *testing.T) {
+	statusCheckTfNode := "azuredevops_branch_policy_status_check.p"
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclBranchPolicyStatusCheckResourceBasic(projectName, repoName, "update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "update"),
+				),
+			}, {
+				Config: hclBranchPolicyStatusCheckResourceUpdate(projectName, repoName, "releaseCheck", true, "conditional", "updateName"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(statusCheckTfNode, "settings.0.author_id"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "releaseCheck"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "true"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "conditional"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.display_name", "updateName"),
+				),
+			}, {
+				ResourceName:      statusCheckTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(statusCheckTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func hclBranchPolicyStatusCheckResourceTemplate(projectName string, repoName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "p" {
+  name               = "%s"
+  description        = "Test Project Description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  features = {
+    "testplans" = "disabled"
+    "artifacts" = "disabled"
+  }
+}
+
+resource "azuredevops_git_repository" "r" {
+  project_id = azuredevops_project.p.id
+  name       = "%s"
+  initialization {
+    init_type = "Clean"
+  }
+}
+`, projectName, repoName)
+}
+
+func hclBranchPolicyStatusCheckResourceBasic(projectName string, repoName string, statusName string) string {
+	projectAndRepo := hclBranchPolicyStatusCheckResourceTemplate(projectName, repoName)
+	statusCheck := fmt.Sprintf(`
+resource "azuredevops_branch_policy_status_check" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+	name = "%s"
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = azuredevops_git_repository.r.default_branch
+      match_type     = "Exact"
+    }
+  }
+}
+`, statusName)
+
+	return fmt.Sprintf(`%s %s`, projectAndRepo, statusCheck)
+}
+
+func hclBranchPolicyStatusCheckResourceComplete(projectName string, repoName string) string {
+	return fmt.Sprintf(
+		`%s %s`,
+		hclBranchPolicyStatusCheckResourceTemplate(projectName, repoName), `
+
+resource "azuredevops_user_entitlement" "user" {
+  principal_name       = "mail@email.com"
+  account_license_type = "basic"
+}
+
+resource "azuredevops_branch_policy_status_check" "p" {
+ project_id = azuredevops_project.p.id
+
+ enabled  = true
+ blocking = true
+
+ settings {
+	name = "Release"
+	author_id            = azuredevops_user_entitlement.user.id
+	invalidate_on_update = true
+	applicability = "conditional"
+	display_name = "PreCheck"
+	filename_patterns = ["*.go","**.ts"]
+
+   scope {
+     repository_id  = azuredevops_git_repository.r.id
+     repository_ref = azuredevops_git_repository.r.default_branch
+     match_type     = "Exact"
+   }
+ }
+}
+`)
+}
+
+func hclBranchPolicyStatusCheckResourceUpdate(projectName string, repoName string,
+	statusName string, invalid bool, applicability string, displayName string) string {
+
+	statusCheck := fmt.Sprintf(
+		`
+data "azuredevops_group" "group" {
+  project_id = azuredevops_project.p.id
+  name       = "Project Administrators"
+}
+
+resource "azuredevops_branch_policy_status_check" "p" {
+ project_id = azuredevops_project.p.id
+
+ enabled  = true
+ blocking = true
+
+ settings {
+	name = "%s"
+	author_id = data.azuredevops_group.group.origin_id
+	invalidate_on_update = %t
+	applicability = "%s"
+	display_name = "%s"
+	filename_patterns = ["*.go","**.ts"]
+
+   scope {
+     repository_id  = azuredevops_git_repository.r.id
+     repository_ref = azuredevops_git_repository.r.default_branch
+     match_type     = "Exact"
+   }
+ }
+}
+`, statusName, invalid, applicability, displayName)
+
+	return fmt.Sprintf(
+		`%s %s`,
+		hclBranchPolicyStatusCheckResourceTemplate(projectName, repoName),
+		statusCheck)
+}

--- a/azuredevops/internal/service/policy/common.go
+++ b/azuredevops/internal/service/policy/common.go
@@ -31,6 +31,7 @@ var (
 	WorkItemLinking   = uuid.MustParse("40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e")
 	CommentResolution = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
 	MergeTypes        = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4916e5d171ab")
+	StatusCheck       = uuid.MustParse("cbdc66da-9728-4af8-aada-9a5a32e4a226")
 )
 
 // Keys for schema elements

--- a/azuredevops/internal/service/policy/resource_branchpolicy_auto_reviewers.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_auto_reviewers.go
@@ -52,9 +52,8 @@ func ResourceBranchPolicyAutoReviewers() *schema.Resource {
 	}
 	settingsSchema[displayMessage] = &schema.Schema{
 		Type:     schema.TypeString,
-		Required: false,
-		Default:  "",
 		Optional: true,
+		Default:  "",
 	}
 	settingsSchema[schemaSubmitterCanVote] = &schema.Schema{
 		Type:     schema.TypeBool,

--- a/azuredevops/internal/service/policy/resource_branchpolicy_status_check.go
+++ b/azuredevops/internal/service/policy/resource_branchpolicy_status_check.go
@@ -1,0 +1,123 @@
+package policy
+
+import (
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+)
+
+type policyApplicability struct {
+	Default     string
+	Conditional string
+}
+
+var applicability = policyApplicability{
+	Default:     "default",
+	Conditional: "conditional",
+}
+
+func ResourceBranchPolicyStatusCheck() *schema.Resource {
+	resource := genBasePolicyResource(&policyCrudArgs{
+		FlattenFunc: statusCheckFlattenFunc,
+		ExpandFunc:  statusCheckExpandFunc,
+		PolicyType:  StatusCheck,
+	})
+
+	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
+
+	settingsSchema["name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	settingsSchema["author_id"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.IsUUID,
+	}
+	settingsSchema["invalidate_on_update"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+	settingsSchema["applicability"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			applicability.Default,
+			applicability.Conditional,
+		}, false),
+		Default: applicability.Default,
+	}
+	settingsSchema["filename_patterns"] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+	settingsSchema["display_name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "",
+	}
+	return resource
+}
+
+func statusCheckFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	err := baseFlattenFunc(d, policyConfig, projectID)
+	if err != nil {
+		return err
+	}
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	settings["name"] = policySettings["statusName"]
+	settings["author_id"] = policySettings["authorId"]
+	settings["invalidate_on_update"] = policySettings["invalidateOnSourceUpdate"]
+	settings["display_name"] = policySettings["defaultDisplayName"]
+
+	if patterns, ok := policySettings["filenamePatterns"]; ok {
+		if patterns != nil {
+			settings["filename_patterns"] = policySettings["filenamePatterns"].([]interface{})
+		}
+	}
+
+	settings["applicability"] = applicability.Default
+	if policyApplicability, ok := policySettings["policyApplicability"]; ok {
+		if policyApplicability != nil && policyApplicability.(float64) == 1 {
+			settings["applicability"] = applicability.Conditional
+		}
+	}
+	_ = d.Set(SchemaSettings, settingsList)
+	return nil
+}
+
+func statusCheckExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	policyConfig, projectID, err := baseExpandFunc(d, typeID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+	policySettings["statusName"] = settings["name"].(string)
+	policySettings["authorId"] = settings["author_id"].(string)
+	policySettings["invalidateOnSourceUpdate"] = settings["invalidate_on_update"].(bool)
+	policySettings["defaultDisplayName"] = settings["display_name"].(string)
+	policySettings["filenamePatterns"] = expandFilenamePatterns(settings[filenamePatterns].(*schema.Set))
+
+	if v, ok := settings["applicability"].(string); ok {
+		if v == applicability.Conditional {
+			policySettings["policyApplicability"] = 1
+		}
+	}
+
+	return policyConfig, projectID, nil
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -27,6 +27,7 @@ func Provider() *schema.Provider {
 			"azuredevops_branch_policy_work_item_linking":   policy.ResourceBranchPolicyWorkItemLinking(),
 			"azuredevops_branch_policy_comment_resolution":  policy.ResourceBranchPolicyCommentResolution(),
 			"azuredevops_branch_policy_merge_types":         policy.ResourceBranchPolicyMergeTypes(),
+			"azuredevops_branch_policy_status_check":        policy.ResourceBranchPolicyStatusCheck(),
 			"azuredevops_build_definition":                  build.ResourceBuildDefinition(),
 			"azuredevops_project":                           core.ResourceProject(),
 			"azuredevops_project_features":                  core.ResourceProjectFeatures(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -18,6 +18,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_branch_policy_work_item_linking",
 		"azuredevops_branch_policy_comment_resolution",
 		"azuredevops_branch_policy_merge_types",
+		"azuredevops_branch_policy_status_check",
 		"azuredevops_project",
 		"azuredevops_project_features",
 		"azuredevops_serviceendpoint_github",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -80,6 +80,9 @@
                   <a href="/docs/providers/azuredevops/r/area_permissions.html">azuredevops_area_permissions</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/branch_policy_auto_reviewers.html">azuredevops_branch_policy_auto_reviewers</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_build_validation.html">azuredevops_branch_policy_build_validation</a>
                 </li>
                 <li>
@@ -87,6 +90,9 @@
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_min_reviewers.html">azuredevops_branch_policy_min_reviewers</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azuredevops/r/branch_policy_status_check.html">azuredevops_branch_policy_status_check</a>
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_work_item_linking.html">azuredevops_branch_policy_work_item_linking</a>

--- a/website/docs/r/branch_policy_build_validation.html.markdown
+++ b/website/docs/r/branch_policy_build_validation.html.markdown
@@ -82,7 +82,7 @@ A `settings` block supports the following:
 - `manual_queue_only` - (Optional) If set to true, the build will need to be manually queued. Defaults to `false`
 - `queue_on_source_update_only` - (Optional) True if the build should queue on source updates only. Defaults to `true`.
 - `valid_duration` - (Optional) The number of minutes for which the build is valid. If `0`, the build will not expire. Defaults to `720` (12 hours).
-- `filename_patterns` - (Optional) If a path filter is set, the policy wil only apply when files which match the filter are changes. Not setting this field means that the policy will always apply. You can specify absolute paths and wildcards. Example: `["/WebApp/Models/Data.cs", "/WebApp/*", "*.cs"]`. Paths prefixed with "!" are excluded. Example: `["/WebApp/*", "!/WebApp/Tests/*"]`. Order is significant.
+- `filename_patterns` - (Optional) If a path filter is set, the policy will only apply when files which match the filter are changes. Not setting this field means that the policy will always apply. You can specify absolute paths and wildcards. Example: `["/WebApp/Models/Data.cs", "/WebApp/*", "*.cs"]`. Paths prefixed with "!" are excluded. Example: `["/WebApp/*", "!/WebApp/Tests/*"]`. Order is significant.
 - `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
 
 A `settings` `scope` block supports the following:

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -1,0 +1,109 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_branch_policy_status_check"
+description: |- Manages status check branch policy within Azure DevOps project.
+---
+
+# azuredevops_branch_policy_status_check
+
+Manages a status check branch policy within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "p" {
+  name               = "Sample Project"
+  description        = "Managed by Terraform"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  features = {
+    "testplans" = "disabled"
+    "artifacts" = "disabled"
+  }
+}
+
+resource "azuredevops_git_repository" "r" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Repo"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_user_entitlement" "user" {
+  principal_name       = "mail@email.com"
+  account_license_type = "basic"
+}
+
+resource "azuredevops_branch_policy_status_check" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    name                 = "Release"
+    author_id            = azuredevops_user_entitlement.user.id
+    invalidate_on_update = true
+    applicability        = "conditional"
+    display_name         = "PreCheck"
+
+    scope {
+      repository_id  = azuredevops_git_repository.r.id
+      repository_ref = azuredevops_git_repository.r.default_branch
+      match_type     = "Exact"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The ID of the project in which the policy will be created.
+- `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
+- `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+- `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
+
+`settings` block supports the following:
+
+- `status_name` - (Required) Status to check
+- `author_id` - (Optional) Only the authorized user can post the status.
+- `invalidate_on_update` - (Optional) Reset status whenever there are new changes.
+- `applicability` - (Optional) Policy applicability. If policy `applicability` is `default`, apply unless "Not Applicable" 
+  status is posted to the pull request. If policy `applicability` is `conditional`, policy is applied only after a status 
+  is posted to the pull request.
+- `filename_patterns` - (Optional) If a path filter is set, the policy will only apply when files which match the filter are changes. Not setting this field means that the policy will always apply. You can specify absolute paths and wildcards. Example: `["/WebApp/Models/Data.cs", "/WebApp/*", "*.cs"]`. Paths prefixed with "!" are excluded. Example: `["/WebApp/*", "!/WebApp/Tests/*"]`. Order is significant.
+- `display_name` - (Optional) Default display name.
+- `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined
+  at least once.
+
+  `scope` block supports the following:
+
+    - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single
+      repository.
+    - `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a
+      qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such
+      as `refs/heads/releases`.
+    - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default)
+      or `Prefix`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of branch policy configuration.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 5.1 - Policy Configurations](https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations/create?view=azure-devops-rest-5.1)
+
+## Import
+
+Azure DevOps Branch Policies can be imported using the project ID and policy configuration ID:
+
+```sh
+$ terraform import azuredevops_branch_policy_status_check.p 00000000-0000-0000-0000-000000000000/0
+```

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -69,8 +69,8 @@ The following arguments are supported:
 
 `settings` block supports the following:
 
-- `status_name` - (Required) Status to check
-- `author_id` - (Optional) Only the authorized user can post the status.
+- `status_name` - (Required) The status name to check.
+- `author_id` - (Optional) The authorized user can post the status.
 - `invalidate_on_update` - (Optional) Reset status whenever there are new changes.
 - `applicability` - (Optional) Policy applicability. If policy `applicability` is `default`, apply unless "Not Applicable" 
   status is posted to the pull request. If policy `applicability` is `conditional`, policy is applied only after a status 

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
   status is posted to the pull request. If policy `applicability` is `conditional`, policy is applied only after a status 
   is posted to the pull request.
 - `filename_patterns` - (Optional) If a path filter is set, the policy will only apply when files which match the filter are changes. Not setting this field means that the policy will always apply. You can specify absolute paths and wildcards. Example: `["/WebApp/Models/Data.cs", "/WebApp/*", "*.cs"]`. Paths prefixed with "!" are excluded. Example: `["/WebApp/*", "!/WebApp/Tests/*"]`. Order is significant.
-- `display_name` - (Optional) Default display name.
+- `display_name` - (Optional) The display name.
 - `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined
   at least once.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

AccTest result:
```log
==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if avaliable
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
        TF_ACC=1 go test -count=1 -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v -run=TestAccBranchPolicyStatusCheck -timeout 120m
=== RUN   TestAccBranchPolicyStatusCheckBasic
--- PASS: TestAccBranchPolicyStatusCheckBasic (34.98s)
=== RUN   TestAccBranchPolicyStatusCheckComplete
--- PASS: TestAccBranchPolicyStatusCheckComplete (34.21s)
=== RUN   TestAccBranchPolicyStatusCheckUpdate
--- PASS: TestAccBranchPolicyStatusCheckUpdate (41.15s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        111.119s

```
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #352 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->