### PR TITLE
Support project level repository policy setting

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
@@ -103,10 +103,6 @@ resource "azuredevops_project" "p" {
   visibility         = "private"
   version_control    = "Git"
   work_item_template = "Agile"
-  //features = {
-  //  "testplans" = "disabled"
-  //  "artifacts" = "disabled"
-  //}
 }
 
 resource "azuredevops_git_repository" "r" {

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
@@ -103,10 +103,10 @@ resource "azuredevops_project" "p" {
   visibility         = "private"
   version_control    = "Git"
   work_item_template = "Agile"
-  features = {
-    "testplans" = "disabled"
-    "artifacts" = "disabled"
-  }
+  //features = {
+  //  "testplans" = "disabled"
+  //  "artifacts" = "disabled"
+  //}
 }
 
 resource "azuredevops_git_repository" "r" {

--- a/azuredevops/internal/acceptancetests/testutils/commons.go
+++ b/azuredevops/internal/acceptancetests/testutils/commons.go
@@ -94,3 +94,17 @@ func containsPropertyWithValue(m map[string]string, property string, value strin
 	}
 	return false
 }
+
+func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testing.T)) {
+	for group, m := range tests {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/azuredevops/internal/service/core/resource_project_features.go
+++ b/azuredevops/internal/service/core/resource_project_features.go
@@ -184,6 +184,7 @@ func setProjectFeatureStates(ctx context.Context, fc featuremanagement.Client, p
 		if !ok {
 			return fmt.Errorf("unknown feature: %s", k)
 		}
+		//TODO handle response state
 		_, err := fc.SetFeatureStateForScope(ctx, featuremanagement.SetFeatureStateForScopeArgs{
 			Feature: &featuremanagement.ContributedFeatureState{
 				FeatureId: converter.String(f),

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"encoding/json"
@@ -25,19 +25,13 @@ import (
 // Policy type IDs. These are global and can be listed using the following endpoint:
 //	https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/types/list?view=azure-devops-rest-5.1
 var (
-	MinReviewerCount   = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4906e5d171dd")
-	BuildValidation    = uuid.MustParse("0609b952-1397-4640-95ec-e00a01b2c241")
-	AutoReviewers      = uuid.MustParse("fd2167ab-b0be-447a-8ec8-39368250530e")
-	WorkItemLinking    = uuid.MustParse("40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e")
-	CommentResolution  = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
-	MergeTypes         = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4916e5d171ab")
-	StatusCheck        = uuid.MustParse("cbdc66da-9728-4af8-aada-9a5a32e4a226")
-	AuthorEmailPattern = uuid.MustParse("77ed4bd3-b063-4689-934a-175e4d0a78d7")
-	FilePathPattern    = uuid.MustParse("51c78909-e838-41a2-9496-c647091e3c61")
-	CaseEnforcement    = uuid.MustParse("7ed39669-655c-494e-b4a0-a08b4da0fcce") //git repo settings
-	ReservedNames      = uuid.MustParse("db2b9b4c-180d-4529-9701-01541d19f36b")
-	PathLength         = uuid.MustParse("001a79cf-fda1-4c4e-9e7c-bac40ee5ead8")
-	FileSize           = uuid.MustParse("2e26e725-8201-4edd-8bf5-978563c34a80")
+	MinReviewerCount  = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4906e5d171dd")
+	BuildValidation   = uuid.MustParse("0609b952-1397-4640-95ec-e00a01b2c241")
+	AutoReviewers     = uuid.MustParse("fd2167ab-b0be-447a-8ec8-39368250530e")
+	WorkItemLinking   = uuid.MustParse("40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e")
+	CommentResolution = uuid.MustParse("c6a1889d-b943-4856-b76f-9e46bb6b0df2")
+	MergeTypes        = uuid.MustParse("fa4e907d-c16b-4a4c-9dfa-4916e5d171ab")
+	StatusCheck       = uuid.MustParse("cbdc66da-9728-4af8-aada-9a5a32e4a226")
 )
 
 // Keys for schema elements

--- a/azuredevops/internal/service/policy/branch/common_test.go
+++ b/azuredevops/internal/service/policy/branch/common_test.go
@@ -1,7 +1,7 @@
 // +build all policy
 // +build !exclude_policy
 
-package policy
+package branch
 
 // The tests in this file use the mock clients in mock_client.go to mock out
 // the Azure DevOps client operations.

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"encoding/json"

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"encoding/json"

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation_test.go
@@ -1,7 +1,7 @@
-// +build all resource_branchpolicy_merge_types
-// +build !exclude_resource_branchpolicy_merge_types
+// +build all resource_branchpolicy_build_validation
+// +build !exclude_resource_branchpolicy_build_validation
 
-package policy
+package branch
 
 import (
 	"testing"
@@ -15,7 +15,7 @@ import (
 )
 
 // verifies that the flatten/expand round trip path produces repeatable results
-func TestBranchPolicyMergeTypes_ExpandFlatten_Roundtrip(t *testing.T) {
+func TestBranchPolicyBuildValidation_ExpandFlatten_Roundtrip(t *testing.T) {
 	var projectID = uuid.New().String()
 	var randomUUID = uuid.New()
 	var testPolicy = &policy.PolicyConfiguration{
@@ -33,17 +33,19 @@ func TestBranchPolicyMergeTypes_ExpandFlatten_Roundtrip(t *testing.T) {
 					"matchKind":    "test-match-kind",
 				},
 			},
-			"allowSquash":        true,
-			"allowRebase":        true,
-			"allowNoFastForward": true,
-			"allowRebaseMerge":   true,
+			"buildDefinitionId":       77,
+			"displayName":             "test policy",
+			"manualQueueOnly":         true,
+			"queueOnSourceUpdateOnly": true,
+			"validDuration":           700,
+			"filenamePatterns":        &([]string{"*md"}),
 		},
 	}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyMergeTypes().Schema, nil)
-	err := mergeTypesFlattenFunc(resourceData, testPolicy, &projectID)
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyBuildValidation().Schema, nil)
+	err := buildValidationFlattenFunc(resourceData, testPolicy, &projectID)
 	require.Nil(t, err)
-	expandedPolicy, expandedProjectID, err := mergeTypesExpandFunc(resourceData, randomUUID)
+	expandedPolicy, expandedProjectID, err := buildValidationExpandFunc(resourceData, randomUUID)
 	require.Nil(t, err)
 
 	require.Equal(t, testPolicy, expandedPolicy)

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_comment_resolution.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_comment_resolution.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"github.com/google/uuid"
@@ -7,17 +7,17 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 )
 
-// ResourceBranchPolicyWorkItemLinking schema and implementation for min reviewer policy resource
-func ResourceBranchPolicyWorkItemLinking() *schema.Resource {
+// ResourceBranchPolicyCommentResolution schema and implementation for min reviewer policy resource
+func ResourceBranchPolicyCommentResolution() *schema.Resource {
 	resource := genBasePolicyResource(&policyCrudArgs{
-		FlattenFunc: workItemLinkingFlattenFunc,
-		ExpandFunc:  workItemLinkingExpandFunc,
-		PolicyType:  WorkItemLinking,
+		FlattenFunc: commentResolutionFlattenFunc,
+		ExpandFunc:  commentResolutionExpandFunc,
+		PolicyType:  CommentResolution,
 	})
 	return resource
 }
 
-func workItemLinkingFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+func commentResolutionFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
 	err := baseFlattenFunc(d, policyConfig, projectID)
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func workItemLinkingFlattenFunc(d *schema.ResourceData, policyConfig *policy.Pol
 	return nil
 }
 
-func workItemLinkingExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+func commentResolutionExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
 	policyConfig, projectID, err := baseExpandFunc(d, typeID)
 	if err != nil {
 		return nil, nil, err

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_comment_resolution_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_comment_resolution_test.go
@@ -1,7 +1,7 @@
 // +build all resource_branchpolicy_work_item_linking
 // +build !exclude_resource_branchpolicy_work_item_linking
 
-package policy
+package branch
 
 import (
 	"testing"
@@ -15,7 +15,7 @@ import (
 )
 
 // verifies that the flatten/expand round trip path produces repeatable results
-func TestBranchPolicyWorkItemLinking_ExpandFlatten_Roundtrip(t *testing.T) {
+func TestBranchPolicyCommentResolution_ExpandFlatten_Roundtrip(t *testing.T) {
 	var projectID = uuid.New().String()
 	var randomUUID = uuid.New()
 	var testPolicy = &policy.PolicyConfiguration{
@@ -36,7 +36,7 @@ func TestBranchPolicyWorkItemLinking_ExpandFlatten_Roundtrip(t *testing.T) {
 		},
 	}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyWorkItemLinking().Schema, nil)
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyCommentResolution().Schema, nil)
 	err := workItemLinkingFlattenFunc(resourceData, testPolicy, &projectID)
 	require.Nil(t, err)
 	expandedPolicy, expandedProjectID, err := workItemLinkingExpandFunc(resourceData, randomUUID)

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_merge_types_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_merge_types_test.go
@@ -1,7 +1,7 @@
-// +build all resource_branchpolicy_min_reviewers
-// +build !exclude_resource_branchpolicy_min_reviewers
+// +build all resource_branchpolicy_merge_types
+// +build !exclude_resource_branchpolicy_merge_types
 
-package policy
+package branch
 
 import (
 	"testing"
@@ -15,7 +15,7 @@ import (
 )
 
 // verifies that the flatten/expand round trip path produces repeatable results
-func TestBranchPolicyMinReviewers_ExpandFlatten_Roundtrip(t *testing.T) {
+func TestBranchPolicyMergeTypes_ExpandFlatten_Roundtrip(t *testing.T) {
 	var projectID = uuid.New().String()
 	var randomUUID = uuid.New()
 	var testPolicy = &policy.PolicyConfiguration{
@@ -33,20 +33,17 @@ func TestBranchPolicyMinReviewers_ExpandFlatten_Roundtrip(t *testing.T) {
 					"matchKind":    "test-match-kind",
 				},
 			},
-			"minimumApproverCount":        2,
-			"creatorVoteCounts":           true,
-			"allowDownvotes":              true,
-			"resetOnSourcePush":           true,
-			"requireVoteOnLastIteration":  true,
-			"resetRejectionsOnSourcePush": true,
-			"blockLastPusherVote":         true,
+			"allowSquash":        true,
+			"allowRebase":        true,
+			"allowNoFastForward": true,
+			"allowRebaseMerge":   true,
 		},
 	}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyMinReviewers().Schema, nil)
-	err := minReviewersFlattenFunc(resourceData, testPolicy, &projectID)
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyMergeTypes().Schema, nil)
+	err := mergeTypesFlattenFunc(resourceData, testPolicy, &projectID)
 	require.Nil(t, err)
-	expandedPolicy, expandedProjectID, err := minReviewersExpandFunc(resourceData, randomUUID)
+	expandedPolicy, expandedProjectID, err := mergeTypesExpandFunc(resourceData, randomUUID)
 	require.Nil(t, err)
 
 	require.Equal(t, testPolicy, expandedPolicy)

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"encoding/json"
@@ -7,29 +7,33 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 )
 
-type mergeTypePolicySettings struct {
-	AllowSquash        bool `json:"allowSquash" tf:"allow_squash"`
-	AllowRebase        bool `json:"allowRebase" tf:"allow_rebase_and_fast_forward"`
-	AllowNoFastForward bool `json:"allowNoFastForward" tf:"allow_basic_no_fast_forward"`
-	AllowRebaseMerge   bool `json:"allowRebaseMerge" tf:"allow_rebase_with_merge"`
+type minReviewerPolicySettings struct {
+	ApprovalCount                     int  `json:"minimumApproverCount" tf:"reviewer_count"`
+	SubmitterCanVote                  bool `json:"creatorVoteCounts" tf:"submitter_can_vote"`
+	AllowCompletionWithRejectsOrWaits bool `json:"allowDownvotes" tf:"allow_completion_with_rejects_or_waits"`
+	OnPushResetApprovedVotes          bool `json:"resetOnSourcePush" tf:"on_push_reset_approved_votes" ConflictsWith:"on_push_reset_all_votes"`
+	OnLastIterationRequireVote        bool `json:"requireVoteOnLastIteration" tf:"on_last_iteration_require_vote"`
+	OnPushResetAllVotes               bool `json:"resetRejectionsOnSourcePush" tf:"on_push_reset_all_votes" ConflictsWith:"on_push_reset_approved_votes"`
+	LastPusherCannotVote              bool `json:"blockLastPusherVote" tf:"last_pusher_cannot_approve"`
 }
 
 // ResourceBranchPolicyMinReviewers schema and implementation for min reviewer policy resource
-func ResourceBranchPolicyMergeTypes() *schema.Resource {
+func ResourceBranchPolicyMinReviewers() *schema.Resource {
 	resource := genBasePolicyResource(&policyCrudArgs{
-		FlattenFunc: mergeTypesFlattenFunc,
-		ExpandFunc:  mergeTypesExpandFunc,
-		PolicyType:  MergeTypes,
+		FlattenFunc: minReviewersFlattenFunc,
+		ExpandFunc:  minReviewersExpandFunc,
+		PolicyType:  MinReviewerCount,
 	})
 
 	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
 
-	// Dynamically create the schema based on the mergeTypePolicySettings tags
-	metaField := reflect.TypeOf(mergeTypePolicySettings{})
+	// Dynamically create the schema based on the minReviewerPolicySettings tags
+	metaField := reflect.TypeOf(minReviewerPolicySettings{})
 	// Loop through the fields, adding schema for each one.
 	for i := 0; i < metaField.NumField(); i++ {
 		tfName := metaField.Field(i).Tag.Get("tf")
@@ -43,12 +47,25 @@ func ResourceBranchPolicyMergeTypes() *schema.Resource {
 				Optional: true,
 			}
 		}
+		if metaField.Field(i).Type == reflect.TypeOf(0) {
+			settingsSchema[tfName] = &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			}
+		}
+		if conflicts, ok := metaField.Field(i).Tag.Lookup("ConflictsWith"); ok {
+			if _, ok := settingsSchema[conflicts]; ok {
+				settingsSchema[conflicts].ConflictsWith = []string{SchemaSettings + ".0." + tfName}
+				settingsSchema[tfName].ConflictsWith = []string{SchemaSettings + ".0." + conflicts}
+			}
+		}
 	}
 	return resource
 }
 
 // API to TF
-func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+func minReviewersFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
 	err := baseFlattenFunc(d, policyConfig, projectID)
 	if err != nil {
 		return err
@@ -58,7 +75,7 @@ func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyCo
 		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
-	policySettings := mergeTypePolicySettings{}
+	policySettings := minReviewerPolicySettings{}
 	err = json.Unmarshal(policyAsJSON, &policySettings)
 	if err != nil {
 		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
@@ -74,6 +91,9 @@ func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyCo
 		if tipe.Field(i).Type == reflect.TypeOf(true) {
 			settings[tfName] = ps.Field(i).Bool()
 		}
+		if tipe.Field(i).Type == reflect.TypeOf(0) {
+			settings[tfName] = ps.Field(i).Int()
+		}
 	}
 
 	d.Set(SchemaSettings, settingsList)
@@ -81,7 +101,7 @@ func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyCo
 }
 
 // From TF to API
-func mergeTypesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+func minReviewersExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
 	policyConfig, projectID, err := baseExpandFunc(d, typeID)
 	if err != nil {
 		return nil, nil, err
@@ -92,7 +112,7 @@ func mergeTypesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.Pol
 
 	policySettings := policyConfig.Settings.(map[string]interface{})
 
-	tipe := reflect.TypeOf(mergeTypePolicySettings{})
+	tipe := reflect.TypeOf(minReviewerPolicySettings{})
 	for i := 0; i < tipe.NumField(); i++ {
 		tags := tipe.Field(i).Tag
 		apiName := tags.Get("json")
@@ -102,6 +122,9 @@ func mergeTypesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.Pol
 		}
 		if tipe.Field(i).Type == reflect.TypeOf(true) {
 			policySettings[apiName] = settings[tfName].(bool)
+		}
+		if tipe.Field(i).Type == reflect.TypeOf(0) {
+			policySettings[apiName] = settings[tfName].(int)
 		}
 	}
 

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers_test.go
@@ -1,7 +1,7 @@
-// +build all resource_branchpolicy_build_validation
-// +build !exclude_resource_branchpolicy_build_validation
+// +build all resource_branchpolicy_min_reviewers
+// +build !exclude_resource_branchpolicy_min_reviewers
 
-package policy
+package branch
 
 import (
 	"testing"
@@ -15,7 +15,7 @@ import (
 )
 
 // verifies that the flatten/expand round trip path produces repeatable results
-func TestBranchPolicyBuildValidation_ExpandFlatten_Roundtrip(t *testing.T) {
+func TestBranchPolicyMinReviewers_ExpandFlatten_Roundtrip(t *testing.T) {
 	var projectID = uuid.New().String()
 	var randomUUID = uuid.New()
 	var testPolicy = &policy.PolicyConfiguration{
@@ -33,19 +33,20 @@ func TestBranchPolicyBuildValidation_ExpandFlatten_Roundtrip(t *testing.T) {
 					"matchKind":    "test-match-kind",
 				},
 			},
-			"buildDefinitionId":       77,
-			"displayName":             "test policy",
-			"manualQueueOnly":         true,
-			"queueOnSourceUpdateOnly": true,
-			"validDuration":           700,
-			"filenamePatterns":        &([]string{"*md"}),
+			"minimumApproverCount":        2,
+			"creatorVoteCounts":           true,
+			"allowDownvotes":              true,
+			"resetOnSourcePush":           true,
+			"requireVoteOnLastIteration":  true,
+			"resetRejectionsOnSourcePush": true,
+			"blockLastPusherVote":         true,
 		},
 	}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyBuildValidation().Schema, nil)
-	err := buildValidationFlattenFunc(resourceData, testPolicy, &projectID)
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyMinReviewers().Schema, nil)
+	err := minReviewersFlattenFunc(resourceData, testPolicy, &projectID)
 	require.Nil(t, err)
-	expandedPolicy, expandedProjectID, err := buildValidationExpandFunc(resourceData, randomUUID)
+	expandedPolicy, expandedProjectID, err := minReviewersExpandFunc(resourceData, randomUUID)
 	require.Nil(t, err)
 
 	require.Equal(t, testPolicy, expandedPolicy)

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_status_check.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_status_check.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"github.com/google/uuid"

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_work_item_linking.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_work_item_linking.go
@@ -1,4 +1,4 @@
-package policy
+package branch
 
 import (
 	"github.com/google/uuid"
@@ -7,17 +7,17 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 )
 
-// ResourceBranchPolicyCommentResolution schema and implementation for min reviewer policy resource
-func ResourceBranchPolicyCommentResolution() *schema.Resource {
+// ResourceBranchPolicyWorkItemLinking schema and implementation for min reviewer policy resource
+func ResourceBranchPolicyWorkItemLinking() *schema.Resource {
 	resource := genBasePolicyResource(&policyCrudArgs{
-		FlattenFunc: commentResolutionFlattenFunc,
-		ExpandFunc:  commentResolutionExpandFunc,
-		PolicyType:  CommentResolution,
+		FlattenFunc: workItemLinkingFlattenFunc,
+		ExpandFunc:  workItemLinkingExpandFunc,
+		PolicyType:  WorkItemLinking,
 	})
 	return resource
 }
 
-func commentResolutionFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+func workItemLinkingFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
 	err := baseFlattenFunc(d, policyConfig, projectID)
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func commentResolutionFlattenFunc(d *schema.ResourceData, policyConfig *policy.P
 	return nil
 }
 
-func commentResolutionExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+func workItemLinkingExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
 	policyConfig, projectID, err := baseExpandFunc(d, typeID)
 	if err != nil {
 		return nil, nil, err

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_work_item_linking_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_work_item_linking_test.go
@@ -1,7 +1,7 @@
 // +build all resource_branchpolicy_work_item_linking
 // +build !exclude_resource_branchpolicy_work_item_linking
 
-package policy
+package branch
 
 import (
 	"testing"
@@ -15,7 +15,7 @@ import (
 )
 
 // verifies that the flatten/expand round trip path produces repeatable results
-func TestBranchPolicyCommentResolution_ExpandFlatten_Roundtrip(t *testing.T) {
+func TestBranchPolicyWorkItemLinking_ExpandFlatten_Roundtrip(t *testing.T) {
 	var projectID = uuid.New().String()
 	var randomUUID = uuid.New()
 	var testPolicy = &policy.PolicyConfiguration{
@@ -36,7 +36,7 @@ func TestBranchPolicyCommentResolution_ExpandFlatten_Roundtrip(t *testing.T) {
 		},
 	}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyCommentResolution().Schema, nil)
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyWorkItemLinking().Schema, nil)
 	err := workItemLinkingFlattenFunc(resourceData, testPolicy, &projectID)
 	require.Nil(t, err)
 	expandedPolicy, expandedProjectID, err := workItemLinkingExpandFunc(resourceData, randomUUID)

--- a/azuredevops/internal/service/policy/repository/common.go
+++ b/azuredevops/internal/service/policy/repository/common.go
@@ -201,7 +201,6 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 			SchemaScope: scopes,
 		}
 	}
-
 }
 
 func genPolicyCreateFunc(crudArgs *policyCrudArgs) schema.CreateFunc {

--- a/azuredevops/internal/service/policy/repository/common.go
+++ b/azuredevops/internal/service/policy/repository/common.go
@@ -1,0 +1,297 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// Policy type IDs. These are global and can be listed using the following endpoint:
+//	https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/types/list?view=azure-devops-rest-5.1
+var (
+	AuthorEmailPattern = uuid.MustParse("77ed4bd3-b063-4689-934a-175e4d0a78d7")
+	FilePathPattern    = uuid.MustParse("51c78909-e838-41a2-9496-c647091e3c61")
+	CaseEnforcement    = uuid.MustParse("7ed39669-655c-494e-b4a0-a08b4da0fcce")
+	ReservedNames      = uuid.MustParse("db2b9b4c-180d-4529-9701-01541d19f36b")
+	PathLength         = uuid.MustParse("001a79cf-fda1-4c4e-9e7c-bac40ee5ead8")
+	FileSize           = uuid.MustParse("2e26e725-8201-4edd-8bf5-978563c34a80")
+)
+
+// Keys for schema elements
+const (
+	SchemaProjectID    = "project_id"
+	SchemaEnabled      = "enabled"
+	SchemaBlocking     = "blocking"
+	SchemaSettings     = "settings"
+	SchemaScope        = "scope"
+	SchemaRepositoryID = "repository_id"
+)
+
+// policyCrudArgs arguments for genBasePolicyResource
+type policyCrudArgs struct {
+	FlattenFunc func(d *schema.ResourceData, policy *policy.PolicyConfiguration, projectID *string) error
+	ExpandFunc  func(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error)
+	PolicyType  uuid.UUID
+}
+
+// genBasePolicyResource creates a Resource with the common elements of a build policy
+func genBasePolicyResource(crudArgs *policyCrudArgs) *schema.Resource {
+	return &schema.Resource{
+		Create:   genPolicyCreateFunc(crudArgs),
+		Read:     genPolicyReadFunc(crudArgs),
+		Update:   genPolicyUpdateFunc(crudArgs),
+		Delete:   genPolicyDeleteFunc(crudArgs),
+		Importer: tfhelper.ImportProjectQualifiedResourceInteger(),
+		Schema: map[string]*schema.Schema{
+			SchemaProjectID: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			SchemaEnabled: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			SchemaBlocking: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			SchemaSettings: {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						SchemaScope: {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									branch.SchemaRepositoryID: {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type commonPolicySettings struct {
+	Scopes []struct {
+		RepositoryID string `json:"repositoryId,omitempty"`
+	} `json:"scope"`
+}
+
+// baseFlattenFunc flattens each of the base elements of the schema
+func baseFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	if policyConfig.Id == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(strconv.Itoa(*policyConfig.Id))
+	d.Set(SchemaProjectID, converter.ToString(projectID, ""))
+	d.Set(SchemaEnabled, converter.ToBool(policyConfig.IsEnabled, true))
+	d.Set(SchemaBlocking, converter.ToBool(policyConfig.IsBlocking, true))
+	settings, err := flattenSettings(policyConfig)
+	if err != nil {
+		return err
+	}
+	err = d.Set(SchemaSettings, settings)
+	if err != nil {
+		return fmt.Errorf("Unable to persist policy settings configuration: %+v", err)
+	}
+	return nil
+}
+
+func flattenSettings(policyConfig *policy.PolicyConfiguration) ([]interface{}, error) {
+	policySettings := commonPolicySettings{}
+	policyAsJSON, err := json.Marshal(policyConfig.Settings)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
+	}
+
+	_ = json.Unmarshal(policyAsJSON, &policySettings)
+	var scopes []interface{}
+	for _, scope := range policySettings.Scopes {
+		scopeSetting := map[string]interface{}{}
+		if scope.RepositoryID != "" {
+			scopeSetting[SchemaRepositoryID] = scope.RepositoryID
+			scopes = append(scopes, scopeSetting)
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			SchemaScope: scopes,
+		},
+	}, nil
+}
+
+// baseExpandFunc expands each of the base elements of the schema
+func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	projectID := d.Get(SchemaProjectID).(string)
+
+	policyConfig := policy.PolicyConfiguration{
+		IsEnabled:  converter.Bool(d.Get(SchemaEnabled).(bool)),
+		IsBlocking: converter.Bool(d.Get(SchemaBlocking).(bool)),
+		Type: &policy.PolicyTypeRef{
+			Id: &typeID,
+		},
+		Settings: expandSettings(d),
+	}
+
+	if d.Id() != "" {
+		policyID, err := strconv.Atoi(d.Id())
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error parsing policy configuration ID: (%+v)", err)
+		}
+		policyConfig.Id = &policyID
+	}
+
+	return &policyConfig, &projectID, nil
+}
+
+func expandSettings(d *schema.ResourceData) map[string]interface{} {
+	settingsList := d.Get(SchemaSettings).([]interface{})
+	settings := settingsList[0].(map[string]interface{})
+	settingsScopes := settings[SchemaScope].([]interface{})
+
+	if len(settingsScopes) == 0 {
+		return map[string]interface{}{
+			SchemaScope: []map[string]interface{}{
+				{
+					"repositoryId": "",
+				},
+			},
+		}
+	} else {
+		scopes := make([]map[string]interface{}, len(settingsScopes))
+		for index, scope := range settingsScopes {
+			scopeMap := scope.(map[string]interface{})
+			scopeSetting := map[string]interface{}{}
+			if repoID, ok := scopeMap[SchemaRepositoryID]; ok {
+				scopeSetting["repositoryId"] = repoID
+			}
+			scopes[index] = scopeSetting
+		}
+		return map[string]interface{}{
+			SchemaScope: scopes,
+		}
+	}
+
+}
+
+func genPolicyCreateFunc(crudArgs *policyCrudArgs) schema.CreateFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*client.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		createdPolicy, err := clients.PolicyClient.CreatePolicyConfiguration(clients.Ctx, policy.CreatePolicyConfigurationArgs{
+			Configuration: policyConfig,
+			Project:       projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error creating policy in Azure DevOps: %+v", err)
+		}
+
+		return crudArgs.FlattenFunc(d, createdPolicy, projectID)
+	}
+}
+
+func genPolicyReadFunc(crudArgs *policyCrudArgs) schema.ReadFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*client.AggregatedClient)
+		projectID := d.Get(SchemaProjectID).(string)
+		policyID, err := strconv.Atoi(d.Id())
+
+		if err != nil {
+			return fmt.Errorf("Error converting policy ID to an integer: (%+v)", err)
+		}
+
+		policyConfig, err := clients.PolicyClient.GetPolicyConfiguration(clients.Ctx, policy.GetPolicyConfigurationArgs{
+			Project:         &projectID,
+			ConfigurationId: &policyID,
+		})
+
+		if utils.ResponseWasNotFound(err) || (policyConfig != nil && *policyConfig.IsDeleted) {
+			d.SetId("")
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
+		}
+
+		return crudArgs.FlattenFunc(d, policyConfig, &projectID)
+	}
+}
+
+func genPolicyUpdateFunc(crudArgs *policyCrudArgs) schema.UpdateFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*client.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		updatedPolicy, err := clients.PolicyClient.UpdatePolicyConfiguration(clients.Ctx, policy.UpdatePolicyConfigurationArgs{
+			ConfigurationId: policyConfig.Id,
+			Configuration:   policyConfig,
+			Project:         projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error updating policy in Azure DevOps: %+v", err)
+		}
+
+		return crudArgs.FlattenFunc(d, updatedPolicy, projectID)
+	}
+}
+
+func genPolicyDeleteFunc(crudArgs *policyCrudArgs) schema.DeleteFunc {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*client.AggregatedClient)
+		policyConfig, projectID, err := crudArgs.ExpandFunc(d, crudArgs.PolicyType)
+		if err != nil {
+			return err
+		}
+
+		err = clients.PolicyClient.DeletePolicyConfiguration(clients.Ctx, policy.DeletePolicyConfigurationArgs{
+			ConfigurationId: policyConfig.Id,
+			Project:         projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting policy in Azure DevOps: %+v", err)
+		}
+
+		return nil
+	}
+}

--- a/azuredevops/internal/service/policy/repository/common.go
+++ b/azuredevops/internal/service/policy/repository/common.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"

--- a/azuredevops/internal/service/policy/repository/resource_repositorypolicy_author_email_patterns.go
+++ b/azuredevops/internal/service/policy/repository/resource_repositorypolicy_author_email_patterns.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 )
 
 func ResourceRepositoryPolicyAuthorEmailPatterns() *schema.Resource {
@@ -14,36 +15,14 @@ func ResourceRepositoryPolicyAuthorEmailPatterns() *schema.Resource {
 		PolicyType:  AuthorEmailPattern,
 	})
 
-	resource.Schema[SchemaSettings] = &schema.Schema{
+	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
+	settingsSchema["author_email_patterns"] = &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
 		MinItems: 1,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"author_email_patterns": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Schema{
-						Type:         schema.TypeString,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-				},
-				SchemaScope: {
-					Type:     schema.TypeList,
-					Required: true,
-					MinItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							SchemaRepositoryID: {
-								Type:         schema.TypeString,
-								Required:     true,
-								ValidateFunc: validation.StringIsNotEmpty,
-							},
-						},
-					},
-				},
-			},
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 	return resource
@@ -62,7 +41,7 @@ func authorEmailPatternFlattenFunc(d *schema.ResourceData, policyConfig *policy.
 	if policySettings["authorEmailPatterns"] != nil {
 		settings["author_email_patterns"] = policySettings["authorEmailPatterns"].([]interface{})
 	}
-	_ = d.Set(SchemaSettings, settingsList)
+	_ = d.Set(branch.SchemaSettings, settingsList)
 	return nil
 }
 

