### PR TITLE
docs: Fix service endpoint `description` descriptions

### DIFF
--- a/website/docs/r/serviceendpoint_azurecr.html.markdown
+++ b/website/docs/r/serviceendpoint_azurecr.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 - `azurecr_name` - (Required) The Azure container registry name.
 - `azurecr_subscription_id` - (Required) The subscription id of the Azure targets.
 - `azurecr_subscription_name` - (Required) The subscription name of the Azure targets.
-- `description` - (Optional) The name you will use to refer to this service connection in task inputs.
+- `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
 
 ## Attributes Reference
 

--- a/website/docs/r/serviceendpoint_dockerregistry.html.markdown
+++ b/website/docs/r/serviceendpoint_dockerregistry.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 - `project_id` - (Required) The project ID or project name.
 - `service_endpoint_name` - (Required) The name you will use to refer to this service connection in task inputs.
-- `description` - (Optional) The name you will use to refer to this service connection in task inputs.
+- `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
 - `docker_registry` - (Optional) The URL of the Docker registry. (Default: "https://index.docker.io/v1/")
 - `docker_username` - (Optional) The identifier of the Docker account user.
 - `docker_email` - (Optional) The email for Docker account user.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Two apparently incorrect argument descriptions have been fixed; seems like they had been copy-pasted from `service_endpoint_name`.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I _assume_ the sentence about defaulting to `Managed by Terraform` is correct in both cases, based on the fact that the majority of the service endpoints seem to work that way (```git grep --heading '`description` - ' **/*serviceendpoint*```).