### PR TITLE
docs: add hint for blocking argument

### DIFF
--- a/website/docs/r/branch_policy_auto_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_auto_reviewers.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 - `project_id` - (Required) The ID of the project in which the policy will be created.
 - `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
-- `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+- `blocking` - (Optional) A flag indicating if the policy should be blocking. This relates to the Azure DevOps terms "optional" and "required" reviewers. Defaults to `true`.
 - `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
 
 `settings` block supports the following:


### PR DESCRIPTION
I spent a lot of time trying to get a working combination of auto_reviewers and min_reviewers where i added 3 people to auto_reviwers and set min_reviewers to 1. In this combination the 3 of _auto_reviewers counts more than the 1 of mon_reviewers. In the GUI i found the setting of auto_reviewers to switch between "optional" and "required". Took me some time to realize that this might be what is named "blocking" in this resource. So i added an hint that "blocking" in this case means "optional" (if false) or "required" (if true).

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->