--- a/azuredevops/internal/service/policy/repository/resource_repositorypolicy_file_path_patterns.go
+++ b/azuredevops/internal/service/policy/repository/resource_repositorypolicy_file_path_patterns.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 )
 
 func ResourceRepositoryFilePathPatterns() *schema.Resource {
@@ -14,36 +15,14 @@ func ResourceRepositoryFilePathPatterns() *schema.Resource {
 		PolicyType:  FilePathPattern,
 	})
 
-	resource.Schema[SchemaSettings] = &schema.Schema{
+	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
+	settingsSchema["filepath_patterns"] = &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
 		MinItems: 1,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"filepath_patterns": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Schema{
-						Type:         schema.TypeString,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-				},
-				SchemaScope: {
-					Type:     schema.TypeList,
-					Required: true,
-					MinItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							SchemaRepositoryID: {
-								Type:         schema.TypeString,
-								Required:     true,
-								ValidateFunc: validation.StringIsNotEmpty,
-							},
-						},
-					},
-				},
-			},
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 	return resource
@@ -57,10 +36,10 @@ func filePathPatternFlattenFunc(d *schema.ResourceData, policyConfig *policy.Pol
 
 	policySettings := policyConfig.Settings.(map[string]interface{})
 
-	settingsList := d.Get(SchemaSettings).([]interface{})
+	settingsList := d.Get(branch.SchemaSettings).([]interface{})
 	settings := settingsList[0].(map[string]interface{})
 	settings["filepath_patterns"] = policySettings["filenamePatterns"].([]interface{})
-	_ = d.Set(SchemaSettings, settingsList)
+	_ = d.Set(branch.SchemaSettings, settingsList)
 	return nil
 }
 
