### PR TITLE
init_type changes should recreate the repositroy

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -106,6 +106,7 @@ func ResourceGitRepository() *schema.Resource {
 						"init_type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(RepoInitTypeValues.Clean),
 								string(RepoInitTypeValues.Fork),


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #406 

```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepo_CreateAndUpdate
=== PAUSE TestAccGitRepo_CreateAndUpdate
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
=== PAUSE TestAccGitRepo_Create_IncorrectInitialization
=== RUN   TestAccGitRepo_Create_Import
=== PAUSE TestAccGitRepo_Create_Import
=== RUN   TestAccGitRepo_RepoInitialization_Clean
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
=== CONT  TestAccGitRepo_Create_Import
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_CreateAndUpdate
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (0.12s)
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (93.05s)
--- PASS: TestAccGitRepo_Create_Import (106.80s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (117.51s)
--- PASS: TestAccGitRepo_CreateAndUpdate (128.77s)
--- PASS: TestAccGitRepository_DataSource (159.41s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (169.17s)

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->