@@ -70,7 +49,7 @@ func filePathPatternExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*polic
 		return nil, nil, err
 	}
 
-	settingsList := d.Get(SchemaSettings).([]interface{})
+	settingsList := d.Get(branch.SchemaSettings).([]interface{})
 	settings := settingsList[0].(map[string]interface{})
 
 	policySettings := policyConfig.Settings.(map[string]interface{})

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -10,7 +10,8 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/graph"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/memberentitlementmanagement"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
+	policy2 "github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/repository"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/workitemtracking"
@@ -21,19 +22,19 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"azuredevops_resource_authorization":                 build.ResourceResourceAuthorization(),
-			"azuredevops_branch_policy_build_validation":         policy.ResourceBranchPolicyBuildValidation(),
-			"azuredevops_branch_policy_min_reviewers":            policy.ResourceBranchPolicyMinReviewers(),
-			"azuredevops_branch_policy_auto_reviewers":           policy.ResourceBranchPolicyAutoReviewers(),
-			"azuredevops_branch_policy_work_item_linking":        policy.ResourceBranchPolicyWorkItemLinking(),
-			"azuredevops_branch_policy_comment_resolution":       policy.ResourceBranchPolicyCommentResolution(),
-			"azuredevops_branch_policy_merge_types":              policy.ResourceBranchPolicyMergeTypes(),
-			"azuredevops_branch_policy_status_check":             policy.ResourceBranchPolicyStatusCheck(),
+			"azuredevops_branch_policy_build_validation":         branch.ResourceBranchPolicyBuildValidation(),
+			"azuredevops_branch_policy_min_reviewers":            branch.ResourceBranchPolicyMinReviewers(),
+			"azuredevops_branch_policy_auto_reviewers":           branch.ResourceBranchPolicyAutoReviewers(),
+			"azuredevops_branch_policy_work_item_linking":        branch.ResourceBranchPolicyWorkItemLinking(),
+			"azuredevops_branch_policy_comment_resolution":       branch.ResourceBranchPolicyCommentResolution(),
+			"azuredevops_branch_policy_merge_types":              branch.ResourceBranchPolicyMergeTypes(),
+			"azuredevops_branch_policy_status_check":             branch.ResourceBranchPolicyStatusCheck(),
 			"azuredevops_build_definition":                       build.ResourceBuildDefinition(),
 			"azuredevops_project":                                core.ResourceProject(),
 			"azuredevops_project_features":                       core.ResourceProjectFeatures(),
 			"azuredevops_variable_group":                         taskagent.ResourceVariableGroup(),
-			"azuredevops_repository_policy_author_email_pattern": policy.ResourceRepositoryPolicyAuthorEmailPatterns(),
-			"azuredevops_repository_policy_file_path_pattern":    policy.ResourceRepositoryFilePathPatterns(),
+			"azuredevops_repository_policy_author_email_pattern": policy2.ResourceRepositoryPolicyAuthorEmailPatterns(),
+			"azuredevops_repository_policy_file_path_pattern":    policy2.ResourceRepositoryFilePathPatterns(),
 			"azuredevops_serviceendpoint_artifactory":            serviceendpoint.ResourceServiceEndpointArtifactory(),
 			"azuredevops_serviceendpoint_aws":                    serviceendpoint.ResourceServiceEndpointAws(),
 			"azuredevops_serviceendpoint_azurerm":                serviceendpoint.ResourceServiceEndpointAzureRM(),

--- a/website/docs/r/repository_policy_author_email_pattern.html.markdown
+++ b/website/docs/r/repository_policy_author_email_pattern.html.markdown
@@ -53,9 +53,9 @@ The following arguments are supported:
 
 `settings` block supports the following:
 
-- `author_email_patterns` - (Optional) Block pushes with a commit author email that does not match the patterns. You can specify exact emails or use wildcards. 
+- `author_email_patterns` - (Required) Block pushes with a commit author email that does not match the patterns. You can specify exact emails or use wildcards. 
   Email patterns prefixed with "!" are excluded. Order is important.
-- `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined
+- `scope` (Optional) Controls which repositories and branches the policy will be enabled for. This block must be defined
   at least once.   
   
   `scope` block supports the following:

--- a/website/docs/r/repository_policy_author_email_pattern.html.markdown
+++ b/website/docs/r/repository_policy_author_email_pattern.html.markdown
@@ -42,6 +42,20 @@ resource "azuredevops_repository_policy_author_email_pattern" "p" {
 }
 ```
 
+## Set project level repository policy
+```hcl
+resource "azuredevops_repository_policy_author_email_pattern" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    author_email_patterns = ["user1@test.com", "user2@test.com"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -55,8 +69,7 @@ The following arguments are supported:
 
 - `author_email_patterns` - (Required) Block pushes with a commit author email that does not match the patterns. You can specify exact emails or use wildcards. 
   Email patterns prefixed with "!" are excluded. Order is important.
-- `scope` (Optional) Controls which repositories and branches the policy will be enabled for. This block must be defined
-  at least once.   
+- `scope` (Optional) Control whether the policy is enabled for the repository or the project. If `scope` not configured, the policy will be set to the project.
   
   `scope` block supports the following:
     - `repository_id` - (Required) The repository ID.

--- a/website/docs/r/repository_policy_file_path_pattern.html.markdown
+++ b/website/docs/r/repository_policy_file_path_pattern.html.markdown
@@ -42,6 +42,20 @@ resource "azuredevops_repository_policy_file_path_pattern" "p" {
 }
 ```
 
+# Set project level repository policy
+```hcl
+resource "azuredevops_repository_policy_file_path_pattern" "p" {
+  project_id = azuredevops_project.p.id
+
+  enabled  = true
+  blocking = true
+
+  settings {
+    filepath_patterns = ["*.go", "/home/test/*.ts"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -54,8 +68,7 @@ The following arguments are supported:
 `settings` block supports the following:
 
 - `filepath_patterns` - (Required) Block pushes from introducing file paths that match the following patterns. Exact paths begin with "/". You can specify exact paths and wildcards. You can also specify multiple paths using ";" as a separator. Paths prefixed with "!" are excluded. Order is important.
-- `scope` (Optional) Controls which repositories and branches the policy will be enabled for. This block must be defined
-  at least once.   
+- `scope` (Optional) Control whether the policy is enabled for the repository or the project. If `scope` not configured, the policy will be set to the project.
   
   `scope` block supports the following:
     - `repository_id` - (Required) The repository ID.

--- a/website/docs/r/repository_policy_file_path_pattern.html.markdown
+++ b/website/docs/r/repository_policy_file_path_pattern.html.markdown
@@ -53,8 +53,8 @@ The following arguments are supported:
 
 `settings` block supports the following:
 
-- `filepath_patterns` - (Optional) Block pushes from introducing file paths that match the following patterns. Exact paths begin with "/". You can specify exact paths and wildcards. You can also specify multiple paths using ";" as a separator. Paths prefixed with "!" are excluded. Order is important.
-- `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined
+- `filepath_patterns` - (Required) Block pushes from introducing file paths that match the following patterns. Exact paths begin with "/". You can specify exact paths and wildcards. You can also specify multiple paths using ";" as a separator. Paths prefixed with "!" are excluded. Order is important.
+- `scope` (Optional) Controls which repositories and branches the policy will be enabled for. This block must be defined
   at least once.   
   
   `scope` block supports the following:


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`azuredevops_repository_policy_author_email_pattern` and `azuredevops_repository_policy_file_path_pattern` can set project level repository policy or to specific repository
Issue Number: #113 

```log
==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if avaliable
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
        TF_ACC=1 go test -count=1 -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v -run=TestAccRepositoryPolicyFilePathPatterns -timeout 120m
=== RUN   TestAccRepositoryPolicyFilePathPatterns
=== RUN   TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies
=== RUN   TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/basic
=== PAUSE TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/basic
=== RUN   TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/update
=== PAUSE TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/update
=== CONT  TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/basic
=== CONT  TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/update
=== RUN   TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies
=== RUN   TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/basic
=== PAUSE TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/basic
=== RUN   TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/update
=== PAUSE TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/update
=== CONT  TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/basic
=== CONT  TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/update
--- PASS: TestAccRepositoryPolicyFilePathPatterns (154.37s)
    --- PASS: TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies (0.00s)
        --- PASS: TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/basic (75.03s)
        --- PASS: TestAccRepositoryPolicyFilePathPatterns/RepositoryPolicies/update (78.08s)
    --- PASS: TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies (0.00s)
        --- PASS: TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/basic (74.15s)
        --- PASS: TestAccRepositoryPolicyFilePathPatterns/ProjectPolicies/update (76.29s)
=== RUN   TestAccRepositoryPolicyFilePathPatternsProjectPolicyBasic
=== PAUSE TestAccRepositoryPolicyFilePathPatternsProjectPolicyBasic
=== CONT  TestAccRepositoryPolicyFilePathPatternsProjectPolicyBasic
--- PASS: TestAccRepositoryPolicyFilePathPatternsProjectPolicyBasic (54.62s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        210.021s


==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if avaliable
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
        TF_ACC=1 go test -count=1 -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v -run=TestAccRepositoryPolicyAuthorEmailPatterns -timeout 120m
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/basic
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/update
=== PAUSE TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/update
=== CONT  TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/update
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/basic
=== RUN   TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/update
=== PAUSE TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/update
=== CONT  TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/update
--- PASS: TestAccRepositoryPolicyAuthorEmailPatterns (194.58s)
    --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies (35.95s)
        --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/basic (35.95s)
        --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/RepositoryPolicies/update (67.14s)
    --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies (53.64s)
        --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/basic (53.64s)
        --- PASS: TestAccRepositoryPolicyAuthorEmailPatterns/ProjectPolicies/update (37.85s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        195.35
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?
For `azuredevops_repository_policy_author_email_pattern` and `azuredevops_repository_policy_file_path_pattern`
1. `scope` can be omitted to set the policy to the project
2. The patterns now are required if `scope` is configured.

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->