### PR TITLE
feat: add azure devops servicehook webhook resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_servicehook_webhook_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_webhook_test.go
@@ -1,0 +1,169 @@
+// +build all resource_servicehook_webhook
+// +build !exclude_servicehook
+
+package acceptancetests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccServiceHookWebhook_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	eventType := "git.push"
+	url := "https://webhooks.org"
+
+	resourceType := "azuredevops_servicehook_webhook"
+	tfSvcHookNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceHookWebhookDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcHookWebhookResourceBasic(projectName, eventType, url),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceHookWebhookExistsWithEventTypeAndUrl(tfSvcHookNode, eventType, url),
+					resource.TestCheckResourceAttrSet(tfSvcHookNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "event_type", eventType),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "url", url),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceHookWebhook_complete(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	repositoryName := testutils.GenerateResourceName()
+	eventType := "git.push"
+	url := "https://webhooks.org"
+	basicAuth := BasicAuth{
+		Username: "some_username",
+		Password: "some_password",
+	}
+	httpHeaders := map[string]string{
+		"Authorization":     "Bearer bearing",
+		"X-My-Secret-Token": "whatever",
+	}
+
+	resourceType := "azuredevops_servicehook_webhook"
+	tfSvcHookNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceHookWebhookDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcHookWebhookResourceComplete(projectName, repositoryName, eventType, url, basicAuth, httpHeaders),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceHookWebhookExistsWithEventTypeAndUrl(tfSvcHookNode, eventType, url),
+					resource.TestCheckResourceAttrSet(tfSvcHookNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "event_type", eventType),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "url", url),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceHookWebhook_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	eventType := "git.push"
+	url := "https://webhooks.org"
+
+	updatedEventType := "git.pullrequest.created"
+	updatedUrl := "https://webhooks2.org"
+
+	resourceType := "azuredevops_servicehook_webhook"
+	tfSvcHookNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceHookWebhookDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcHookWebhookResourceBasic(projectName, eventType, url),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceHookWebhookExistsWithEventTypeAndUrl(tfSvcHookNode, eventType, url),
+					resource.TestCheckResourceAttrSet(tfSvcHookNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "event_type", eventType),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "url", url),
+				),
+			},
+			{
+				Config: hclSvcHookWebhookResourceUpdate(projectName, updatedEventType, updatedUrl),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceHookWebhookExistsWithEventTypeAndUrl(tfSvcHookNode, updatedEventType, updatedUrl),
+					resource.TestCheckResourceAttrSet(tfSvcHookNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "event_type", updatedEventType),
+					resource.TestCheckResourceAttr(tfSvcHookNode, "url", updatedUrl),
+				),
+			},
+		},
+	})
+}
+
+func hclSvcHookWebhookResourceBasic(projectName string, eventType string, url string) string {
+	serviceHookResource := fmt.Sprintf(`
+resource "azuredevops_servicehook_webhook" "test" {
+	project_id             = azuredevops_project.project.id
+	event_type = "%s"
+	url        = "%s"
+}`, eventType, url)
+
+	projectResource := testutils.HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, serviceHookResource)
+}
+
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+func hclSvcHookWebhookResourceComplete(projectName string, repositoryName string, eventType string, url string, basicAuth BasicAuth, httpHeaders map[string]string) string {
+	headers := []string{}
+	for key, val := range httpHeaders {
+		headers = append(headers, fmt.Sprintf("%s = \"%s\"", key, val))
+	}
+
+	serviceHookResource := fmt.Sprintf(`
+resource "azuredevops_servicehook_webhook" "test" {
+	project_id             = azuredevops_project.project.id
+	event_type = "%s"
+	url        = "%s"
+
+	basic_auth {
+		username = "%s"
+		password = "%s"
+	}
+
+
+	filters = {
+		repository = azuredevops_git_repository.repository.id
+	}
+
+	http_headers = {
+		%s
+	}
+}`, eventType, url, basicAuth.Username, basicAuth.Password, strings.Join(headers, "\n"))
+
+	projectAndRepositoryResource := testutils.HclGitRepoResource(projectName, repositoryName, "Clean")
+	return fmt.Sprintf("%s\n%s", projectAndRepositoryResource, serviceHookResource)
+}
+
+func hclSvcHookWebhookResourceUpdate(projectName string, eventType string, url string) string {
+	serviceHookResource := fmt.Sprintf(`
+resource "azuredevops_servicehook_webhook" "test" {
+	project_id             = azuredevops_project.project.id
+	event_type = "%s"
+	url        = "%s"
+}`, eventType, url)
+
+	projectResource := testutils.HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, serviceHookResource)
+}

--- a/azuredevops/internal/acceptancetests/testutils/servicehook.go
+++ b/azuredevops/internal/acceptancetests/testutils/servicehook.go
@@ -1,0 +1,69 @@
+package testutils
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// CheckServiceHookWebhookExistsWithEventTypeAndUrl verifies that a service hook webhook exists in the state,
+// and that it has the expected event type and url when compared against the data in Azure DevOps.
+func CheckServiceHookWebhookExistsWithEventTypeAndUrl(tfNode string, expectedEventType string, expectedUrl string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[tfNode]
+		if !ok {
+			return fmt.Errorf("Did not find a service hook webhook in the state")
+		}
+
+		subscription, err := getSvcHookWebhookFromState(resourceState)
+		if err != nil {
+			return err
+		}
+
+		if *subscription.EventType != expectedEventType {
+			return fmt.Errorf("Service Hook webhook has event type=%s, but expected event type=%s", *subscription.EventType, expectedEventType)
+		}
+
+		if (*subscription.ConsumerInputs)["url"] != expectedUrl {
+			return fmt.Errorf("Service Hook webhook has url=%s, but expected url=%s", *subscription.Url, expectedUrl)
+		}
+
+		return nil
+	}
+}
+
+// CheckServiceHookWebhookDestroyed verifies that all service hook webhoks the state are destroyed.
+// This will be invoked *after* terraform destroys the resource but *before* the state is wiped clean.
+func CheckServiceHookWebhookDestroyed(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, resource := range s.RootModule().Resources {
+			if resource.Type != resourceType {
+				continue
+			}
+
+			// indicates the resource exists - this should fail the test
+			if _, err := getSvcHookWebhookFromState(resource); err == nil {
+				return fmt.Errorf("Unexpectedly found a service hook webhook that should have been deleted")
+			}
+		}
+
+		return nil
+	}
+}
+
+// given a resource from the state, return a service hook webhook (and error)
+func getSvcHookWebhookFromState(resource *terraform.ResourceState) (*servicehooks.Subscription, error) {
+	serviceHookWebhookDefID, err := uuid.Parse(resource.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := GetProvider().Meta().(*client.AggregatedClient)
+	return clients.ServiceHooksClient.GetSubscription(clients.Ctx, servicehooks.GetSubscriptionArgs{
+		SubscriptionId: &serviceHookWebhookDefID,
+	})
+}

--- a/azuredevops/internal/client/client.go
+++ b/azuredevops/internal/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/release"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/security"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking"
 	"github.com/microsoft/terraform-provider-azuredevops/version"
@@ -38,6 +39,7 @@ type AggregatedClient struct {
 	BuildClient                   build.Client
 	GitReposClient                git.Client
 	GraphClient                   graph.Client
+	ServiceHooksClient            servicehooks.Client
 	OperationsClient              operations.Client
 	PolicyClient                  policy.Client
 	ReleaseClient                 release.Client
@@ -93,6 +95,10 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		log.Printf("getAzdoClient(): serviceendpoint.NewClient failed.")
 		return nil, err
 	}
+
+	// client for these APIs (includes CRUD for AzDO service hooks a.k.a.):
+	//  https://docs.microsoft.com/en-us/rest/api/azure/devops/hooks/?view=azure-devops-rest-5.1
+	serviceHooksClient := servicehooks.NewClient(ctx, connection)
 
 	// client for these APIs (includes CRUD for AzDO variable groups):
 	taskagentClient, err := taskagent.NewClient(ctx, connection)
@@ -162,6 +168,7 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		PolicyClient:                  policyClient,
 		ReleaseClient:                 releaseClient,
 		ServiceEndpointClient:         serviceEndpointClient,
+		ServiceHooksClient:            serviceHooksClient,
 		TaskAgentClient:               taskagentClient,
 		MemberEntitleManagementClient: memberentitlementmanagementClient,
 		FeatureManagementClient:       featuremanagementClient,

--- a/azuredevops/internal/service/servicehook/resource_servicehook_webhook.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_webhook.go
@@ -1,4 +1,4 @@
-package servicehooks
+package servicehook
 
 import (
 	"bufio"
@@ -31,7 +31,7 @@ func ResourceServiceHookWebhook() *schema.Resource {
 			},
 			"url": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.IsURLWithHTTPS,
 			},
 			"event_type": {
@@ -165,7 +165,9 @@ func createResourceWebhookRead(afterCreateOrUpdate bool) func(d *schema.Resource
 			}
 			filters[key] = value
 		}
-		d.Set("filters", filters)
+		if len(filters) != 0 {
+			d.Set("filters", filters)
+		}
 
 		return nil
 	}

--- a/azuredevops/internal/service/servicehooks/resource_servicehooks_webhook.go
+++ b/azuredevops/internal/service/servicehooks/resource_servicehooks_webhook.go
@@ -1,0 +1,251 @@
+package servicehooks
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+func ResourceServiceHookWebhook() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceWebhookCreate,
+		Read:     createResourceWebhookRead(false),
+		Update:   resourceWebhookUpdate,
+		Delete:   resourceWebhookDelete,
+		Importer: tfhelper.ImportProjectQualifiedResourceUUID(),
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsURLWithHTTPS,
+			},
+			"event_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"basic_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      nil,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"password": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+							Sensitive:    true,
+						},
+					},
+				},
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			"http_headers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"filters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceWebhookCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	subscriptionData := getSubscription(d)
+
+	subscription, err := clients.ServiceHooksClient.CreateSubscription(clients.Ctx, servicehooks.CreateSubscriptionArgs{
+		Subscription: &subscriptionData,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(subscription.Id.String())
+
+	return createResourceWebhookRead(true)(d, m)
+}
+
+func createResourceWebhookRead(afterCreateOrUpdate bool) func(d *schema.ResourceData, m interface{}) error {
+	return func(d *schema.ResourceData, m interface{}) error {
+		clients := m.(*client.AggregatedClient)
+
+		subscriptionId := d.Id()
+
+		subscription, err := clients.ServiceHooksClient.GetSubscription(clients.Ctx, servicehooks.GetSubscriptionArgs{
+			SubscriptionId: converter.UUID(subscriptionId),
+		})
+
+		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+
+		d.Set("project_id", (*subscription.PublisherInputs)["projectId"])
+		d.Set("url", (*subscription.ConsumerInputs)["url"])
+		d.Set("event_type", *subscription.EventType)
+
+		oldUpdatedAt := d.Get("updated_at")
+		newUpdatedAt := subscription.ModifiedDate.String()
+		d.Set("updated_at", newUpdatedAt)
+
+		if basicAuthList, ok := d.GetOk("basic_auth"); ok {
+			basicAuth := basicAuthList.([]interface{})[0].(map[string]interface{})
+
+			if username, ok := (*subscription.ConsumerInputs)["basicAuthUsername"]; ok {
+				basicAuth["username"] = username
+			}
+
+			if password, ok := basicAuth["password"]; ok && !afterCreateOrUpdate && oldUpdatedAt != newUpdatedAt {
+				// note: condition above means someone modified webhook subscription externally and since we can't
+				// know whether they've changed password (API returns mask ********) we'll force a password change
+				basicAuth["password"] = password.(string) + " - this suffix will cause a diff and therefore change"
+			}
+
+			d.Set("basic_auth", basicAuthList)
+		}
+
+		// http headers are returned as string -> we need to parse them
+		httpHeadersString := (*subscription.ConsumerInputs)["httpHeaders"]
+		reader := bufio.NewReader(strings.NewReader("GET / HTTP/1.1\r\n" + (*subscription.ConsumerInputs)["httpHeaders"] + "\r\n\n"))
+		req, err := http.ReadRequest(reader)
+		if err != nil {
+			return fmt.Errorf("could not parse subscription http headers: %s", httpHeadersString)
+		}
+
+		httpHeaders := map[string]string{}
+		for header, values := range req.Header {
+			httpHeaders[header] = strings.Join(values, ", ")
+		}
+		d.Set("http_headers", httpHeaders)
+
+		filters := map[string]string{}
+		for key, value := range *subscription.PublisherInputs {
+			if key == "projectId" || key == "tfsSubscriptionId" {
+				continue
+			}
+			filters[key] = value
+		}
+		d.Set("filters", filters)
+
+		return nil
+	}
+}
+
+func resourceWebhookUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	subscriptionData := getSubscription(d)
+
+	if _, err := clients.ServiceHooksClient.ReplaceSubscription(clients.Ctx, servicehooks.ReplaceSubscriptionArgs{
+		SubscriptionId: converter.UUID(d.Id()),
+		Subscription:   &subscriptionData,
+	}); err != nil {
+		return err
+	}
+
+	return createResourceWebhookRead(true)(d, m)
+}
+
+func resourceWebhookDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	err := clients.ServiceHooksClient.DeleteSubscription(clients.Ctx, servicehooks.DeleteSubscriptionArgs{
+		SubscriptionId: converter.UUID(d.Id()),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func getSubscription(d *schema.ResourceData) servicehooks.Subscription {
+	publisherId := "tfs"
+	eventType := d.Get("event_type").(string)
+	url := d.Get("url").(string)
+	consumerId := "webHooks"
+	consumerActionId := "httpRequest"
+	httpHeaders := d.Get("http_headers").(map[string]interface{})
+	filters := d.Get("filters").(map[string]interface{})
+
+	consumerInputs := map[string]string{
+		"url": url,
+	}
+	if basicAuthList, ok := d.GetOk("basic_auth"); ok {
+		basicAuth := basicAuthList.([]interface{})[0].(map[string]interface{})
+		if username, ok := basicAuth["username"]; ok && username != "" {
+			consumerInputs["basicAuthUsername"] = username.(string)
+		}
+		if password, ok := basicAuth["password"]; ok && password != "" {
+			consumerInputs["basicAuthPassword"] = password.(string)
+		}
+	}
+
+	httpHeadersSlice := []string{}
+	for header, value := range httpHeaders {
+		httpHeadersSlice = append(httpHeadersSlice, fmt.Sprintf("%s: %s", header, value.(string)))
+	}
+	httpHeadersStr := strings.Join(httpHeadersSlice, "\n")
+	if httpHeadersStr != "" {
+		consumerInputs["httpHeaders"] = httpHeadersStr
+	}
+
+	publisherInputs := map[string]string{}
+	for key, value := range filters {
+		publisherInputs[key] = value.(string)
+	}
+	publisherInputs["projectId"] = d.Get("project_id").(string)
+
+	subscriptionData := servicehooks.Subscription{
+		PublisherId:      &publisherId,
+		EventType:        &eventType,
+		ConsumerId:       &consumerId,
+		ConsumerActionId: &consumerActionId,
+		PublisherInputs:  &publisherInputs,
+		ConsumerInputs:   &consumerInputs,
+	}
+
+	return subscriptionData
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/repository"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/servicehooks"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/workitemtracking"
 )
@@ -57,6 +58,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_npm":                    serviceendpoint.ResourceServiceEndpointNpm(),
 			"azuredevops_serviceendpoint_generic":                serviceendpoint.ResourceServiceEndpointGeneric(),
 			"azuredevops_serviceendpoint_generic_git":            serviceendpoint.ResourceServiceEndpointGenericGit(),
+			"azuredevops_servicehooks_webhook":                   servicehooks.ResourceServiceHookWebhook(),
 			"azuredevops_git_repository":                         git.ResourceGitRepository(),
 			"azuredevops_git_repository_file":                    git.ResourceGitRepositoryFile(),
 			"azuredevops_user_entitlement":                       memberentitlementmanagement.ResourceUserEntitlement(),

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/repository"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/servicehook"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/workitemtracking"
 )
@@ -58,7 +58,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_npm":                    serviceendpoint.ResourceServiceEndpointNpm(),
 			"azuredevops_serviceendpoint_generic":                serviceendpoint.ResourceServiceEndpointGeneric(),
 			"azuredevops_serviceendpoint_generic_git":            serviceendpoint.ResourceServiceEndpointGenericGit(),
-			"azuredevops_servicehooks_webhook":                   servicehooks.ResourceServiceHookWebhook(),
+			"azuredevops_servicehook_webhook":                    servicehook.ResourceServiceHookWebhook(),
 			"azuredevops_git_repository":                         git.ResourceGitRepository(),
 			"azuredevops_git_repository_file":                    git.ResourceGitRepositoryFile(),
 			"azuredevops_user_entitlement":                       memberentitlementmanagement.ResourceUserEntitlement(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -38,6 +38,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_npm",
 		"azuredevops_serviceendpoint_generic",
 		"azuredevops_serviceendpoint_generic_git",
+		"azuredevops_servicehooks_webhook",
 		"azuredevops_variable_group",
 		"azuredevops_repository_policy_author_email_pattern",
 		"azuredevops_repository_policy_case_enforcement",

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -38,7 +38,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_npm",
 		"azuredevops_serviceendpoint_generic",
 		"azuredevops_serviceendpoint_generic_git",
-		"azuredevops_servicehooks_webhook",
+		"azuredevops_servicehook_webhook",
 		"azuredevops_variable_group",
 		"azuredevops_repository_policy_author_email_pattern",
 		"azuredevops_repository_policy_case_enforcement",

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/terraform-exec v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b3
+	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b3 h1:5iyKm9Mzp0NbKLVHP6PZbigCAzvOYq/pAaMyc8KpNLs=
-github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b3/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
+github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 h1:YH424zrwLTlyHSH/GzLMJeu5zhYVZSx5RQxGKm1h96s=
+github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/mitchellh/cli v1.1.2 h1:PvH+lL2B7IQ101xQL63Of8yFS2y+aDlsFcsqNc+u/Kw=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/build/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/build/client.go
@@ -1524,10 +1524,10 @@ func (client *ClientImpl) GetBuilds(ctx context.Context, args GetBuildsArgs) (*G
 		queryParams.Add("buildNumber", *args.BuildNumber)
 	}
 	if args.MinTime != nil {
-		queryParams.Add("minTime", (*args.MinTime).String())
+		queryParams.Add("minTime", (*args.MinTime).AsQueryParameter())
 	}
 	if args.MaxTime != nil {
-		queryParams.Add("maxTime", (*args.MaxTime).String())
+		queryParams.Add("maxTime", (*args.MaxTime).AsQueryParameter())
 	}
 	if args.RequestedFor != nil {
 		queryParams.Add("requestedFor", *args.RequestedFor)
@@ -1889,7 +1889,7 @@ func (client *ClientImpl) GetDefinition(ctx context.Context, args GetDefinitionA
 		queryParams.Add("revision", strconv.Itoa(*args.Revision))
 	}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	if args.PropertyFilters != nil {
 		listAsString := strings.Join((*args.PropertyFilters)[:], ",")
@@ -1939,7 +1939,7 @@ func (client *ClientImpl) GetDefinitionMetrics(ctx context.Context, args GetDefi
 
 	queryParams := url.Values{}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("d973b939-0ce0-4fec-91d8-da3940fa1827")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1-preview.1", routeValues, queryParams, nil, "", "application/json", nil)
@@ -2090,7 +2090,7 @@ func (client *ClientImpl) GetDefinitions(ctx context.Context, args GetDefinition
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	if args.DefinitionIds != nil {
 		var stringList []string
@@ -2104,10 +2104,10 @@ func (client *ClientImpl) GetDefinitions(ctx context.Context, args GetDefinition
 		queryParams.Add("path", *args.Path)
 	}
 	if args.BuiltAfter != nil {
-		queryParams.Add("builtAfter", (*args.BuiltAfter).String())
+		queryParams.Add("builtAfter", (*args.BuiltAfter).AsQueryParameter())
 	}
 	if args.NotBuiltAfter != nil {
-		queryParams.Add("notBuiltAfter", (*args.NotBuiltAfter).String())
+		queryParams.Add("notBuiltAfter", (*args.NotBuiltAfter).AsQueryParameter())
 	}
 	if args.IncludeAllProperties != nil {
 		queryParams.Add("includeAllProperties", strconv.FormatBool(*args.IncludeAllProperties))
@@ -2454,7 +2454,7 @@ func (client *ClientImpl) GetProjectMetrics(ctx context.Context, args GetProject
 
 	queryParams := url.Values{}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("7433fae7-a6bc-41dc-a6e2-eef9005ce41a")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1-preview.1", routeValues, queryParams, nil, "", "application/json", nil)

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/client.go
@@ -45,13 +45,20 @@ var apiResourceLocationCache = make(map[string]*map[uuid.UUID]ApiResourceLocatio
 var apiResourceLocationCacheLock = sync.RWMutex{}
 
 var version = "1.1.0-b3" // todo: remove hardcoded version
-var versionSuffix = ""
+var versionSuffix = " (dev)"
 
 // Base user agent string.  The UserAgent set on the connection will be appended to this.
 var baseUserAgent = "go/" + runtime.Version() + " (" + runtime.GOOS + " " + runtime.GOARCH + ") azure-devops-go-api/" + version + versionSuffix
 
 func NewClient(connection *Connection, baseUrl string) *Client {
-	client := &http.Client{}
+	var client *http.Client
+
+	if connection.TlsConfig != nil {
+		client = &http.Client{Transport: &http.Transport{TLSClientConfig: connection.TlsConfig}}
+	} else {
+		client = &http.Client{}
+	}
+
 	if connection.Timeout != nil {
 		client.Timeout = *connection.Timeout
 	}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/connection.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/connection.go
@@ -5,11 +5,13 @@ package azuredevops
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
-	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Creates a new Azure DevOps connection instance using a personal access token.
@@ -38,6 +40,7 @@ type Connection struct {
 	SuppressFedAuthRedirect bool
 	ForceMsaPassThrough     bool
 	Timeout                 *time.Duration
+	TlsConfig               *tls.Config
 	clientCache             map[string]Client
 	clientCacheLock         sync.RWMutex
 	resourceAreaCache       map[uuid.UUID]ResourceAreaInfo

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/git/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/git/client.go
@@ -4435,10 +4435,10 @@ func (client *ClientImpl) GetPushes(ctx context.Context, args GetPushesArgs) (*[
 	}
 	if args.SearchCriteria != nil {
 		if args.SearchCriteria.FromDate != nil {
-			queryParams.Add("searchCriteria.fromDate", (*args.SearchCriteria.FromDate).String())
+			queryParams.Add("searchCriteria.fromDate", (*args.SearchCriteria.FromDate).AsQueryParameter())
 		}
 		if args.SearchCriteria.ToDate != nil {
-			queryParams.Add("searchCriteria.toDate", (*args.SearchCriteria.ToDate).String())
+			queryParams.Add("searchCriteria.toDate", (*args.SearchCriteria.ToDate).AsQueryParameter())
 		}
 		if args.SearchCriteria.PusherId != nil {
 			queryParams.Add("searchCriteria.pusherId", (*args.SearchCriteria.PusherId).String())

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/models.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/models.go
@@ -95,6 +95,11 @@ func (t *Time) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
 }
 
+// AsQueryParameter formats time value for query parameter usage.
+func (t Time) AsQueryParameter() string {
+	return t.Time.Format(time.RFC3339Nano)
+}
+
 func (t Time) String() string {
 	return t.Time.String()
 }

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/notification/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/notification/client.go
@@ -1,0 +1,545 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Client interface {
+	// Create a new subscription.
+	CreateSubscription(context.Context, CreateSubscriptionArgs) (*NotificationSubscription, error)
+	// Delete a subscription.
+	DeleteSubscription(context.Context, DeleteSubscriptionArgs) error
+	// Get a specific event type.
+	GetEventType(context.Context, GetEventTypeArgs) (*NotificationEventType, error)
+	GetSettings(context.Context, GetSettingsArgs) (*NotificationAdminSettings, error)
+	// Get delivery preferences of a notifications subscriber.
+	GetSubscriber(context.Context, GetSubscriberArgs) (*NotificationSubscriber, error)
+	// Get a notification subscription by its ID.
+	GetSubscription(context.Context, GetSubscriptionArgs) (*NotificationSubscription, error)
+	// Get the diagnostics settings for a subscription.
+	GetSubscriptionDiagnostics(context.Context, GetSubscriptionDiagnosticsArgs) (*SubscriptionDiagnostics, error)
+	// Get available subscription templates.
+	GetSubscriptionTemplates(context.Context, GetSubscriptionTemplatesArgs) (*[]NotificationSubscriptionTemplate, error)
+	// List available event types for this service. Optionally filter by only event types for the specified publisher.
+	ListEventTypes(context.Context, ListEventTypesArgs) (*[]NotificationEventType, error)
+	// Get a list of diagnostic logs for this service.
+	ListLogs(context.Context, ListLogsArgs) (*[]INotificationDiagnosticLog, error)
+	// Get a list of notification subscriptions, either by subscription IDs or by all subscriptions for a given user or group.
+	ListSubscriptions(context.Context, ListSubscriptionsArgs) (*[]NotificationSubscription, error)
+	// Query for subscriptions. A subscription is returned if it matches one or more of the specified conditions.
+	QuerySubscriptions(context.Context, QuerySubscriptionsArgs) (*[]NotificationSubscription, error)
+	UpdateSettings(context.Context, UpdateSettingsArgs) (*NotificationAdminSettings, error)
+	// Update delivery preferences of a notifications subscriber.
+	UpdateSubscriber(context.Context, UpdateSubscriberArgs) (*NotificationSubscriber, error)
+	// Update an existing subscription. Depending on the type of subscription and permissions, the caller can update the description, filter settings, channel (delivery) settings and more.
+	UpdateSubscription(context.Context, UpdateSubscriptionArgs) (*NotificationSubscription, error)
+	// Update the diagnostics settings for a subscription.
+	UpdateSubscriptionDiagnostics(context.Context, UpdateSubscriptionDiagnosticsArgs) (*SubscriptionDiagnostics, error)
+	// Update the specified user's settings for the specified subscription. This API is typically used to opt in or out of a shared subscription. User settings can only be applied to shared subscriptions, like team subscriptions or default subscriptions.
+	UpdateSubscriptionUserSettings(context.Context, UpdateSubscriptionUserSettingsArgs) (*SubscriptionUserSettings, error)
+}
+
+type ClientImpl struct {
+	Client azuredevops.Client
+}
+
+func NewClient(ctx context.Context, connection *azuredevops.Connection) Client {
+	client := connection.GetClientByUrl(connection.BaseUrl)
+	return &ClientImpl{
+		Client: *client,
+	}
+}
+
+// Create a new subscription.
+func (client *ClientImpl) CreateSubscription(ctx context.Context, args CreateSubscriptionArgs) (*NotificationSubscription, error) {
+	if args.CreateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.CreateParameters"}
+	}
+	body, marshalErr := json.Marshal(*args.CreateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("70f911d6-abac-488c-85b3-a206bf57e165")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationSubscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the CreateSubscription function
+type CreateSubscriptionArgs struct {
+	// (required)
+	CreateParameters *NotificationSubscriptionCreateParameters
+}
+
+// Delete a subscription.
+func (client *ClientImpl) DeleteSubscription(ctx context.Context, args DeleteSubscriptionArgs) error {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	locationId, _ := uuid.Parse("70f911d6-abac-488c-85b3-a206bf57e165")
+	_, err := client.Client.Send(ctx, http.MethodDelete, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Arguments for the DeleteSubscription function
+type DeleteSubscriptionArgs struct {
+	// (required)
+	SubscriptionId *string
+}
+
+// Get a specific event type.
+func (client *ClientImpl) GetEventType(ctx context.Context, args GetEventTypeArgs) (*NotificationEventType, error) {
+	routeValues := make(map[string]string)
+	if args.EventType == nil || *args.EventType == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.EventType"}
+	}
+	routeValues["eventType"] = *args.EventType
+
+	locationId, _ := uuid.Parse("cc84fb5f-6247-4c7a-aeae-e5a3c3fddb21")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationEventType
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetEventType function
+type GetEventTypeArgs struct {
+	// (required) The ID of the event type.
+	EventType *string
+}
+
+func (client *ClientImpl) GetSettings(ctx context.Context, args GetSettingsArgs) (*NotificationAdminSettings, error) {
+	locationId, _ := uuid.Parse("cbe076d8-2803-45ff-8d8d-44653686ea2a")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationAdminSettings
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSettings function
+type GetSettingsArgs struct {
+}
+
+// Get delivery preferences of a notifications subscriber.
+func (client *ClientImpl) GetSubscriber(ctx context.Context, args GetSubscriberArgs) (*NotificationSubscriber, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriberId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriberId"}
+	}
+	routeValues["subscriberId"] = (*args.SubscriberId).String()
+
+	locationId, _ := uuid.Parse("4d5caff1-25ba-430b-b808-7a1f352cc197")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationSubscriber
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscriber function
+type GetSubscriberArgs struct {
+	// (required) ID of the user or group.
+	SubscriberId *uuid.UUID
+}
+
+// Get a notification subscription by its ID.
+func (client *ClientImpl) GetSubscription(ctx context.Context, args GetSubscriptionArgs) (*NotificationSubscription, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	queryParams := url.Values{}
+	if args.QueryFlags != nil {
+		queryParams.Add("queryFlags", string(*args.QueryFlags))
+	}
+	locationId, _ := uuid.Parse("70f911d6-abac-488c-85b3-a206bf57e165")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationSubscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscription function
+type GetSubscriptionArgs struct {
+	// (required)
+	SubscriptionId *string
+	// (optional)
+	QueryFlags *SubscriptionQueryFlags
+}
+
+// Get the diagnostics settings for a subscription.
+func (client *ClientImpl) GetSubscriptionDiagnostics(ctx context.Context, args GetSubscriptionDiagnosticsArgs) (*SubscriptionDiagnostics, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	locationId, _ := uuid.Parse("20f1929d-4be7-4c2e-a74e-d47640ff3418")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue SubscriptionDiagnostics
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscriptionDiagnostics function
+type GetSubscriptionDiagnosticsArgs struct {
+	// (required) The id of the notifications subscription.
+	SubscriptionId *string
+}
+
+// Get available subscription templates.
+func (client *ClientImpl) GetSubscriptionTemplates(ctx context.Context, args GetSubscriptionTemplatesArgs) (*[]NotificationSubscriptionTemplate, error) {
+	locationId, _ := uuid.Parse("fa5d24ba-7484-4f3d-888d-4ec6b1974082")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []NotificationSubscriptionTemplate
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscriptionTemplates function
+type GetSubscriptionTemplatesArgs struct {
+}
+
+// List available event types for this service. Optionally filter by only event types for the specified publisher.
+func (client *ClientImpl) ListEventTypes(ctx context.Context, args ListEventTypesArgs) (*[]NotificationEventType, error) {
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	locationId, _ := uuid.Parse("cc84fb5f-6247-4c7a-aeae-e5a3c3fddb21")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []NotificationEventType
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListEventTypes function
+type ListEventTypesArgs struct {
+	// (optional) Limit to event types for this publisher
+	PublisherId *string
+}
+
+// Get a list of diagnostic logs for this service.
+func (client *ClientImpl) ListLogs(ctx context.Context, args ListLogsArgs) (*[]INotificationDiagnosticLog, error) {
+	routeValues := make(map[string]string)
+	if args.Source == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Source"}
+	}
+	routeValues["source"] = (*args.Source).String()
+	if args.EntryId != nil {
+		routeValues["entryId"] = (*args.EntryId).String()
+	}
+
+	queryParams := url.Values{}
+	if args.StartTime != nil {
+		queryParams.Add("startTime", (*args.StartTime).AsQueryParameter())
+	}
+	if args.EndTime != nil {
+		queryParams.Add("endTime", (*args.EndTime).AsQueryParameter())
+	}
+	locationId, _ := uuid.Parse("991842f3-eb16-4aea-ac81-81353ef2b75c")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []INotificationDiagnosticLog
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListLogs function
+type ListLogsArgs struct {
+	// (required) ID specifying which type of logs to check diagnostics for.
+	Source *uuid.UUID
+	// (optional) The ID of the specific log to query for.
+	EntryId *uuid.UUID
+	// (optional) Start time for the time range to query in.
+	StartTime *azuredevops.Time
+	// (optional) End time for the time range to query in.
+	EndTime *azuredevops.Time
+}
+
+// Get a list of notification subscriptions, either by subscription IDs or by all subscriptions for a given user or group.
+func (client *ClientImpl) ListSubscriptions(ctx context.Context, args ListSubscriptionsArgs) (*[]NotificationSubscription, error) {
+	queryParams := url.Values{}
+	if args.TargetId != nil {
+		queryParams.Add("targetId", (*args.TargetId).String())
+	}
+	if args.Ids != nil {
+		listAsString := strings.Join((*args.Ids)[:], ",")
+		queryParams.Add("ids", listAsString)
+	}
+	if args.QueryFlags != nil {
+		queryParams.Add("queryFlags", string(*args.QueryFlags))
+	}
+	locationId, _ := uuid.Parse("70f911d6-abac-488c-85b3-a206bf57e165")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []NotificationSubscription
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListSubscriptions function
+type ListSubscriptionsArgs struct {
+	// (optional) User or Group ID
+	TargetId *uuid.UUID
+	// (optional) List of subscription IDs
+	Ids *[]string
+	// (optional)
+	QueryFlags *SubscriptionQueryFlags
+}
+
+// Query for subscriptions. A subscription is returned if it matches one or more of the specified conditions.
+func (client *ClientImpl) QuerySubscriptions(ctx context.Context, args QuerySubscriptionsArgs) (*[]NotificationSubscription, error) {
+	if args.SubscriptionQuery == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriptionQuery"}
+	}
+	body, marshalErr := json.Marshal(*args.SubscriptionQuery)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("6864db85-08c0-4006-8e8e-cc1bebe31675")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []NotificationSubscription
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the QuerySubscriptions function
+type QuerySubscriptionsArgs struct {
+	// (required)
+	SubscriptionQuery *SubscriptionQuery
+}
+
+func (client *ClientImpl) UpdateSettings(ctx context.Context, args UpdateSettingsArgs) (*NotificationAdminSettings, error) {
+	if args.UpdateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UpdateParameters"}
+	}
+	body, marshalErr := json.Marshal(*args.UpdateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("cbe076d8-2803-45ff-8d8d-44653686ea2a")
+	resp, err := client.Client.Send(ctx, http.MethodPatch, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationAdminSettings
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSettings function
+type UpdateSettingsArgs struct {
+	// (required)
+	UpdateParameters *NotificationAdminSettingsUpdateParameters
+}
+
+// Update delivery preferences of a notifications subscriber.
+func (client *ClientImpl) UpdateSubscriber(ctx context.Context, args UpdateSubscriberArgs) (*NotificationSubscriber, error) {
+	if args.UpdateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UpdateParameters"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriberId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriberId"}
+	}
+	routeValues["subscriberId"] = (*args.SubscriberId).String()
+
+	body, marshalErr := json.Marshal(*args.UpdateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("4d5caff1-25ba-430b-b808-7a1f352cc197")
+	resp, err := client.Client.Send(ctx, http.MethodPatch, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationSubscriber
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSubscriber function
+type UpdateSubscriberArgs struct {
+	// (required)
+	UpdateParameters *NotificationSubscriberUpdateParameters
+	// (required) ID of the user or group.
+	SubscriberId *uuid.UUID
+}
+
+// Update an existing subscription. Depending on the type of subscription and permissions, the caller can update the description, filter settings, channel (delivery) settings and more.
+func (client *ClientImpl) UpdateSubscription(ctx context.Context, args UpdateSubscriptionArgs) (*NotificationSubscription, error) {
+	if args.UpdateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UpdateParameters"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	body, marshalErr := json.Marshal(*args.UpdateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("70f911d6-abac-488c-85b3-a206bf57e165")
+	resp, err := client.Client.Send(ctx, http.MethodPatch, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationSubscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSubscription function
+type UpdateSubscriptionArgs struct {
+	// (required)
+	UpdateParameters *NotificationSubscriptionUpdateParameters
+	// (required)
+	SubscriptionId *string
+}
+
+// Update the diagnostics settings for a subscription.
+func (client *ClientImpl) UpdateSubscriptionDiagnostics(ctx context.Context, args UpdateSubscriptionDiagnosticsArgs) (*SubscriptionDiagnostics, error) {
+	if args.UpdateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UpdateParameters"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	body, marshalErr := json.Marshal(*args.UpdateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("20f1929d-4be7-4c2e-a74e-d47640ff3418")
+	resp, err := client.Client.Send(ctx, http.MethodPut, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue SubscriptionDiagnostics
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSubscriptionDiagnostics function
+type UpdateSubscriptionDiagnosticsArgs struct {
+	// (required)
+	UpdateParameters *UpdateSubscripitonDiagnosticsParameters
+	// (required) The id of the notifications subscription.
+	SubscriptionId *string
+}
+
+// Update the specified user's settings for the specified subscription. This API is typically used to opt in or out of a shared subscription. User settings can only be applied to shared subscriptions, like team subscriptions or default subscriptions.
+func (client *ClientImpl) UpdateSubscriptionUserSettings(ctx context.Context, args UpdateSubscriptionUserSettingsArgs) (*SubscriptionUserSettings, error) {
+	if args.UserSettings == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UserSettings"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+	if args.UserId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UserId"}
+	}
+	routeValues["userId"] = (*args.UserId).String()
+
+	body, marshalErr := json.Marshal(*args.UserSettings)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("ed5a3dff-aeb5-41b1-b4f7-89e66e58b62e")
+	resp, err := client.Client.Send(ctx, http.MethodPut, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue SubscriptionUserSettings
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSubscriptionUserSettings function
+type UpdateSubscriptionUserSettingsArgs struct {
+	// (required)
+	UserSettings *SubscriptionUserSettings
+	// (required)
+	SubscriptionId *string
+	// (required) ID of the user
+	UserId *uuid.UUID
+}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/notification/models.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/notification/models.go
@@ -1,0 +1,1353 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package notification
+
+import (
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/forminput"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
+)
+
+type ActorFilter struct {
+	EventType  *string                `json:"eventType,omitempty"`
+	Criteria   *ExpressionFilterModel `json:"criteria,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+	Exclusions *[]string              `json:"exclusions,omitempty"`
+	Inclusions *[]string              `json:"inclusions,omitempty"`
+}
+
+type ActorNotificationReason struct {
+	NotificationReasonType *NotificationReasonType `json:"notificationReasonType,omitempty"`
+	TargetIdentities       *[]webapi.IdentityRef   `json:"targetIdentities,omitempty"`
+	MatchedRoles           *[]string               `json:"matchedRoles,omitempty"`
+}
+
+// Artifact filter options. Used in "follow" subscriptions.
+type ArtifactFilter struct {
+	EventType    *string `json:"eventType,omitempty"`
+	ArtifactId   *string `json:"artifactId,omitempty"`
+	ArtifactType *string `json:"artifactType,omitempty"`
+	ArtifactUri  *string `json:"artifactUri,omitempty"`
+	Type         *string `json:"type,omitempty"`
+}
+
+type BaseSubscriptionFilter struct {
+	EventType *string `json:"eventType,omitempty"`
+	Type      *string `json:"type,omitempty"`
+}
+
+type BatchNotificationOperation struct {
+	NotificationOperation       *NotificationOperation        `json:"notificationOperation,omitempty"`
+	NotificationQueryConditions *[]NotificationQueryCondition `json:"notificationQueryConditions,omitempty"`
+}
+
+type BlockFilter struct {
+	EventType  *string                `json:"eventType,omitempty"`
+	Criteria   *ExpressionFilterModel `json:"criteria,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+	Exclusions *[]string              `json:"exclusions,omitempty"`
+	Inclusions *[]string              `json:"inclusions,omitempty"`
+}
+
+type BlockSubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+// Default delivery preference for group subscribers. Indicates how the subscriber should be notified.
+type DefaultGroupDeliveryPreference string
+
+type defaultGroupDeliveryPreferenceValuesType struct {
+	NoDelivery DefaultGroupDeliveryPreference
+	EachMember DefaultGroupDeliveryPreference
+}
+
+var DefaultGroupDeliveryPreferenceValues = defaultGroupDeliveryPreferenceValuesType{
+	NoDelivery: "noDelivery",
+	EachMember: "eachMember",
+}
+
+type DiagnosticIdentity struct {
+	DisplayName  *string    `json:"displayName,omitempty"`
+	EmailAddress *string    `json:"emailAddress,omitempty"`
+	Id           *uuid.UUID `json:"id,omitempty"`
+}
+
+type DiagnosticNotification struct {
+	EventId        *int                                `json:"eventId,omitempty"`
+	EventType      *string                             `json:"eventType,omitempty"`
+	Id             *int                                `json:"id,omitempty"`
+	Messages       *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Recipients     *map[uuid.UUID]DiagnosticRecipient  `json:"recipients,omitempty"`
+	Result         *string                             `json:"result,omitempty"`
+	Stats          *map[string]int                     `json:"stats,omitempty"`
+	SubscriptionId *string                             `json:"subscriptionId,omitempty"`
+}
+
+type DiagnosticRecipient struct {
+	Recipient *DiagnosticIdentity `json:"recipient,omitempty"`
+	Status    *string             `json:"status,omitempty"`
+}
+
+type EmailHtmlSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+type EmailPlaintextSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+// Describes the subscription evaluation operation status.
+type EvaluationOperationStatus string
+
+type evaluationOperationStatusValuesType struct {
+	NotSet     EvaluationOperationStatus
+	Queued     EvaluationOperationStatus
+	InProgress EvaluationOperationStatus
+	Cancelled  EvaluationOperationStatus
+	Succeeded  EvaluationOperationStatus
+	Failed     EvaluationOperationStatus
+	TimedOut   EvaluationOperationStatus
+	NotFound   EvaluationOperationStatus
+}
+
+var EvaluationOperationStatusValues = evaluationOperationStatusValuesType{
+	// The operation object does not have the status set.
+	NotSet: "notSet",
+	// The operation has been queued.
+	Queued: "queued",
+	// The operation is in progress.
+	InProgress: "inProgress",
+	// The operation was cancelled by the user.
+	Cancelled: "cancelled",
+	// The operation completed successfully.
+	Succeeded: "succeeded",
+	// The operation completed with a failure.
+	Failed: "failed",
+	// The operation timed out.
+	TimedOut: "timedOut",
+	// The operation could not be found.
+	NotFound: "notFound",
+}
+
+type EventBacklogStatus struct {
+	CaptureTime             *azuredevops.Time `json:"captureTime,omitempty"`
+	JobId                   *uuid.UUID        `json:"jobId,omitempty"`
+	LastEventBatchStartTime *azuredevops.Time `json:"lastEventBatchStartTime,omitempty"`
+	LastEventProcessedTime  *azuredevops.Time `json:"lastEventProcessedTime,omitempty"`
+	LastJobBatchStartTime   *azuredevops.Time `json:"lastJobBatchStartTime,omitempty"`
+	LastJobProcessedTime    *azuredevops.Time `json:"lastJobProcessedTime,omitempty"`
+	OldestPendingEventTime  *azuredevops.Time `json:"oldestPendingEventTime,omitempty"`
+	Publisher               *string           `json:"publisher,omitempty"`
+	UnprocessedEvents       *int              `json:"unprocessedEvents,omitempty"`
+}
+
+type EventBatch struct {
+	EndTime             interface{}     `json:"endTime,omitempty"`
+	EventCounts         *map[string]int `json:"eventCounts,omitempty"`
+	EventIds            *string         `json:"eventIds,omitempty"`
+	NotificationCounts  *map[string]int `json:"notificationCounts,omitempty"`
+	PreProcessEndTime   interface{}     `json:"preProcessEndTime,omitempty"`
+	PreProcessStartTime interface{}     `json:"preProcessStartTime,omitempty"`
+	ProcessEndTime      interface{}     `json:"processEndTime,omitempty"`
+	ProcessStartTime    interface{}     `json:"processStartTime,omitempty"`
+	StartTime           interface{}     `json:"startTime,omitempty"`
+	SubscriptionCounts  *map[string]int `json:"subscriptionCounts,omitempty"`
+}
+
+type EventProcessingLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source         *uuid.UUID                 `json:"source,omitempty"`
+	StartTime      *azuredevops.Time          `json:"startTime,omitempty"`
+	Warnings       *int                       `json:"warnings,omitempty"`
+	Result         *string                    `json:"result,omitempty"`
+	Stats          *map[string]map[string]int `json:"stats,omitempty"`
+	Batches        *[]EventBatch              `json:"batches,omitempty"`
+	MatcherResults *[]MatcherResult           `json:"matcherResults,omitempty"`
+}
+
+// [Flags] Set of flags used to determine which set of information is retrieved when querying for event publishers
+type EventPublisherQueryFlags string
+
+type eventPublisherQueryFlagsValuesType struct {
+	None                  EventPublisherQueryFlags
+	IncludeRemoteServices EventPublisherQueryFlags
+}
+
+var EventPublisherQueryFlagsValues = eventPublisherQueryFlagsValuesType{
+	None: "none",
+	// Include event types from the remote services too
+	IncludeRemoteServices: "includeRemoteServices",
+}
+
+// Encapsulates events result properties. It defines the total number of events used and the number of matched events.
+type EventsEvaluationResult struct {
+	// Count of events evaluated.
+	Count *int `json:"count,omitempty"`
+	// Count of matched events.
+	MatchedCount *int `json:"matchedCount,omitempty"`
+}
+
+// A transform request specify the properties of a notification event to be transformed.
+type EventTransformRequest struct {
+	// Event payload.
+	EventPayload *string `json:"eventPayload,omitempty"`
+	// Event type.
+	EventType *string `json:"eventType,omitempty"`
+	// System inputs.
+	SystemInputs *map[string]string `json:"systemInputs,omitempty"`
+}
+
+// Result of transforming a notification event.
+type EventTransformResult struct {
+	// Transformed html content.
+	Content *string `json:"content,omitempty"`
+	// Calculated data.
+	Data interface{} `json:"data,omitempty"`
+	// Calculated system inputs.
+	SystemInputs *map[string]string `json:"systemInputs,omitempty"`
+}
+
+// [Flags] Set of flags used to determine which set of information is retrieved when querying for eventtypes
+type EventTypeQueryFlags string
+
+type eventTypeQueryFlagsValuesType struct {
+	None          EventTypeQueryFlags
+	IncludeFields EventTypeQueryFlags
+}
+
+var EventTypeQueryFlagsValues = eventTypeQueryFlagsValuesType{
+	None: "none",
+	// IncludeFields will include all fields and their types
+	IncludeFields: "includeFields",
+}
+
+type ExpressionFilter struct {
+	EventType *string                `json:"eventType,omitempty"`
+	Criteria  *ExpressionFilterModel `json:"criteria,omitempty"`
+	Type      *string                `json:"type,omitempty"`
+}
+
+// Subscription Filter Clause represents a single clause in a subscription filter e.g. If the subscription has the following criteria "Project Name = [Current Project] AND Assigned To = [Me] it will be represented as two Filter Clauses Clause 1: Index = 1, Logical Operator: NULL  , FieldName = 'Project Name', Operator = '=', Value = '[Current Project]' Clause 2: Index = 2, Logical Operator: 'AND' , FieldName = 'Assigned To' , Operator = '=', Value = '[Me]'
+type ExpressionFilterClause struct {
+	FieldName *string `json:"fieldName,omitempty"`
+	// The order in which this clause appeared in the filter query
+	Index *int `json:"index,omitempty"`
+	// Logical Operator 'AND', 'OR' or NULL (only for the first clause in the filter)
+	LogicalOperator *string `json:"logicalOperator,omitempty"`
+	Operator        *string `json:"operator,omitempty"`
+	Value           *string `json:"value,omitempty"`
+}
+
+// Represents a hierarchy of SubscritionFilterClauses that have been grouped together through either adding a group in the WebUI or using parethesis in the Subscription condition string
+type ExpressionFilterGroup struct {
+	// The index of the last FilterClause in this group
+	End *int `json:"end,omitempty"`
+	// Level of the group, since groups can be nested for each nested group the level will increase by 1
+	Level *int `json:"level,omitempty"`
+	// The index of the first FilterClause in this group
+	Start *int `json:"start,omitempty"`
+}
+
+type ExpressionFilterModel struct {
+	// Flat list of clauses in this subscription
+	Clauses *[]ExpressionFilterClause `json:"clauses,omitempty"`
+	// Grouping of clauses in the subscription
+	Groups *[]ExpressionFilterGroup `json:"groups,omitempty"`
+	// Max depth of the Subscription tree
+	MaxGroupLevel *int `json:"maxGroupLevel,omitempty"`
+}
+
+type FieldInputValues struct {
+	// The default value to use for this input
+	DefaultValue *string `json:"defaultValue,omitempty"`
+	// Errors encountered while computing dynamic values.
+	Error *forminput.InputValuesError `json:"error,omitempty"`
+	// The id of the input
+	InputId *string `json:"inputId,omitempty"`
+	// Should this input be disabled
+	IsDisabled *bool `json:"isDisabled,omitempty"`
+	// Should the value be restricted to one of the values in the PossibleValues (True) or are the values in PossibleValues just a suggestion (False)
+	IsLimitedToPossibleValues *bool `json:"isLimitedToPossibleValues,omitempty"`
+	// Should this input be made read-only
+	IsReadOnly *bool `json:"isReadOnly,omitempty"`
+	// Possible values that this input can take
+	PossibleValues *[]forminput.InputValue `json:"possibleValues,omitempty"`
+	Operators      *[]byte                 `json:"operators,omitempty"`
+}
+
+type FieldValuesQuery struct {
+	CurrentValues *map[string]string `json:"currentValues,omitempty"`
+	// Subscription containing information about the publisher/consumer and the current input values
+	Resource    interface{}         `json:"resource,omitempty"`
+	InputValues *[]FieldInputValues `json:"inputValues,omitempty"`
+	Scope       *string             `json:"scope,omitempty"`
+}
+
+type GeneratedNotification struct {
+	Recipients *[]DiagnosticIdentity `json:"recipients,omitempty"`
+}
+
+type GroupSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+// Abstraction interface for the diagnostic log.  Primarily for deserialization.
+type INotificationDiagnosticLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId *uuid.UUID `json:"activityId,omitempty"`
+	// Description of what subscription or notification job is being logged.
+	Description *string `json:"description,omitempty"`
+	// Time the log ended.
+	EndTime *azuredevops.Time `json:"endTime,omitempty"`
+	// Unique instance identifier.
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Type of information being logged.
+	LogType *string `json:"logType,omitempty"`
+	// List of log messages.
+	Messages *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	// Dictionary of log properties and settings for the job.
+	Properties *map[string]string `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source *uuid.UUID `json:"source,omitempty"`
+	// Time the log started.
+	StartTime *azuredevops.Time `json:"startTime,omitempty"`
+}
+
+type ISubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+type ISubscriptionFilter struct {
+	EventType *string `json:"eventType,omitempty"`
+	Type      *string `json:"type,omitempty"`
+}
+
+type MatcherResult struct {
+	Matcher *string                    `json:"matcher,omitempty"`
+	Stats   *map[string]map[string]int `json:"stats,omitempty"`
+}
+
+type MessageQueueSubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+type NotificationAdminSettings struct {
+	// The default group delivery preference for groups in this collection
+	DefaultGroupDeliveryPreference *DefaultGroupDeliveryPreference `json:"defaultGroupDeliveryPreference,omitempty"`
+}
+
+type NotificationAdminSettingsUpdateParameters struct {
+	DefaultGroupDeliveryPreference *DefaultGroupDeliveryPreference `json:"defaultGroupDeliveryPreference,omitempty"`
+}
+
+type NotificationBacklogStatus struct {
+	CaptureTime                    *azuredevops.Time `json:"captureTime,omitempty"`
+	Channel                        *string           `json:"channel,omitempty"`
+	JobId                          *uuid.UUID        `json:"jobId,omitempty"`
+	LastJobBatchStartTime          *azuredevops.Time `json:"lastJobBatchStartTime,omitempty"`
+	LastJobProcessedTime           *azuredevops.Time `json:"lastJobProcessedTime,omitempty"`
+	LastNotificationBatchStartTime *azuredevops.Time `json:"lastNotificationBatchStartTime,omitempty"`
+	LastNotificationProcessedTime  *azuredevops.Time `json:"lastNotificationProcessedTime,omitempty"`
+	OldestPendingNotificationTime  *azuredevops.Time `json:"oldestPendingNotificationTime,omitempty"`
+	Publisher                      *string           `json:"publisher,omitempty"`
+	// Null status is unprocessed
+	Status                   *string `json:"status,omitempty"`
+	UnprocessedNotifications *int    `json:"unprocessedNotifications,omitempty"`
+}
+
+type NotificationBatch struct {
+	EndTime                  interface{}               `json:"endTime,omitempty"`
+	NotificationCount        *int                      `json:"notificationCount,omitempty"`
+	NotificationIds          *string                   `json:"notificationIds,omitempty"`
+	ProblematicNotifications *[]DiagnosticNotification `json:"problematicNotifications,omitempty"`
+	StartTime                interface{}               `json:"startTime,omitempty"`
+}
+
+type NotificationDeliveryLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID                 `json:"source,omitempty"`
+	StartTime *azuredevops.Time          `json:"startTime,omitempty"`
+	Warnings  *int                       `json:"warnings,omitempty"`
+	Result    *string                    `json:"result,omitempty"`
+	Stats     *map[string]map[string]int `json:"stats,omitempty"`
+	Batches   *[]NotificationBatch       `json:"batches,omitempty"`
+}
+
+// Abstract base class for all of the diagnostic logs.
+type NotificationDiagnosticLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID        `json:"source,omitempty"`
+	StartTime *azuredevops.Time `json:"startTime,omitempty"`
+	Warnings  *int              `json:"warnings,omitempty"`
+}
+
+type NotificationDiagnosticLogMessage struct {
+	// Corresponds to .Net TraceLevel enumeration
+	Level   *int        `json:"level,omitempty"`
+	Message *string     `json:"message,omitempty"`
+	Time    interface{} `json:"time,omitempty"`
+}
+
+type NotificationEventBacklogStatus struct {
+	EventBacklogStatus        *[]EventBacklogStatus        `json:"eventBacklogStatus,omitempty"`
+	NotificationBacklogStatus *[]NotificationBacklogStatus `json:"notificationBacklogStatus,omitempty"`
+}
+
+// Encapsulates the properties of a filterable field. A filterable field is a field in an event that can used to filter notifications for a certain event type.
+type NotificationEventField struct {
+	// Gets or sets the type of this field.
+	FieldType *NotificationEventFieldType `json:"fieldType,omitempty"`
+	// Gets or sets the unique identifier of this field.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets the name of this field.
+	Name *string `json:"name,omitempty"`
+	// Gets or sets the path to the field in the event object. This path can be either Json Path or XPath, depending on if the event will be serialized into Json or XML
+	Path *string `json:"path,omitempty"`
+	// Gets or sets the scopes that this field supports. If not specified then the event type scopes apply.
+	SupportedScopes *[]string `json:"supportedScopes,omitempty"`
+}
+
+// Encapsulates the properties of a field type. It includes a unique id for the operator and a localized string for display name
+type NotificationEventFieldOperator struct {
+	// Gets or sets the display name of an operator
+	DisplayName *string `json:"displayName,omitempty"`
+	// Gets or sets the id of an operator
+	Id *string `json:"id,omitempty"`
+}
+
+// Encapsulates the properties of a field type. It describes the data type of a field, the operators it support and how to populate it in the UI
+type NotificationEventFieldType struct {
+	// Gets or sets the unique identifier of this field type.
+	Id                  *string               `json:"id,omitempty"`
+	OperatorConstraints *[]OperatorConstraint `json:"operatorConstraints,omitempty"`
+	// Gets or sets the list of operators that this type supports.
+	Operators             *[]NotificationEventFieldOperator `json:"operators,omitempty"`
+	SubscriptionFieldType *SubscriptionFieldType            `json:"subscriptionFieldType,omitempty"`
+	// Gets or sets the value definition of this field like the getValuesMethod and template to display in the UI
+	Value *ValueDefinition `json:"value,omitempty"`
+}
+
+// Encapsulates the properties of a notification event publisher.
+type NotificationEventPublisher struct {
+	Id                         *string                 `json:"id,omitempty"`
+	SubscriptionManagementInfo *SubscriptionManagement `json:"subscriptionManagementInfo,omitempty"`
+	Url                        *string                 `json:"url,omitempty"`
+}
+
+// Encapsulates the properties of an event role.  An event Role is used for role based subscription for example for a buildCompletedEvent, one role is request by field
+type NotificationEventRole struct {
+	// Gets or sets an Id for that role, this id is used by the event.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets the Name for that role, this name is used for UI display.
+	Name *string `json:"name,omitempty"`
+	// Gets or sets whether this role can be a group or just an individual user
+	SupportsGroups *bool `json:"supportsGroups,omitempty"`
+}
+
+// Encapsulates the properties of an event type. It defines the fields, that can be used for filtering, for that event type.
+type NotificationEventType struct {
+	Category *NotificationEventTypeCategory `json:"category,omitempty"`
+	// Gets or sets the color representing this event type. Example: rgb(128,245,211) or #fafafa
+	Color                      *string                            `json:"color,omitempty"`
+	CustomSubscriptionsAllowed *bool                              `json:"customSubscriptionsAllowed,omitempty"`
+	EventPublisher             *NotificationEventPublisher        `json:"eventPublisher,omitempty"`
+	Fields                     *map[string]NotificationEventField `json:"fields,omitempty"`
+	HasInitiator               *bool                              `json:"hasInitiator,omitempty"`
+	// Gets or sets the icon representing this event type. Can be a URL or a CSS class. Example: css://some-css-class
+	Icon *string `json:"icon,omitempty"`
+	// Gets or sets the unique identifier of this event definition.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets the name of this event definition.
+	Name  *string                  `json:"name,omitempty"`
+	Roles *[]NotificationEventRole `json:"roles,omitempty"`
+	// Gets or sets the scopes that this event type supports
+	SupportedScopes *[]string `json:"supportedScopes,omitempty"`
+	// Gets or sets the rest end point to get this event type details (fields, fields types)
+	Url *string `json:"url,omitempty"`
+}
+
+// Encapsulates the properties of a category. A category will be used by the UI to group event types
+type NotificationEventTypeCategory struct {
+	// Gets or sets the unique identifier of this category.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets the friendly name of this category.
+	Name *string `json:"name,omitempty"`
+}
+
+type NotificationJobDiagnosticLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID                 `json:"source,omitempty"`
+	StartTime *azuredevops.Time          `json:"startTime,omitempty"`
+	Warnings  *int                       `json:"warnings,omitempty"`
+	Result    *string                    `json:"result,omitempty"`
+	Stats     *map[string]map[string]int `json:"stats,omitempty"`
+}
+
+type NotificationOperation string
+
+type notificationOperationValuesType struct {
+	None               NotificationOperation
+	SuspendUnprocessed NotificationOperation
+}
+
+var NotificationOperationValues = notificationOperationValuesType{
+	None:               "none",
+	SuspendUnprocessed: "suspendUnprocessed",
+}
+
+type NotificationQueryCondition struct {
+	EventInitiator *uuid.UUID `json:"eventInitiator,omitempty"`
+	EventType      *string    `json:"eventType,omitempty"`
+	Subscriber     *uuid.UUID `json:"subscriber,omitempty"`
+	SubscriptionId *string    `json:"subscriptionId,omitempty"`
+}
+
+type NotificationReason struct {
+	NotificationReasonType *NotificationReasonType `json:"notificationReasonType,omitempty"`
+	TargetIdentities       *[]webapi.IdentityRef   `json:"targetIdentities,omitempty"`
+}
+
+type NotificationReasonType string
+
+type notificationReasonTypeValuesType struct {
+	Unknown                 NotificationReasonType
+	Follows                 NotificationReasonType
+	Personal                NotificationReasonType
+	PersonalAlias           NotificationReasonType
+	DirectMember            NotificationReasonType
+	IndirectMember          NotificationReasonType
+	GroupAlias              NotificationReasonType
+	SubscriptionAlias       NotificationReasonType
+	SingleRole              NotificationReasonType
+	DirectMemberGroupRole   NotificationReasonType
+	InDirectMemberGroupRole NotificationReasonType
+	AliasMemberGroupRole    NotificationReasonType
+}
+
+var NotificationReasonTypeValues = notificationReasonTypeValuesType{
+	Unknown:                 "unknown",
+	Follows:                 "follows",
+	Personal:                "personal",
+	PersonalAlias:           "personalAlias",
+	DirectMember:            "directMember",
+	IndirectMember:          "indirectMember",
+	GroupAlias:              "groupAlias",
+	SubscriptionAlias:       "subscriptionAlias",
+	SingleRole:              "singleRole",
+	DirectMemberGroupRole:   "directMemberGroupRole",
+	InDirectMemberGroupRole: "inDirectMemberGroupRole",
+	AliasMemberGroupRole:    "aliasMemberGroupRole",
+}
+
+// Encapsulates notifications result properties. It defines the number of notifications and the recipients of notifications.
+type NotificationsEvaluationResult struct {
+	// Count of generated notifications
+	Count *int `json:"count,omitempty"`
+}
+
+type NotificationStatistic struct {
+	Date     *azuredevops.Time          `json:"date,omitempty"`
+	HitCount *int                       `json:"hitCount,omitempty"`
+	Path     *string                    `json:"path,omitempty"`
+	Type     *NotificationStatisticType `json:"type,omitempty"`
+	User     *webapi.IdentityRef        `json:"user,omitempty"`
+}
+
+type NotificationStatisticsQuery struct {
+	Conditions *[]NotificationStatisticsQueryConditions `json:"conditions,omitempty"`
+}
+
+type NotificationStatisticsQueryConditions struct {
+	EndDate         *azuredevops.Time          `json:"endDate,omitempty"`
+	HitCountMinimum *int                       `json:"hitCountMinimum,omitempty"`
+	Path            *string                    `json:"path,omitempty"`
+	StartDate       *azuredevops.Time          `json:"startDate,omitempty"`
+	Type            *NotificationStatisticType `json:"type,omitempty"`
+	User            *webapi.IdentityRef        `json:"user,omitempty"`
+}
+
+type NotificationStatisticType string
+
+type notificationStatisticTypeValuesType struct {
+	NotificationBySubscription                             NotificationStatisticType
+	EventsByEventType                                      NotificationStatisticType
+	NotificationByEventType                                NotificationStatisticType
+	EventsByEventTypePerUser                               NotificationStatisticType
+	NotificationByEventTypePerUser                         NotificationStatisticType
+	Events                                                 NotificationStatisticType
+	Notifications                                          NotificationStatisticType
+	NotificationFailureBySubscription                      NotificationStatisticType
+	UnprocessedRangeStart                                  NotificationStatisticType
+	UnprocessedEventsByPublisher                           NotificationStatisticType
+	UnprocessedEventDelayByPublisher                       NotificationStatisticType
+	UnprocessedNotificationsByChannelByPublisher           NotificationStatisticType
+	UnprocessedNotificationDelayByChannelByPublisher       NotificationStatisticType
+	DelayRangeStart                                        NotificationStatisticType
+	TotalPipelineTime                                      NotificationStatisticType
+	NotificationPipelineTime                               NotificationStatisticType
+	EventPipelineTime                                      NotificationStatisticType
+	HourlyRangeStart                                       NotificationStatisticType
+	HourlyNotificationBySubscription                       NotificationStatisticType
+	HourlyEventsByEventTypePerUser                         NotificationStatisticType
+	HourlyEvents                                           NotificationStatisticType
+	HourlyNotifications                                    NotificationStatisticType
+	HourlyUnprocessedEventsByPublisher                     NotificationStatisticType
+	HourlyUnprocessedEventDelayByPublisher                 NotificationStatisticType
+	HourlyUnprocessedNotificationsByChannelByPublisher     NotificationStatisticType
+	HourlyUnprocessedNotificationDelayByChannelByPublisher NotificationStatisticType
+	HourlyTotalPipelineTime                                NotificationStatisticType
+	HourlyNotificationPipelineTime                         NotificationStatisticType
+	HourlyEventPipelineTime                                NotificationStatisticType
+}
+
+var NotificationStatisticTypeValues = notificationStatisticTypeValuesType{
+	NotificationBySubscription:                             "notificationBySubscription",
+	EventsByEventType:                                      "eventsByEventType",
+	NotificationByEventType:                                "notificationByEventType",
+	EventsByEventTypePerUser:                               "eventsByEventTypePerUser",
+	NotificationByEventTypePerUser:                         "notificationByEventTypePerUser",
+	Events:                                                 "events",
+	Notifications:                                          "notifications",
+	NotificationFailureBySubscription:                      "notificationFailureBySubscription",
+	UnprocessedRangeStart:                                  "unprocessedRangeStart",
+	UnprocessedEventsByPublisher:                           "unprocessedEventsByPublisher",
+	UnprocessedEventDelayByPublisher:                       "unprocessedEventDelayByPublisher",
+	UnprocessedNotificationsByChannelByPublisher:           "unprocessedNotificationsByChannelByPublisher",
+	UnprocessedNotificationDelayByChannelByPublisher:       "unprocessedNotificationDelayByChannelByPublisher",
+	DelayRangeStart:                                        "delayRangeStart",
+	TotalPipelineTime:                                      "totalPipelineTime",
+	NotificationPipelineTime:                               "notificationPipelineTime",
+	EventPipelineTime:                                      "eventPipelineTime",
+	HourlyRangeStart:                                       "hourlyRangeStart",
+	HourlyNotificationBySubscription:                       "hourlyNotificationBySubscription",
+	HourlyEventsByEventTypePerUser:                         "hourlyEventsByEventTypePerUser",
+	HourlyEvents:                                           "hourlyEvents",
+	HourlyNotifications:                                    "hourlyNotifications",
+	HourlyUnprocessedEventsByPublisher:                     "hourlyUnprocessedEventsByPublisher",
+	HourlyUnprocessedEventDelayByPublisher:                 "hourlyUnprocessedEventDelayByPublisher",
+	HourlyUnprocessedNotificationsByChannelByPublisher:     "hourlyUnprocessedNotificationsByChannelByPublisher",
+	HourlyUnprocessedNotificationDelayByChannelByPublisher: "hourlyUnprocessedNotificationDelayByChannelByPublisher",
+	HourlyTotalPipelineTime:                                "hourlyTotalPipelineTime",
+	HourlyNotificationPipelineTime:                         "hourlyNotificationPipelineTime",
+	HourlyEventPipelineTime:                                "hourlyEventPipelineTime",
+}
+
+// A subscriber is a user or group that has the potential to receive notifications.
+type NotificationSubscriber struct {
+	// Indicates how the subscriber should be notified by default.
+	DeliveryPreference *NotificationSubscriberDeliveryPreference `json:"deliveryPreference,omitempty"`
+	Flags              *SubscriberFlags                          `json:"flags,omitempty"`
+	// Identifier of the subscriber.
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Preferred email address of the subscriber. A null or empty value indicates no preferred email address has been set.
+	PreferredEmailAddress *string `json:"preferredEmailAddress,omitempty"`
+}
+
+// Delivery preference for a subscriber. Indicates how the subscriber should be notified.
+type NotificationSubscriberDeliveryPreference string
+
+type notificationSubscriberDeliveryPreferenceValuesType struct {
+	NoDelivery            NotificationSubscriberDeliveryPreference
+	PreferredEmailAddress NotificationSubscriberDeliveryPreference
+	EachMember            NotificationSubscriberDeliveryPreference
+	UseDefault            NotificationSubscriberDeliveryPreference
+}
+
+var NotificationSubscriberDeliveryPreferenceValues = notificationSubscriberDeliveryPreferenceValuesType{
+	// Do not send notifications by default. Note: notifications can still be delivered to this subscriber, for example via a custom subscription.
+	NoDelivery: "noDelivery",
+	// Deliver notifications to the subscriber's preferred email address.
+	PreferredEmailAddress: "preferredEmailAddress",
+	// Deliver notifications to each member of the group representing the subscriber. Only applicable when the subscriber is a group.
+	EachMember: "eachMember",
+	// Use default
+	UseDefault: "useDefault",
+}
+
+// Updates to a subscriber. Typically used to change (or set) a preferred email address or default delivery preference.
+type NotificationSubscriberUpdateParameters struct {
+	// New delivery preference for the subscriber (indicates how the subscriber should be notified).
+	DeliveryPreference *NotificationSubscriberDeliveryPreference `json:"deliveryPreference,omitempty"`
+	// New preferred email address for the subscriber. Specify an empty string to clear the current address.
+	PreferredEmailAddress *string `json:"preferredEmailAddress,omitempty"`
+}
+
+// A subscription defines criteria for matching events and how the subscription's subscriber should be notified about those events.
+type NotificationSubscription struct {
+	// Links to related resources, APIs, and views for the subscription.
+	Links interface{} `json:"_links,omitempty"`
+	// Admin-managed settings for the subscription. Only applies when the subscriber is a group.
+	AdminSettings *SubscriptionAdminSettings `json:"adminSettings,omitempty"`
+	// Channel for delivering notifications triggered by the subscription.
+	Channel *ISubscriptionChannel `json:"channel,omitempty"`
+	// Description of the subscription. Typically describes filter criteria which helps identity the subscription.
+	Description *string `json:"description,omitempty"`
+	// Diagnostics for this subscription.
+	Diagnostics *SubscriptionDiagnostics `json:"diagnostics,omitempty"`
+	// Any extra properties like detailed description for different contexts, user/group contexts
+	ExtendedProperties *map[string]string `json:"extendedProperties,omitempty"`
+	// Matching criteria for the subscription. ExpressionFilter
+	Filter *ISubscriptionFilter `json:"filter,omitempty"`
+	// Read-only indicators that further describe the subscription.
+	Flags *SubscriptionFlags `json:"flags,omitempty"`
+	// Subscription identifier.
+	Id *string `json:"id,omitempty"`
+	// User that last modified (or created) the subscription.
+	LastModifiedBy *webapi.IdentityRef `json:"lastModifiedBy,omitempty"`
+	// Date when the subscription was last modified. If the subscription has not been updated since it was created, this value will indicate when the subscription was created.
+	ModifiedDate *azuredevops.Time `json:"modifiedDate,omitempty"`
+	// The permissions the user have for this subscriptions.
+	Permissions *SubscriptionPermissions `json:"permissions,omitempty"`
+	// The container in which events must be published from in order to be matched by the subscription. If empty, the scope is the current host (typically an account or project collection). For example, a subscription scoped to project A will not produce notifications for events published from project B.
+	Scope *SubscriptionScope `json:"scope,omitempty"`
+	// Status of the subscription. Typically indicates whether the subscription is enabled or not.
+	Status *SubscriptionStatus `json:"status,omitempty"`
+	// Message that provides more details about the status of the subscription.
+	StatusMessage *string `json:"statusMessage,omitempty"`
+	// User or group that will receive notifications for events matching the subscription's filter criteria.
+	Subscriber *webapi.IdentityRef `json:"subscriber,omitempty"`
+	// REST API URL of the subscriotion.
+	Url *string `json:"url,omitempty"`
+	// User-managed settings for the subscription. Only applies when the subscriber is a group. Typically used to indicate whether the calling user is opted in or out of a group subscription.
+	UserSettings *SubscriptionUserSettings `json:"userSettings,omitempty"`
+}
+
+// Parameters for creating a new subscription. A subscription defines criteria for matching events and how the subscription's subscriber should be notified about those events.
+type NotificationSubscriptionCreateParameters struct {
+	// Channel for delivering notifications triggered by the new subscription.
+	Channel *ISubscriptionChannel `json:"channel,omitempty"`
+	// Brief description for the new subscription. Typically describes filter criteria which helps identity the subscription.
+	Description *string `json:"description,omitempty"`
+	// Matching criteria for the new subscription. ExpressionFilter
+	Filter *ISubscriptionFilter `json:"filter,omitempty"`
+	// The container in which events must be published from in order to be matched by the new subscription. If not specified, defaults to the current host (typically an account or project collection). For example, a subscription scoped to project A will not produce notifications for events published from project B.
+	Scope *SubscriptionScope `json:"scope,omitempty"`
+	// User or group that will receive notifications for events matching the subscription's filter criteria. If not specified, defaults to the calling user.
+	Subscriber *webapi.IdentityRef `json:"subscriber,omitempty"`
+}
+
+type NotificationSubscriptionTemplate struct {
+	Description                  *string                   `json:"description,omitempty"`
+	Filter                       *ISubscriptionFilter      `json:"filter,omitempty"`
+	Id                           *string                   `json:"id,omitempty"`
+	NotificationEventInformation *NotificationEventType    `json:"notificationEventInformation,omitempty"`
+	Type                         *SubscriptionTemplateType `json:"type,omitempty"`
+}
+
+// Parameters for updating an existing subscription. A subscription defines criteria for matching events and how the subscription's subscriber should be notified about those events. Note: only the fields to be updated should be set.
+type NotificationSubscriptionUpdateParameters struct {
+	// Admin-managed settings for the subscription. Only applies to subscriptions where the subscriber is a group.
+	AdminSettings *SubscriptionAdminSettings `json:"adminSettings,omitempty"`
+	// Channel for delivering notifications triggered by the subscription.
+	Channel *ISubscriptionChannel `json:"channel,omitempty"`
+	// Updated description for the subscription. Typically describes filter criteria which helps identity the subscription.
+	Description *string `json:"description,omitempty"`
+	// Matching criteria for the subscription. ExpressionFilter
+	Filter *ISubscriptionFilter `json:"filter,omitempty"`
+	// The container in which events must be published from in order to be matched by the new subscription. If not specified, defaults to the current host (typically the current account or project collection). For example, a subscription scoped to project A will not produce notifications for events published from project B.
+	Scope *SubscriptionScope `json:"scope,omitempty"`
+	// Updated status for the subscription. Typically used to enable or disable a subscription.
+	Status *SubscriptionStatus `json:"status,omitempty"`
+	// Optional message that provides more details about the updated status.
+	StatusMessage *string `json:"statusMessage,omitempty"`
+	// User-managed settings for the subscription. Only applies to subscriptions where the subscriber is a group. Typically used to opt-in or opt-out a user from a group subscription.
+	UserSettings *SubscriptionUserSettings `json:"userSettings,omitempty"`
+}
+
+// Encapsulates the properties of an operator constraint. An operator constraint defines if some operator is available only for specific scope like a project scope.
+type OperatorConstraint struct {
+	Operator *string `json:"operator,omitempty"`
+	// Gets or sets the list of scopes that this type supports.
+	SupportedScopes *[]string `json:"supportedScopes,omitempty"`
+}
+
+type ProcessedEvent struct {
+	// All of the users that were associated with this event and their role.
+	Actors             *[]webapi.EventActor  `json:"actors,omitempty"`
+	AllowedChannels    *string               `json:"allowedChannels,omitempty"`
+	ArtifactUri        *string               `json:"artifactUri,omitempty"`
+	DeliveryIdentities *ProcessingIdentities `json:"deliveryIdentities,omitempty"`
+	// Evaluations for each user
+	Evaluations *map[uuid.UUID]SubscriptionEvaluation `json:"evaluations,omitempty"`
+	EventId     *int                                  `json:"eventId,omitempty"`
+	// Which members were excluded from evaluation (only applies to ActorMatcher subscriptions)
+	Exclusions *[]webapi.EventActor `json:"exclusions,omitempty"`
+	// Which members were included for evaluation (only applies to ActorMatcher subscriptions)
+	Inclusions    *[]webapi.EventActor     `json:"inclusions,omitempty"`
+	Notifications *[]GeneratedNotification `json:"notifications,omitempty"`
+}
+
+type ProcessingDiagnosticIdentity struct {
+	DisplayName        *string    `json:"displayName,omitempty"`
+	EmailAddress       *string    `json:"emailAddress,omitempty"`
+	Id                 *uuid.UUID `json:"id,omitempty"`
+	DeliveryPreference *string    `json:"deliveryPreference,omitempty"`
+	IsActive           *bool      `json:"isActive,omitempty"`
+	IsGroup            *bool      `json:"isGroup,omitempty"`
+	Message            *string    `json:"message,omitempty"`
+}
+
+type ProcessingIdentities struct {
+	ExcludedIdentities *map[uuid.UUID]ProcessingDiagnosticIdentity `json:"excludedIdentities,omitempty"`
+	IncludedIdentities *map[uuid.UUID]ProcessingDiagnosticIdentity `json:"includedIdentities,omitempty"`
+	Messages           *[]NotificationDiagnosticLogMessage         `json:"messages,omitempty"`
+	MissingIdentities  *[]uuid.UUID                                `json:"missingIdentities,omitempty"`
+	Properties         *map[string]string                          `json:"properties,omitempty"`
+}
+
+type RoleBasedFilter struct {
+	EventType  *string                `json:"eventType,omitempty"`
+	Criteria   *ExpressionFilterModel `json:"criteria,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+	Exclusions *[]string              `json:"exclusions,omitempty"`
+	Inclusions *[]string              `json:"inclusions,omitempty"`
+}
+
+type ServiceBusSubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+type ServiceHooksSubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+type SoapSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+// [Flags]
+type SubscriberFlags string
+
+type subscriberFlagsValuesType struct {
+	None                                  SubscriberFlags
+	DeliveryPreferencesEditable           SubscriberFlags
+	SupportsPreferredEmailAddressDelivery SubscriberFlags
+	SupportsEachMemberDelivery            SubscriberFlags
+	SupportsNoDelivery                    SubscriberFlags
+	IsUser                                SubscriberFlags
+	IsGroup                               SubscriberFlags
+	IsTeam                                SubscriberFlags
+}
+
+var SubscriberFlagsValues = subscriberFlagsValuesType{
+	None: "none",
+	// Subscriber's delivery preferences could be updated
+	DeliveryPreferencesEditable: "deliveryPreferencesEditable",
+	// Subscriber's delivery preferences supports email delivery
+	SupportsPreferredEmailAddressDelivery: "supportsPreferredEmailAddressDelivery",
+	// Subscriber's delivery preferences supports individual members delivery(group expansion)
+	SupportsEachMemberDelivery: "supportsEachMemberDelivery",
+	// Subscriber's delivery preferences supports no delivery
+	SupportsNoDelivery: "supportsNoDelivery",
+	// Subscriber is a user
+	IsUser: "isUser",
+	// Subscriber is a group
+	IsGroup: "isGroup",
+	// Subscriber is a team
+	IsTeam: "isTeam",
+}
+
+// Admin-managed settings for a group subscription.
+type SubscriptionAdminSettings struct {
+	// If true, members of the group subscribed to the associated subscription cannot opt (choose not to get notified)
+	BlockUserOptOut *bool `json:"blockUserOptOut,omitempty"`
+}
+
+type SubscriptionChannelWithAddress struct {
+	Address          *string `json:"address,omitempty"`
+	Type             *string `json:"type,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+}
+
+// Contains all the diagnostics settings for a subscription.
+type SubscriptionDiagnostics struct {
+	// Diagnostics settings for retaining delivery results.  Used for Service Hooks subscriptions.
+	DeliveryResults *SubscriptionTracing `json:"deliveryResults,omitempty"`
+	// Diagnostics settings for troubleshooting notification delivery.
+	DeliveryTracing *SubscriptionTracing `json:"deliveryTracing,omitempty"`
+	// Diagnostics settings for troubleshooting event matching.
+	EvaluationTracing *SubscriptionTracing `json:"evaluationTracing,omitempty"`
+}
+
+type SubscriptionEvaluation struct {
+	Clauses *[]SubscriptionEvaluationClause `json:"clauses,omitempty"`
+	User    *DiagnosticIdentity             `json:"user,omitempty"`
+}
+
+type SubscriptionEvaluationClause struct {
+	Clause *string `json:"clause,omitempty"`
+	Order  *int    `json:"order,omitempty"`
+	Result *bool   `json:"result,omitempty"`
+}
+
+// Encapsulates the properties of a SubscriptionEvaluationRequest. It defines the subscription to be evaluated and time interval for events used in evaluation.
+type SubscriptionEvaluationRequest struct {
+	// The min created date for the events used for matching in UTC. Use all events created since this date
+	MinEventsCreatedDate *azuredevops.Time `json:"minEventsCreatedDate,omitempty"`
+	// User or group that will receive notifications for events matching the subscription's filter criteria. If not specified, defaults to the calling user.
+	SubscriptionCreateParameters *NotificationSubscriptionCreateParameters `json:"subscriptionCreateParameters,omitempty"`
+}
+
+// Encapsulates the subscription evaluation results. It defines the Date Interval that was used, number of events evaluated and events and notifications results
+type SubscriptionEvaluationResult struct {
+	// Subscription evaluation job status
+	EvaluationJobStatus *EvaluationOperationStatus `json:"evaluationJobStatus,omitempty"`
+	// Subscription evaluation events results.
+	Events *EventsEvaluationResult `json:"events,omitempty"`
+	// The requestId which is the subscription evaluation jobId
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Subscription evaluation  notification results.
+	Notifications *NotificationsEvaluationResult `json:"notifications,omitempty"`
+}
+
+// Encapsulates the subscription evaluation settings needed for the UI
+type SubscriptionEvaluationSettings struct {
+	// Indicates whether subscription evaluation before saving is enabled or not
+	Enabled *bool `json:"enabled,omitempty"`
+	// Time interval to check on subscription evaluation job in seconds
+	Interval *int `json:"interval,omitempty"`
+	// Threshold on the number of notifications for considering a subscription too noisy
+	Threshold *int `json:"threshold,omitempty"`
+	// Time out for the subscription evaluation check in seconds
+	TimeOut *int `json:"timeOut,omitempty"`
+}
+
+type SubscriptionFieldType string
+
+type subscriptionFieldTypeValuesType struct {
+	String          SubscriptionFieldType
+	Integer         SubscriptionFieldType
+	DateTime        SubscriptionFieldType
+	PlainText       SubscriptionFieldType
+	Html            SubscriptionFieldType
+	TreePath        SubscriptionFieldType
+	History         SubscriptionFieldType
+	Double          SubscriptionFieldType
+	Guid            SubscriptionFieldType
+	Boolean         SubscriptionFieldType
+	Identity        SubscriptionFieldType
+	PicklistInteger SubscriptionFieldType
+	PicklistString  SubscriptionFieldType
+	PicklistDouble  SubscriptionFieldType
+	TeamProject     SubscriptionFieldType
+}
+
+var SubscriptionFieldTypeValues = subscriptionFieldTypeValuesType{
+	String:          "string",
+	Integer:         "integer",
+	DateTime:        "dateTime",
+	PlainText:       "plainText",
+	Html:            "html",
+	TreePath:        "treePath",
+	History:         "history",
+	Double:          "double",
+	Guid:            "guid",
+	Boolean:         "boolean",
+	Identity:        "identity",
+	PicklistInteger: "picklistInteger",
+	PicklistString:  "picklistString",
+	PicklistDouble:  "picklistDouble",
+	TeamProject:     "teamProject",
+}
+
+// [Flags] Read-only indicators that further describe the subscription.
+type SubscriptionFlags string
+
+type subscriptionFlagsValuesType struct {
+	None                    SubscriptionFlags
+	GroupSubscription       SubscriptionFlags
+	ContributedSubscription SubscriptionFlags
+	CanOptOut               SubscriptionFlags
+	TeamSubscription        SubscriptionFlags
+	OneActorMatches         SubscriptionFlags
+}
+
+var SubscriptionFlagsValues = subscriptionFlagsValuesType{
+	// None
+	None: "none",
+	// Subscription's subscriber is a group, not a user
+	GroupSubscription: "groupSubscription",
+	// Subscription is contributed and not persisted. This means certain fields of the subscription, like Filter, are read-only.
+	ContributedSubscription: "contributedSubscription",
+	// A user that is member of the subscription's subscriber group can opt in/out of the subscription.
+	CanOptOut: "canOptOut",
+	// If the subscriber is a group, is it a team.
+	TeamSubscription: "teamSubscription",
+	// For role based subscriptions, there is an expectation that there will always be at least one actor that matches
+	OneActorMatches: "oneActorMatches",
+}
+
+// Encapsulates the properties needed to manage subscriptions, opt in and out of subscriptions.
+type SubscriptionManagement struct {
+	ServiceInstanceType *uuid.UUID `json:"serviceInstanceType,omitempty"`
+	Url                 *string    `json:"url,omitempty"`
+}
+
+// [Flags] The permissions that a user has to a certain subscription
+type SubscriptionPermissions string
+
+type subscriptionPermissionsValuesType struct {
+	None   SubscriptionPermissions
+	View   SubscriptionPermissions
+	Edit   SubscriptionPermissions
+	Delete SubscriptionPermissions
+}
+
+var SubscriptionPermissionsValues = subscriptionPermissionsValuesType{
+	// None
+	None: "none",
+	// full view of description, filters, etc. Not limited.
+	View: "view",
+	// update subscription
+	Edit: "edit",
+	// delete subscription
+	Delete: "delete",
+}
+
+// Notification subscriptions query input.
+type SubscriptionQuery struct {
+	// One or more conditions to query on. If more than 2 conditions are specified, the combined results of each condition is returned (i.e. conditions are logically OR'ed).
+	Conditions *[]SubscriptionQueryCondition `json:"conditions,omitempty"`
+	// Flags the refine the types of subscriptions that will be returned from the query.
+	QueryFlags *SubscriptionQueryFlags `json:"queryFlags,omitempty"`
+}
+
+// Conditions a subscription must match to qualify for the query result set. Not all fields are required. A subscription must match all conditions specified in order to qualify for the result set.
+type SubscriptionQueryCondition struct {
+	// Filter conditions that matching subscriptions must have. Typically only the filter's type and event type are used for matching.
+	Filter *ISubscriptionFilter `json:"filter,omitempty"`
+	// Flags to specify the the type subscriptions to query for.
+	Flags *SubscriptionFlags `json:"flags,omitempty"`
+	// Scope that matching subscriptions must have.
+	Scope *string `json:"scope,omitempty"`
+	// ID of the subscriber (user or group) that matching subscriptions must be subscribed to.
+	SubscriberId *uuid.UUID `json:"subscriberId,omitempty"`
+	// ID of the subscription to query for.
+	SubscriptionId *string `json:"subscriptionId,omitempty"`
+}
+
+// [Flags] Flags that influence the result set of a subscription query.
+type SubscriptionQueryFlags string
+
+type subscriptionQueryFlagsValuesType struct {
+	None                         SubscriptionQueryFlags
+	IncludeInvalidSubscriptions  SubscriptionQueryFlags
+	IncludeDeletedSubscriptions  SubscriptionQueryFlags
+	IncludeFilterDetails         SubscriptionQueryFlags
+	AlwaysReturnBasicInformation SubscriptionQueryFlags
+	IncludeSystemSubscriptions   SubscriptionQueryFlags
+}
+
+var SubscriptionQueryFlagsValues = subscriptionQueryFlagsValuesType{
+	None: "none",
+	// Include subscriptions with invalid subscribers.
+	IncludeInvalidSubscriptions: "includeInvalidSubscriptions",
+	// Include subscriptions marked for deletion.
+	IncludeDeletedSubscriptions: "includeDeletedSubscriptions",
+	// Include the full filter details with each subscription.
+	IncludeFilterDetails: "includeFilterDetails",
+	// For a subscription the caller does not have permission to view, return basic (non-confidential) information.
+	AlwaysReturnBasicInformation: "alwaysReturnBasicInformation",
+	// Include system subscriptions.
+	IncludeSystemSubscriptions: "includeSystemSubscriptions",
+}
+
+// A resource, typically an account or project, in which events are published from.
+type SubscriptionScope struct {
+	// Required: This is the identity of the scope for the type.
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Optional: The display name of the scope
+	Name *string `json:"name,omitempty"`
+	// Required: The event specific type of a scope.
+	Type *string `json:"type,omitempty"`
+}
+
+// Subscription status values. A value greater than or equal to zero indicates the subscription is enabled. A negative value indicates the subscription is disabled.
+type SubscriptionStatus string
+
+type subscriptionStatusValuesType struct {
+	JailedByNotificationsVolume      SubscriptionStatus
+	PendingDeletion                  SubscriptionStatus
+	DisabledArgumentException        SubscriptionStatus
+	DisabledProjectInvalid           SubscriptionStatus
+	DisabledMissingPermissions       SubscriptionStatus
+	DisabledFromProbation            SubscriptionStatus
+	DisabledInactiveIdentity         SubscriptionStatus
+	DisabledMessageQueueNotSupported SubscriptionStatus
+	DisabledMissingIdentity          SubscriptionStatus
+	DisabledInvalidRoleExpression    SubscriptionStatus
+	DisabledInvalidPathClause        SubscriptionStatus
+	DisabledAsDuplicateOfDefault     SubscriptionStatus
+	DisabledByAdmin                  SubscriptionStatus
+	Disabled                         SubscriptionStatus
+	Enabled                          SubscriptionStatus
+	EnabledOnProbation               SubscriptionStatus
+}
+
+var SubscriptionStatusValues = subscriptionStatusValuesType{
+	// Subscription is disabled because it generated a high volume of notifications.
+	JailedByNotificationsVolume: "jailedByNotificationsVolume",
+	// Subscription is disabled and will be deleted.
+	PendingDeletion: "pendingDeletion",
+	// Subscription is disabled because of an Argument Exception while processing the subscription
+	DisabledArgumentException: "disabledArgumentException",
+	// Subscription is disabled because the project is invalid
+	DisabledProjectInvalid: "disabledProjectInvalid",
+	// Subscription is disabled because the identity does not have the appropriate permissions
+	DisabledMissingPermissions: "disabledMissingPermissions",
+	// Subscription is disabled service due to failures.
+	DisabledFromProbation: "disabledFromProbation",
+	// Subscription is disabled because the identity is no longer active
+	DisabledInactiveIdentity: "disabledInactiveIdentity",
+	// Subscription is disabled because message queue is not supported.
+	DisabledMessageQueueNotSupported: "disabledMessageQueueNotSupported",
+	// Subscription is disabled because its subscriber is unknown.
+	DisabledMissingIdentity: "disabledMissingIdentity",
+	// Subscription is disabled because it has an invalid role expression.
+	DisabledInvalidRoleExpression: "disabledInvalidRoleExpression",
+	// Subscription is disabled because it has an invalid filter expression.
+	DisabledInvalidPathClause: "disabledInvalidPathClause",
+	// Subscription is disabled because it is a duplicate of a default subscription.
+	DisabledAsDuplicateOfDefault: "disabledAsDuplicateOfDefault",
+	// Subscription is disabled by an administrator, not the subscription's subscriber.
+	DisabledByAdmin: "disabledByAdmin",
+	// Subscription is disabled, typically by the owner of the subscription, and will not produce any notifications.
+	Disabled: "disabled",
+	// Subscription is active.
+	Enabled: "enabled",
+	// Subscription is active, but is on probation due to failed deliveries or other issues with the subscription.
+	EnabledOnProbation: "enabledOnProbation",
+}
+
+// [Flags] Set of flags used to determine which set of templates is retrieved when querying for subscription templates
+type SubscriptionTemplateQueryFlags string
+
+type subscriptionTemplateQueryFlagsValuesType struct {
+	None                        SubscriptionTemplateQueryFlags
+	IncludeUser                 SubscriptionTemplateQueryFlags
+	IncludeGroup                SubscriptionTemplateQueryFlags
+	IncludeUserAndGroup         SubscriptionTemplateQueryFlags
+	IncludeEventTypeInformation SubscriptionTemplateQueryFlags
+}
+
+var SubscriptionTemplateQueryFlagsValues = subscriptionTemplateQueryFlagsValuesType{
+	None: "none",
+	// Include user templates
+	IncludeUser: "includeUser",
+	// Include group templates
+	IncludeGroup: "includeGroup",
+	// Include user and group templates
+	IncludeUserAndGroup: "includeUserAndGroup",
+	// Include the event type details like the fields and operators
+	IncludeEventTypeInformation: "includeEventTypeInformation",
+}
+
+type SubscriptionTemplateType string
+
+type subscriptionTemplateTypeValuesType struct {
+	User SubscriptionTemplateType
+	Team SubscriptionTemplateType
+	Both SubscriptionTemplateType
+	None SubscriptionTemplateType
+}
+
+var SubscriptionTemplateTypeValues = subscriptionTemplateTypeValuesType{
+	User: "user",
+	Team: "team",
+	Both: "both",
+	None: "none",
+}
+
+type SubscriptionTraceDiagnosticLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID        `json:"source,omitempty"`
+	StartTime *azuredevops.Time `json:"startTime,omitempty"`
+	Warnings  *int              `json:"warnings,omitempty"`
+	// Indicates the job Id that processed or delivered this subscription
+	JobId *uuid.UUID `json:"jobId,omitempty"`
+	// Indicates unique instance identifier for the job that processed or delivered this subscription
+	JobInstanceId  *uuid.UUID `json:"jobInstanceId,omitempty"`
+	SubscriptionId *string    `json:"subscriptionId,omitempty"`
+}
+
+type SubscriptionTraceEventProcessingLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID        `json:"source,omitempty"`
+	StartTime *azuredevops.Time `json:"startTime,omitempty"`
+	Warnings  *int              `json:"warnings,omitempty"`
+	// Indicates the job Id that processed or delivered this subscription
+	JobId *uuid.UUID `json:"jobId,omitempty"`
+	// Indicates unique instance identifier for the job that processed or delivered this subscription
+	JobInstanceId        *uuid.UUID            `json:"jobInstanceId,omitempty"`
+	SubscriptionId       *string               `json:"subscriptionId,omitempty"`
+	Channel              *string               `json:"channel,omitempty"`
+	EvaluationIdentities *ProcessingIdentities `json:"evaluationIdentities,omitempty"`
+	// Which members opted out from receiving notifications from this subscription
+	OptedOut        *[]DiagnosticIdentity   `json:"optedOut,omitempty"`
+	ProcessedEvents *map[int]ProcessedEvent `json:"processedEvents,omitempty"`
+}
+
+type SubscriptionTraceNotificationDeliveryLog struct {
+	// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+	ActivityId  *uuid.UUID        `json:"activityId,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	EndTime     *azuredevops.Time `json:"endTime,omitempty"`
+	Errors      *int              `json:"errors,omitempty"`
+	// Unique instance identifier.
+	Id         *uuid.UUID                          `json:"id,omitempty"`
+	LogType    *string                             `json:"logType,omitempty"`
+	Messages   *[]NotificationDiagnosticLogMessage `json:"messages,omitempty"`
+	Properties *map[string]string                  `json:"properties,omitempty"`
+	// This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+	Source    *uuid.UUID        `json:"source,omitempty"`
+	StartTime *azuredevops.Time `json:"startTime,omitempty"`
+	Warnings  *int              `json:"warnings,omitempty"`
+	// Indicates the job Id that processed or delivered this subscription
+	JobId *uuid.UUID `json:"jobId,omitempty"`
+	// Indicates unique instance identifier for the job that processed or delivered this subscription
+	JobInstanceId  *uuid.UUID                `json:"jobInstanceId,omitempty"`
+	SubscriptionId *string                   `json:"subscriptionId,omitempty"`
+	Notifications  *[]DiagnosticNotification `json:"notifications,omitempty"`
+}
+
+// Data controlling a single diagnostic setting for a subscription.
+type SubscriptionTracing struct {
+	// Indicates whether the diagnostic tracing is enabled or not.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Trace until the specified end date.
+	EndDate *azuredevops.Time `json:"endDate,omitempty"`
+	// The maximum number of result details to trace.
+	MaxTracedEntries *int `json:"maxTracedEntries,omitempty"`
+	// The date and time tracing started.
+	StartDate *azuredevops.Time `json:"startDate,omitempty"`
+	// Trace until remaining count reaches 0.
+	TracedEntries *int `json:"tracedEntries,omitempty"`
+}
+
+// User-managed settings for a group subscription.
+type SubscriptionUserSettings struct {
+	// Indicates whether the user will receive notifications for the associated group subscription.
+	OptedOut *bool `json:"optedOut,omitempty"`
+}
+
+type UnsupportedFilter struct {
+	EventType *string `json:"eventType,omitempty"`
+	Type      *string `json:"type,omitempty"`
+}
+
+type UnsupportedSubscriptionChannel struct {
+	Type *string `json:"type,omitempty"`
+}
+
+// Parameters to update diagnostics settings for a subscription.
+type UpdateSubscripitonDiagnosticsParameters struct {
+	// Diagnostics settings for retaining delivery results.  Used for Service Hooks subscriptions.
+	DeliveryResults *UpdateSubscripitonTracingParameters `json:"deliveryResults,omitempty"`
+	// Diagnostics settings for troubleshooting notification delivery.
+	DeliveryTracing *UpdateSubscripitonTracingParameters `json:"deliveryTracing,omitempty"`
+	// Diagnostics settings for troubleshooting event matching.
+	EvaluationTracing *UpdateSubscripitonTracingParameters `json:"evaluationTracing,omitempty"`
+}
+
+// Parameters to update a specific diagnostic setting.
+type UpdateSubscripitonTracingParameters struct {
+	// Indicates whether to enable to disable the diagnostic tracing.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type UserSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+type UserSystemSubscriptionChannel struct {
+	Address          *string `json:"address,omitempty"`
+	UseCustomAddress *bool   `json:"useCustomAddress,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+// Encapsulates the properties of a field value definition. It has the information needed to retrieve the list of possible values for a certain field and how to handle that field values in the UI. This information includes what type of object this value represents, which property to use for UI display and which property to use for saving the subscription
+type ValueDefinition struct {
+	// Gets or sets the data source.
+	DataSource *[]forminput.InputValue `json:"dataSource,omitempty"`
+	// Gets or sets the rest end point.
+	EndPoint *string `json:"endPoint,omitempty"`
+	// Gets or sets the result template.
+	ResultTemplate *string `json:"resultTemplate,omitempty"`
+}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/release/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/release/client.go
@@ -402,10 +402,10 @@ func (client *ClientImpl) GetDeployments(ctx context.Context, args GetDeployment
 		queryParams.Add("createdBy", *args.CreatedBy)
 	}
 	if args.MinModifiedTime != nil {
-		queryParams.Add("minModifiedTime", (*args.MinModifiedTime).String())
+		queryParams.Add("minModifiedTime", (*args.MinModifiedTime).AsQueryParameter())
 	}
 	if args.MaxModifiedTime != nil {
-		queryParams.Add("maxModifiedTime", (*args.MaxModifiedTime).String())
+		queryParams.Add("maxModifiedTime", (*args.MaxModifiedTime).AsQueryParameter())
 	}
 	if args.DeploymentStatus != nil {
 		queryParams.Add("deploymentStatus", string(*args.DeploymentStatus))
@@ -429,10 +429,10 @@ func (client *ClientImpl) GetDeployments(ctx context.Context, args GetDeployment
 		queryParams.Add("createdFor", *args.CreatedFor)
 	}
 	if args.MinStartedTime != nil {
-		queryParams.Add("minStartedTime", (*args.MinStartedTime).String())
+		queryParams.Add("minStartedTime", (*args.MinStartedTime).AsQueryParameter())
 	}
 	if args.MaxStartedTime != nil {
-		queryParams.Add("maxStartedTime", (*args.MaxStartedTime).String())
+		queryParams.Add("maxStartedTime", (*args.MaxStartedTime).AsQueryParameter())
 	}
 	if args.SourceBranch != nil {
 		queryParams.Add("sourceBranch", *args.SourceBranch)
@@ -954,10 +954,10 @@ func (client *ClientImpl) GetReleases(ctx context.Context, args GetReleasesArgs)
 		queryParams.Add("environmentStatusFilter", strconv.Itoa(*args.EnvironmentStatusFilter))
 	}
 	if args.MinCreatedTime != nil {
-		queryParams.Add("minCreatedTime", (*args.MinCreatedTime).String())
+		queryParams.Add("minCreatedTime", (*args.MinCreatedTime).AsQueryParameter())
 	}
 	if args.MaxCreatedTime != nil {
-		queryParams.Add("maxCreatedTime", (*args.MaxCreatedTime).String())
+		queryParams.Add("maxCreatedTime", (*args.MaxCreatedTime).AsQueryParameter())
 	}
 	if args.QueryOrder != nil {
 		queryParams.Add("queryOrder", string(*args.QueryOrder))

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks/client.go
@@ -1,0 +1,718 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package servicehooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/forminput"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/notification"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type Client interface {
+	// Create a subscription.
+	CreateSubscription(context.Context, CreateSubscriptionArgs) (*Subscription, error)
+	// Query for service hook subscriptions.
+	CreateSubscriptionsQuery(context.Context, CreateSubscriptionsQueryArgs) (*SubscriptionsQuery, error)
+	// Sends a test notification. This is useful for verifying the configuration of an updated or new service hooks subscription.
+	CreateTestNotification(context.Context, CreateTestNotificationArgs) (*Notification, error)
+	// Delete a specific service hooks subscription.
+	DeleteSubscription(context.Context, DeleteSubscriptionArgs) error
+	// Get a specific consumer service. Optionally filter out consumer actions that do not support any event types for the specified publisher.
+	GetConsumer(context.Context, GetConsumerArgs) (*Consumer, error)
+	// Get details about a specific consumer action.
+	GetConsumerAction(context.Context, GetConsumerActionArgs) (*ConsumerAction, error)
+	// Get a specific event type.
+	GetEventType(context.Context, GetEventTypeArgs) (*EventTypeDescriptor, error)
+	// Get a specific notification for a subscription.
+	GetNotification(context.Context, GetNotificationArgs) (*Notification, error)
+	// Get a list of notifications for a specific subscription. A notification includes details about the event, the request to and the response from the consumer service.
+	GetNotifications(context.Context, GetNotificationsArgs) (*[]Notification, error)
+	// Get a specific service hooks publisher.
+	GetPublisher(context.Context, GetPublisherArgs) (*Publisher, error)
+	// Get a specific service hooks subscription.
+	GetSubscription(context.Context, GetSubscriptionArgs) (*Subscription, error)
+	// [Preview API]
+	GetSubscriptionDiagnostics(context.Context, GetSubscriptionDiagnosticsArgs) (*notification.SubscriptionDiagnostics, error)
+	// Get a list of consumer actions for a specific consumer.
+	ListConsumerActions(context.Context, ListConsumerActionsArgs) (*[]ConsumerAction, error)
+	// Get a list of available service hook consumer services. Optionally filter by consumers that support at least one event type from the specific publisher.
+	ListConsumers(context.Context, ListConsumersArgs) (*[]Consumer, error)
+	// Get the event types for a specific publisher.
+	ListEventTypes(context.Context, ListEventTypesArgs) (*[]EventTypeDescriptor, error)
+	// Get a list of publishers.
+	ListPublishers(context.Context, ListPublishersArgs) (*[]Publisher, error)
+	// Get a list of subscriptions.
+	ListSubscriptions(context.Context, ListSubscriptionsArgs) (*[]Subscription, error)
+	QueryInputValues(context.Context, QueryInputValuesArgs) (*forminput.InputValuesQuery, error)
+	// Query for notifications. A notification includes details about the event, the request to and the response from the consumer service.
+	QueryNotifications(context.Context, QueryNotificationsArgs) (*NotificationsQuery, error)
+	// Query for service hook publishers.
+	QueryPublishers(context.Context, QueryPublishersArgs) (*PublishersQuery, error)
+	// Update a subscription. <param name="subscriptionId">ID for a subscription that you wish to update.</param>
+	ReplaceSubscription(context.Context, ReplaceSubscriptionArgs) (*Subscription, error)
+	// [Preview API]
+	UpdateSubscriptionDiagnostics(context.Context, UpdateSubscriptionDiagnosticsArgs) (*notification.SubscriptionDiagnostics, error)
+}
+
+type ClientImpl struct {
+	Client azuredevops.Client
+}
+
+func NewClient(ctx context.Context, connection *azuredevops.Connection) Client {
+	client := connection.GetClientByUrl(connection.BaseUrl)
+	return &ClientImpl{
+		Client: *client,
+	}
+}
+
+// Create a subscription.
+func (client *ClientImpl) CreateSubscription(ctx context.Context, args CreateSubscriptionArgs) (*Subscription, error) {
+	if args.Subscription == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Subscription"}
+	}
+	body, marshalErr := json.Marshal(*args.Subscription)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("fc50d02a-849f-41fb-8af1-0a5216103269")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Subscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the CreateSubscription function
+type CreateSubscriptionArgs struct {
+	// (required) Subscription to be created.
+	Subscription *Subscription
+}
+
+// Query for service hook subscriptions.
+func (client *ClientImpl) CreateSubscriptionsQuery(ctx context.Context, args CreateSubscriptionsQueryArgs) (*SubscriptionsQuery, error) {
+	if args.Query == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Query"}
+	}
+	body, marshalErr := json.Marshal(*args.Query)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("c7c3c1cf-9e05-4c0d-a425-a0f922c2c6ed")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue SubscriptionsQuery
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the CreateSubscriptionsQuery function
+type CreateSubscriptionsQueryArgs struct {
+	// (required)
+	Query *SubscriptionsQuery
+}
+
+// Sends a test notification. This is useful for verifying the configuration of an updated or new service hooks subscription.
+func (client *ClientImpl) CreateTestNotification(ctx context.Context, args CreateTestNotificationArgs) (*Notification, error) {
+	if args.TestNotification == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.TestNotification"}
+	}
+	queryParams := url.Values{}
+	if args.UseRealData != nil {
+		queryParams.Add("useRealData", strconv.FormatBool(*args.UseRealData))
+	}
+	body, marshalErr := json.Marshal(*args.TestNotification)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("1139462c-7e27-4524-a997-31b9b73551fe")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, queryParams, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Notification
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the CreateTestNotification function
+type CreateTestNotificationArgs struct {
+	// (required)
+	TestNotification *Notification
+	// (optional) Only allow testing with real data in existing subscriptions.
+	UseRealData *bool
+}
+
+// Delete a specific service hooks subscription.
+func (client *ClientImpl) DeleteSubscription(ctx context.Context, args DeleteSubscriptionArgs) error {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil {
+		return &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = (*args.SubscriptionId).String()
+
+	locationId, _ := uuid.Parse("fc50d02a-849f-41fb-8af1-0a5216103269")
+	_, err := client.Client.Send(ctx, http.MethodDelete, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Arguments for the DeleteSubscription function
+type DeleteSubscriptionArgs struct {
+	// (required) ID for a subscription.
+	SubscriptionId *uuid.UUID
+}
+
+// Get a specific consumer service. Optionally filter out consumer actions that do not support any event types for the specified publisher.
+func (client *ClientImpl) GetConsumer(ctx context.Context, args GetConsumerArgs) (*Consumer, error) {
+	routeValues := make(map[string]string)
+	if args.ConsumerId == nil || *args.ConsumerId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ConsumerId"}
+	}
+	routeValues["consumerId"] = *args.ConsumerId
+
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	locationId, _ := uuid.Parse("4301c514-5f34-4f5d-a145-f0ea7b5b7d19")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Consumer
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetConsumer function
+type GetConsumerArgs struct {
+	// (required) ID for a consumer.
+	ConsumerId *string
+	// (optional)
+	PublisherId *string
+}
+
+// Get details about a specific consumer action.
+func (client *ClientImpl) GetConsumerAction(ctx context.Context, args GetConsumerActionArgs) (*ConsumerAction, error) {
+	routeValues := make(map[string]string)
+	if args.ConsumerId == nil || *args.ConsumerId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ConsumerId"}
+	}
+	routeValues["consumerId"] = *args.ConsumerId
+	if args.ConsumerActionId == nil || *args.ConsumerActionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ConsumerActionId"}
+	}
+	routeValues["consumerActionId"] = *args.ConsumerActionId
+
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	locationId, _ := uuid.Parse("c3428e90-7a69-4194-8ed8-0f153185ee0d")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue ConsumerAction
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetConsumerAction function
+type GetConsumerActionArgs struct {
+	// (required) ID for a consumer.
+	ConsumerId *string
+	// (required) ID for a consumerActionId.
+	ConsumerActionId *string
+	// (optional)
+	PublisherId *string
+}
+
+// Get a specific event type.
+func (client *ClientImpl) GetEventType(ctx context.Context, args GetEventTypeArgs) (*EventTypeDescriptor, error) {
+	routeValues := make(map[string]string)
+	if args.PublisherId == nil || *args.PublisherId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.PublisherId"}
+	}
+	routeValues["publisherId"] = *args.PublisherId
+	if args.EventTypeId == nil || *args.EventTypeId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.EventTypeId"}
+	}
+	routeValues["eventTypeId"] = *args.EventTypeId
+
+	locationId, _ := uuid.Parse("db4777cd-8e08-4a84-8ba3-c974ea033718")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue EventTypeDescriptor
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetEventType function
+type GetEventTypeArgs struct {
+	// (required) ID for a publisher.
+	PublisherId *string
+	// (required)
+	EventTypeId *string
+}
+
+// Get a specific notification for a subscription.
+func (client *ClientImpl) GetNotification(ctx context.Context, args GetNotificationArgs) (*Notification, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = (*args.SubscriptionId).String()
+	if args.NotificationId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.NotificationId"}
+	}
+	routeValues["notificationId"] = strconv.Itoa(*args.NotificationId)
+
+	locationId, _ := uuid.Parse("0c62d343-21b0-4732-997b-017fde84dc28")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Notification
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetNotification function
+type GetNotificationArgs struct {
+	// (required) ID for a subscription.
+	SubscriptionId *uuid.UUID
+	// (required)
+	NotificationId *int
+}
+
+// Get a list of notifications for a specific subscription. A notification includes details about the event, the request to and the response from the consumer service.
+func (client *ClientImpl) GetNotifications(ctx context.Context, args GetNotificationsArgs) (*[]Notification, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = (*args.SubscriptionId).String()
+
+	queryParams := url.Values{}
+	if args.MaxResults != nil {
+		queryParams.Add("maxResults", strconv.Itoa(*args.MaxResults))
+	}
+	if args.Status != nil {
+		queryParams.Add("status", string(*args.Status))
+	}
+	if args.Result != nil {
+		queryParams.Add("result", string(*args.Result))
+	}
+	locationId, _ := uuid.Parse("0c62d343-21b0-4732-997b-017fde84dc28")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []Notification
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetNotifications function
+type GetNotificationsArgs struct {
+	// (required) ID for a subscription.
+	SubscriptionId *uuid.UUID
+	// (optional) Maximum number of notifications to return. Default is **100**.
+	MaxResults *int
+	// (optional) Get only notifications with this status.
+	Status *NotificationStatus
+	// (optional) Get only notifications with this result type.
+	Result *NotificationResult
+}
+
+// Get a specific service hooks publisher.
+func (client *ClientImpl) GetPublisher(ctx context.Context, args GetPublisherArgs) (*Publisher, error) {
+	routeValues := make(map[string]string)
+	if args.PublisherId == nil || *args.PublisherId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.PublisherId"}
+	}
+	routeValues["publisherId"] = *args.PublisherId
+
+	locationId, _ := uuid.Parse("1e83a210-5b53-43bc-90f0-d476a4e5d731")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Publisher
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetPublisher function
+type GetPublisherArgs struct {
+	// (required) ID for a publisher.
+	PublisherId *string
+}
+
+// Get a specific service hooks subscription.
+func (client *ClientImpl) GetSubscription(ctx context.Context, args GetSubscriptionArgs) (*Subscription, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = (*args.SubscriptionId).String()
+
+	locationId, _ := uuid.Parse("fc50d02a-849f-41fb-8af1-0a5216103269")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Subscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscription function
+type GetSubscriptionArgs struct {
+	// (required) ID for a subscription.
+	SubscriptionId *uuid.UUID
+}
+
+// [Preview API]
+func (client *ClientImpl) GetSubscriptionDiagnostics(ctx context.Context, args GetSubscriptionDiagnosticsArgs) (*notification.SubscriptionDiagnostics, error) {
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	locationId, _ := uuid.Parse("3b36bcb5-02ad-43c6-bbfa-6dfc6f8e9d68")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1-preview.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue notification.SubscriptionDiagnostics
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetSubscriptionDiagnostics function
+type GetSubscriptionDiagnosticsArgs struct {
+	// (required)
+	SubscriptionId *string
+}
+
+// Get a list of consumer actions for a specific consumer.
+func (client *ClientImpl) ListConsumerActions(ctx context.Context, args ListConsumerActionsArgs) (*[]ConsumerAction, error) {
+	routeValues := make(map[string]string)
+	if args.ConsumerId == nil || *args.ConsumerId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ConsumerId"}
+	}
+	routeValues["consumerId"] = *args.ConsumerId
+
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	locationId, _ := uuid.Parse("c3428e90-7a69-4194-8ed8-0f153185ee0d")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []ConsumerAction
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListConsumerActions function
+type ListConsumerActionsArgs struct {
+	// (required) ID for a consumer.
+	ConsumerId *string
+	// (optional)
+	PublisherId *string
+}
+
+// Get a list of available service hook consumer services. Optionally filter by consumers that support at least one event type from the specific publisher.
+func (client *ClientImpl) ListConsumers(ctx context.Context, args ListConsumersArgs) (*[]Consumer, error) {
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	locationId, _ := uuid.Parse("4301c514-5f34-4f5d-a145-f0ea7b5b7d19")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []Consumer
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListConsumers function
+type ListConsumersArgs struct {
+	// (optional)
+	PublisherId *string
+}
+
+// Get the event types for a specific publisher.
+func (client *ClientImpl) ListEventTypes(ctx context.Context, args ListEventTypesArgs) (*[]EventTypeDescriptor, error) {
+	routeValues := make(map[string]string)
+	if args.PublisherId == nil || *args.PublisherId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.PublisherId"}
+	}
+	routeValues["publisherId"] = *args.PublisherId
+
+	locationId, _ := uuid.Parse("db4777cd-8e08-4a84-8ba3-c974ea033718")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []EventTypeDescriptor
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListEventTypes function
+type ListEventTypesArgs struct {
+	// (required) ID for a publisher.
+	PublisherId *string
+}
+
+// Get a list of publishers.
+func (client *ClientImpl) ListPublishers(ctx context.Context, args ListPublishersArgs) (*[]Publisher, error) {
+	locationId, _ := uuid.Parse("1e83a210-5b53-43bc-90f0-d476a4e5d731")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []Publisher
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListPublishers function
+type ListPublishersArgs struct {
+}
+
+// Get a list of subscriptions.
+func (client *ClientImpl) ListSubscriptions(ctx context.Context, args ListSubscriptionsArgs) (*[]Subscription, error) {
+	queryParams := url.Values{}
+	if args.PublisherId != nil {
+		queryParams.Add("publisherId", *args.PublisherId)
+	}
+	if args.EventType != nil {
+		queryParams.Add("eventType", *args.EventType)
+	}
+	if args.ConsumerId != nil {
+		queryParams.Add("consumerId", *args.ConsumerId)
+	}
+	if args.ConsumerActionId != nil {
+		queryParams.Add("consumerActionId", *args.ConsumerActionId)
+	}
+	locationId, _ := uuid.Parse("fc50d02a-849f-41fb-8af1-0a5216103269")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", nil, queryParams, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []Subscription
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ListSubscriptions function
+type ListSubscriptionsArgs struct {
+	// (optional) ID for a subscription.
+	PublisherId *string
+	// (optional) The event type to filter on (if any).
+	EventType *string
+	// (optional) ID for a consumer.
+	ConsumerId *string
+	// (optional) ID for a consumerActionId.
+	ConsumerActionId *string
+}
+
+func (client *ClientImpl) QueryInputValues(ctx context.Context, args QueryInputValuesArgs) (*forminput.InputValuesQuery, error) {
+	if args.InputValuesQuery == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.InputValuesQuery"}
+	}
+	routeValues := make(map[string]string)
+	if args.PublisherId == nil || *args.PublisherId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.PublisherId"}
+	}
+	routeValues["publisherId"] = *args.PublisherId
+
+	body, marshalErr := json.Marshal(*args.InputValuesQuery)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("d815d352-a566-4dc1-a3e3-fd245acf688c")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue forminput.InputValuesQuery
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the QueryInputValues function
+type QueryInputValuesArgs struct {
+	// (required)
+	InputValuesQuery *forminput.InputValuesQuery
+	// (required)
+	PublisherId *string
+}
+
+// Query for notifications. A notification includes details about the event, the request to and the response from the consumer service.
+func (client *ClientImpl) QueryNotifications(ctx context.Context, args QueryNotificationsArgs) (*NotificationsQuery, error) {
+	if args.Query == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Query"}
+	}
+	body, marshalErr := json.Marshal(*args.Query)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("1a57562f-160a-4b5c-9185-905e95b39d36")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue NotificationsQuery
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the QueryNotifications function
+type QueryNotificationsArgs struct {
+	// (required)
+	Query *NotificationsQuery
+}
+
+// Query for service hook publishers.
+func (client *ClientImpl) QueryPublishers(ctx context.Context, args QueryPublishersArgs) (*PublishersQuery, error) {
+	if args.Query == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Query"}
+	}
+	body, marshalErr := json.Marshal(*args.Query)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("99b44a8a-65a8-4670-8f3e-e7f7842cce64")
+	resp, err := client.Client.Send(ctx, http.MethodPost, locationId, "5.1", nil, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue PublishersQuery
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the QueryPublishers function
+type QueryPublishersArgs struct {
+	// (required)
+	Query *PublishersQuery
+}
+
+// Update a subscription. <param name="subscriptionId">ID for a subscription that you wish to update.</param>
+func (client *ClientImpl) ReplaceSubscription(ctx context.Context, args ReplaceSubscriptionArgs) (*Subscription, error) {
+	if args.Subscription == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.Subscription"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriptionId != nil {
+		routeValues["subscriptionId"] = (*args.SubscriptionId).String()
+	}
+
+	body, marshalErr := json.Marshal(*args.Subscription)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("fc50d02a-849f-41fb-8af1-0a5216103269")
+	resp, err := client.Client.Send(ctx, http.MethodPut, locationId, "5.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue Subscription
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the ReplaceSubscription function
+type ReplaceSubscriptionArgs struct {
+	// (required)
+	Subscription *Subscription
+	// (optional)
+	SubscriptionId *uuid.UUID
+}
+
+// [Preview API]
+func (client *ClientImpl) UpdateSubscriptionDiagnostics(ctx context.Context, args UpdateSubscriptionDiagnosticsArgs) (*notification.SubscriptionDiagnostics, error) {
+	if args.UpdateParameters == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.UpdateParameters"}
+	}
+	routeValues := make(map[string]string)
+	if args.SubscriptionId == nil || *args.SubscriptionId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.SubscriptionId"}
+	}
+	routeValues["subscriptionId"] = *args.SubscriptionId
+
+	body, marshalErr := json.Marshal(*args.UpdateParameters)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("3b36bcb5-02ad-43c6-bbfa-6dfc6f8e9d68")
+	resp, err := client.Client.Send(ctx, http.MethodPut, locationId, "5.1-preview.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue notification.SubscriptionDiagnostics
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdateSubscriptionDiagnostics function
+type UpdateSubscriptionDiagnosticsArgs struct {
+	// (required)
+	UpdateParameters *notification.UpdateSubscripitonDiagnosticsParameters
+	// (required)
+	SubscriptionId *string
+}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks/models.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks/models.go
@@ -1,0 +1,467 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package servicehooks
+
+import (
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/forminput"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
+)
+
+// Enumerates consumer authentication types.
+type AuthenticationType string
+
+type authenticationTypeValuesType struct {
+	None     AuthenticationType
+	OAuth    AuthenticationType
+	External AuthenticationType
+}
+
+var AuthenticationTypeValues = authenticationTypeValuesType{
+	// No authentication is required.
+	None: "none",
+	// OAuth authentication.
+	OAuth: "oAuth",
+	// Externally-configured authentication.
+	External: "external",
+}
+
+// Defines the data contract of a consumer.
+type Consumer struct {
+	// Reference Links
+	Links interface{} `json:"_links,omitempty"`
+	// Gets this consumer's actions.
+	Actions *[]ConsumerAction `json:"actions,omitempty"`
+	// Gets or sets this consumer's authentication type.
+	AuthenticationType *AuthenticationType `json:"authenticationType,omitempty"`
+	// Gets or sets this consumer's localized description.
+	Description *string `json:"description,omitempty"`
+	// Non-null only if subscriptions for this consumer are configured externally.
+	ExternalConfiguration *ExternalConfigurationDescriptor `json:"externalConfiguration,omitempty"`
+	// Gets or sets this consumer's identifier.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets this consumer's image URL, if any.
+	ImageUrl *string `json:"imageUrl,omitempty"`
+	// Gets or sets this consumer's information URL, if any.
+	InformationUrl *string `json:"informationUrl,omitempty"`
+	// Gets or sets this consumer's input descriptors.
+	InputDescriptors *[]forminput.InputDescriptor `json:"inputDescriptors,omitempty"`
+	// Gets or sets this consumer's localized name.
+	Name *string `json:"name,omitempty"`
+	// The url for this resource
+	Url *string `json:"url,omitempty"`
+}
+
+// Defines the data contract of a consumer action.
+type ConsumerAction struct {
+	// Reference Links
+	Links interface{} `json:"_links,omitempty"`
+	// Gets or sets the flag indicating if resource version can be overridden when creating or editing a subscription.
+	AllowResourceVersionOverride *bool `json:"allowResourceVersionOverride,omitempty"`
+	// Gets or sets the identifier of the consumer to which this action belongs.
+	ConsumerId *string `json:"consumerId,omitempty"`
+	// Gets or sets this action's localized description.
+	Description *string `json:"description,omitempty"`
+	// Gets or sets this action's identifier.
+	Id *string `json:"id,omitempty"`
+	// Gets or sets this action's input descriptors.
+	InputDescriptors *[]forminput.InputDescriptor `json:"inputDescriptors,omitempty"`
+	// Gets or sets this action's localized name.
+	Name *string `json:"name,omitempty"`
+	// Gets or sets this action's supported event identifiers.
+	SupportedEventTypes *[]string `json:"supportedEventTypes,omitempty"`
+	// Gets or sets this action's supported resource versions.
+	SupportedResourceVersions *map[string][]string `json:"supportedResourceVersions,omitempty"`
+	// The url for this resource
+	Url *string `json:"url,omitempty"`
+}
+
+// Encapsulates the properties of an event.
+type Event struct {
+	// Gets or sets the UTC-based date and time that this event was created.
+	CreatedDate *azuredevops.Time `json:"createdDate,omitempty"`
+	// Gets or sets the detailed message associated with this event.
+	DetailedMessage *FormattedEventMessage `json:"detailedMessage,omitempty"`
+	// Gets or sets the type of this event.
+	EventType *string `json:"eventType,omitempty"`
+	// Gets or sets the unique identifier of this event.
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Gets or sets the (brief) message associated with this event.
+	Message *FormattedEventMessage `json:"message,omitempty"`
+	// Gets or sets the identifier of the publisher that raised this event.
+	PublisherId *string `json:"publisherId,omitempty"`
+	// Gets or sets the data associated with this event.
+	Resource interface{} `json:"resource,omitempty"`
+	// Gets or sets the resource containers.
+	ResourceContainers *map[string]ResourceContainer `json:"resourceContainers,omitempty"`
+	// Gets or sets the version of the data associated with this event.
+	ResourceVersion *string `json:"resourceVersion,omitempty"`
+	// Gets or sets the Session Token that can be used in further interactions
+	SessionToken *SessionToken `json:"sessionToken,omitempty"`
+}
+
+// Describes a type of event
+type EventTypeDescriptor struct {
+	// A localized description of the event type
+	Description *string `json:"description,omitempty"`
+	// A unique id for the event type
+	Id *string `json:"id,omitempty"`
+	// Event-specific inputs
+	InputDescriptors *[]forminput.InputDescriptor `json:"inputDescriptors,omitempty"`
+	// A localized friendly name for the event type
+	Name *string `json:"name,omitempty"`
+	// A unique id for the publisher of this event type
+	PublisherId *string `json:"publisherId,omitempty"`
+	// Supported versions for the event's resource payloads.
+	SupportedResourceVersions *[]string `json:"supportedResourceVersions,omitempty"`
+	// The url for this resource
+	Url *string `json:"url,omitempty"`
+}
+
+// Describes how to configure a subscription that is managed externally.
+type ExternalConfigurationDescriptor struct {
+	// Url of the site to create this type of subscription.
+	CreateSubscriptionUrl *string `json:"createSubscriptionUrl,omitempty"`
+	// The name of an input property that contains the URL to edit a subscription.
+	EditSubscriptionPropertyName *string `json:"editSubscriptionPropertyName,omitempty"`
+	// True if the external configuration applies only to hosted.
+	HostedOnly *bool `json:"hostedOnly,omitempty"`
+}
+
+// Provides different formats of an event message
+type FormattedEventMessage struct {
+	// Gets or sets the html format of the message
+	Html *string `json:"html,omitempty"`
+	// Gets or sets the markdown format of the message
+	Markdown *string `json:"markdown,omitempty"`
+	// Gets or sets the raw text of the message
+	Text *string `json:"text,omitempty"`
+}
+
+// Defines the data contract of the result of processing an event for a subscription.
+type Notification struct {
+	// Gets or sets date and time that this result was created.
+	CreatedDate *azuredevops.Time `json:"createdDate,omitempty"`
+	// Details about this notification (if available)
+	Details *NotificationDetails `json:"details,omitempty"`
+	// The event id associated with this notification
+	EventId *uuid.UUID `json:"eventId,omitempty"`
+	// The notification id
+	Id *int `json:"id,omitempty"`
+	// Gets or sets date and time that this result was last modified.
+	ModifiedDate *azuredevops.Time `json:"modifiedDate,omitempty"`
+	// Result of the notification
+	Result *NotificationResult `json:"result,omitempty"`
+	// Status of the notification
+	Status *NotificationStatus `json:"status,omitempty"`
+	// The subscriber Id  associated with this notification. This is the last identity who touched in the subscription. In case of test notifications it can be the tester if the subscription is not created yet.
+	SubscriberId *uuid.UUID `json:"subscriberId,omitempty"`
+	// The subscription id associated with this notification
+	SubscriptionId *uuid.UUID `json:"subscriptionId,omitempty"`
+}
+
+// Defines the data contract of notification details.
+type NotificationDetails struct {
+	// Gets or sets the time that this notification was completed (response received from the consumer)
+	CompletedDate *azuredevops.Time `json:"completedDate,omitempty"`
+	// Gets or sets this notification detail's consumer action identifier.
+	ConsumerActionId *string `json:"consumerActionId,omitempty"`
+	// Gets or sets this notification detail's consumer identifier.
+	ConsumerId *string `json:"consumerId,omitempty"`
+	// Gets or sets this notification detail's consumer inputs.
+	ConsumerInputs *map[string]string `json:"consumerInputs,omitempty"`
+	// Gets or sets the time that this notification was dequeued for processing
+	DequeuedDate *azuredevops.Time `json:"dequeuedDate,omitempty"`
+	// Gets or sets this notification detail's error detail.
+	ErrorDetail *string `json:"errorDetail,omitempty"`
+	// Gets or sets this notification detail's error message.
+	ErrorMessage *string `json:"errorMessage,omitempty"`
+	// Gets or sets this notification detail's event content.
+	Event *Event `json:"event,omitempty"`
+	// Gets or sets this notification detail's event type.
+	EventType *string `json:"eventType,omitempty"`
+	// Gets or sets the time that this notification was finished processing (just before the request is sent to the consumer)
+	ProcessedDate *azuredevops.Time `json:"processedDate,omitempty"`
+	// Gets or sets this notification detail's publisher identifier.
+	PublisherId *string `json:"publisherId,omitempty"`
+	// Gets or sets this notification detail's publisher inputs.
+	PublisherInputs *map[string]string `json:"publisherInputs,omitempty"`
+	// Gets or sets the time that this notification was queued (created)
+	QueuedDate *azuredevops.Time `json:"queuedDate,omitempty"`
+	// Gets or sets this notification detail's request.
+	Request *string `json:"request,omitempty"`
+	// Number of requests attempted to be sent to the consumer
+	RequestAttempts *int `json:"requestAttempts,omitempty"`
+	// Duration of the request to the consumer in seconds
+	RequestDuration *float64 `json:"requestDuration,omitempty"`
+	// Gets or sets this notification detail's response.
+	Response *string `json:"response,omitempty"`
+}
+
+// Enumerates possible result types of a notification.
+type NotificationResult string
+
+type notificationResultValuesType struct {
+	Pending   NotificationResult
+	Succeeded NotificationResult
+	Failed    NotificationResult
+	Filtered  NotificationResult
+}
+
+var NotificationResultValues = notificationResultValuesType{
+	// The notification has not yet completed
+	Pending: "pending",
+	// The notification was sent successfully
+	Succeeded: "succeeded",
+	// The notification failed to be sent successfully to the consumer
+	Failed: "failed",
+	// The notification was filtered by the Delivery Job
+	Filtered: "filtered",
+}
+
+// Summary of a particular result and count.
+type NotificationResultsSummaryDetail struct {
+	// Count of notification sent out with a matching result.
+	NotificationCount *int `json:"notificationCount,omitempty"`
+	// Result of the notification
+	Result *NotificationResult `json:"result,omitempty"`
+}
+
+// Defines a query for service hook notifications.
+type NotificationsQuery struct {
+	// The subscriptions associated with the notifications returned from the query
+	AssociatedSubscriptions *[]Subscription `json:"associatedSubscriptions,omitempty"`
+	// If true, we will return all notification history for the query provided; otherwise, the summary is returned.
+	IncludeDetails *bool `json:"includeDetails,omitempty"`
+	// Optional maximum date at which the notification was created
+	MaxCreatedDate *azuredevops.Time `json:"maxCreatedDate,omitempty"`
+	// Optional maximum number of overall results to include
+	MaxResults *int `json:"maxResults,omitempty"`
+	// Optional maximum number of results for each subscription. Only takes effect when a list of subscription ids is supplied in the query.
+	MaxResultsPerSubscription *int `json:"maxResultsPerSubscription,omitempty"`
+	// Optional minimum date at which the notification was created
+	MinCreatedDate *azuredevops.Time `json:"minCreatedDate,omitempty"`
+	// Optional publisher id to restrict the results to
+	PublisherId *string `json:"publisherId,omitempty"`
+	// Results from the query
+	Results *[]Notification `json:"results,omitempty"`
+	// Optional notification result type to filter results to
+	ResultType *NotificationResult `json:"resultType,omitempty"`
+	// Optional notification status to filter results to
+	Status *NotificationStatus `json:"status,omitempty"`
+	// Optional list of subscription ids to restrict the results to
+	SubscriptionIds *[]uuid.UUID `json:"subscriptionIds,omitempty"`
+	// Summary of notifications - the count of each result type (success, fail, ..).
+	Summary *[]NotificationSummary `json:"summary,omitempty"`
+}
+
+// Enumerates possible status' of a notification.
+type NotificationStatus string
+
+type notificationStatusValuesType struct {
+	Queued            NotificationStatus
+	Processing        NotificationStatus
+	RequestInProgress NotificationStatus
+	Completed         NotificationStatus
+}
+
+var NotificationStatusValues = notificationStatusValuesType{
+	// The notification has been queued
+	Queued: "queued",
+	// The notification has been dequeued and has begun processing.
+	Processing: "processing",
+	// The consumer action has processed the notification. The request is in progress.
+	RequestInProgress: "requestInProgress",
+	// The request completed
+	Completed: "completed",
+}
+
+// Summary of the notifications for a subscription.
+type NotificationSummary struct {
+	// The notification results for this particular subscription.
+	Results *[]NotificationResultsSummaryDetail `json:"results,omitempty"`
+	// The subscription id associated with this notification
+	SubscriptionId *uuid.UUID `json:"subscriptionId,omitempty"`
+}
+
+// Defines the data contract of an event publisher.
+type Publisher struct {
+	// Reference Links
+	Links interface{} `json:"_links,omitempty"`
+	// Gets this publisher's localized description.
+	Description *string `json:"description,omitempty"`
+	// Gets this publisher's identifier.
+	Id *string `json:"id,omitempty"`
+	// Publisher-specific inputs
+	InputDescriptors *[]forminput.InputDescriptor `json:"inputDescriptors,omitempty"`
+	// Gets this publisher's localized name.
+	Name *string `json:"name,omitempty"`
+	// The service instance type of the first party publisher.
+	ServiceInstanceType *string `json:"serviceInstanceType,omitempty"`
+	// Gets this publisher's supported event types.
+	SupportedEvents *[]EventTypeDescriptor `json:"supportedEvents,omitempty"`
+	// The url for this resource
+	Url *string `json:"url,omitempty"`
+}
+
+// Wrapper around an event which is being published
+type PublisherEvent struct {
+	// Add key/value pairs which will be stored with a published notification in the SH service DB.  This key/value pairs are for diagnostic purposes only and will have not effect on the delivery of a notification.
+	Diagnostics *map[string]string `json:"diagnostics,omitempty"`
+	// The event being published
+	Event *Event `json:"event,omitempty"`
+	// Gets or sets flag for filtered events
+	IsFilteredEvent *bool `json:"isFilteredEvent,omitempty"`
+	// Additional data that needs to be sent as part of notification to complement the Resource data in the Event
+	NotificationData *map[string]string `json:"notificationData,omitempty"`
+	// Gets or sets the array of older supported resource versions.
+	OtherResourceVersions *[]VersionedResource `json:"otherResourceVersions,omitempty"`
+	// Optional publisher-input filters which restricts the set of subscriptions which are triggered by the event
+	PublisherInputFilters *[]forminput.InputFilter `json:"publisherInputFilters,omitempty"`
+	// Gets or sets matched hooks subscription which caused this event.
+	Subscription *Subscription `json:"subscription,omitempty"`
+}
+
+// Defines a query for service hook publishers.
+type PublishersQuery struct {
+	// Optional list of publisher ids to restrict the results to
+	PublisherIds *[]string `json:"publisherIds,omitempty"`
+	// Filter for publisher inputs
+	PublisherInputs *map[string]string `json:"publisherInputs,omitempty"`
+	// Results from the query
+	Results *[]Publisher `json:"results,omitempty"`
+}
+
+// The base class for all resource containers, i.e. Account, Collection, Project
+type ResourceContainer struct {
+	// Gets or sets the container's base URL, i.e. the URL of the host (collection, application, or deployment) containing the container resource.
+	BaseUrl *string `json:"baseUrl,omitempty"`
+	// Gets or sets the container's specific Id.
+	Id *uuid.UUID `json:"id,omitempty"`
+	// Gets or sets the container's name.
+	Name *string `json:"name,omitempty"`
+	// Gets or sets the container's REST API URL.
+	Url *string `json:"url,omitempty"`
+}
+
+// Represents a session token to be attached in Events for Consumer actions that need it.
+type SessionToken struct {
+	// The error message in case of error
+	Error *string `json:"error,omitempty"`
+	// The access token
+	Token *string `json:"token,omitempty"`
+	// The expiration date in UTC
+	ValidTo *azuredevops.Time `json:"validTo,omitempty"`
+}
+
+// Encapsulates an event subscription.
+type Subscription struct {
+	// Reference Links
+	Links             interface{} `json:"_links,omitempty"`
+	ActionDescription *string     `json:"actionDescription,omitempty"`
+	ConsumerActionId  *string     `json:"consumerActionId,omitempty"`
+	ConsumerId        *string     `json:"consumerId,omitempty"`
+	// Consumer input values
+	ConsumerInputs   *map[string]string  `json:"consumerInputs,omitempty"`
+	CreatedBy        *webapi.IdentityRef `json:"createdBy,omitempty"`
+	CreatedDate      *azuredevops.Time   `json:"createdDate,omitempty"`
+	EventDescription *string             `json:"eventDescription,omitempty"`
+	EventType        *string             `json:"eventType,omitempty"`
+	Id               *uuid.UUID          `json:"id,omitempty"`
+	ModifiedBy       *webapi.IdentityRef `json:"modifiedBy,omitempty"`
+	ModifiedDate     *azuredevops.Time   `json:"modifiedDate,omitempty"`
+	ProbationRetries *byte               `json:"probationRetries,omitempty"`
+	PublisherId      *string             `json:"publisherId,omitempty"`
+	// Publisher input values
+	PublisherInputs *map[string]string  `json:"publisherInputs,omitempty"`
+	ResourceVersion *string             `json:"resourceVersion,omitempty"`
+	Status          *SubscriptionStatus `json:"status,omitempty"`
+	Subscriber      *webapi.IdentityRef `json:"subscriber,omitempty"`
+	Url             *string             `json:"url,omitempty"`
+}
+
+// The scope to which a subscription input applies
+type SubscriptionInputScope string
+
+type subscriptionInputScopeValuesType struct {
+	Publisher SubscriptionInputScope
+	Consumer  SubscriptionInputScope
+}
+
+var SubscriptionInputScopeValues = subscriptionInputScopeValuesType{
+	// An input defined and consumed by a Publisher or Publisher Event Type
+	Publisher: "publisher",
+	// An input defined and consumed by a Consumer or Consumer Action
+	Consumer: "consumer",
+}
+
+// Query for obtaining information about the possible/allowed values for one or more subscription inputs
+type SubscriptionInputValuesQuery struct {
+	// The input values to return on input, and the result from the consumer on output.
+	InputValues *[]forminput.InputValues `json:"inputValues,omitempty"`
+	// The scope at which the properties to query belong
+	Scope *SubscriptionInputScope `json:"scope,omitempty"`
+	// Subscription containing information about the publisher/consumer and the current input values
+	Subscription *Subscription `json:"subscription,omitempty"`
+}
+
+// Defines a query for service hook subscriptions.
+type SubscriptionsQuery struct {
+	// Optional consumer action id to restrict the results to (null for any)
+	ConsumerActionId *string `json:"consumerActionId,omitempty"`
+	// Optional consumer id to restrict the results to (null for any)
+	ConsumerId *string `json:"consumerId,omitempty"`
+	// Filter for subscription consumer inputs
+	ConsumerInputFilters *[]forminput.InputFilter `json:"consumerInputFilters,omitempty"`
+	// Optional event type id to restrict the results to (null for any)
+	EventType *string `json:"eventType,omitempty"`
+	// Optional publisher id to restrict the results to (null for any)
+	PublisherId *string `json:"publisherId,omitempty"`
+	// Filter for subscription publisher inputs
+	PublisherInputFilters *[]forminput.InputFilter `json:"publisherInputFilters,omitempty"`
+	// Results from the query
+	Results *[]Subscription `json:"results,omitempty"`
+	// Optional subscriber filter.
+	SubscriberId *uuid.UUID `json:"subscriberId,omitempty"`
+}
+
+// Enumerates possible states of a subscription.
+type SubscriptionStatus string
+
+type subscriptionStatusValuesType struct {
+	Enabled                    SubscriptionStatus
+	OnProbation                SubscriptionStatus
+	DisabledByUser             SubscriptionStatus
+	DisabledBySystem           SubscriptionStatus
+	DisabledByInactiveIdentity SubscriptionStatus
+}
+
+var SubscriptionStatusValues = subscriptionStatusValuesType{
+	// The subscription is enabled.
+	Enabled: "enabled",
+	// The subscription is temporarily on probation by the system.
+	OnProbation: "onProbation",
+	// The subscription is disabled by a user.
+	DisabledByUser: "disabledByUser",
+	// The subscription is disabled by the system.
+	DisabledBySystem: "disabledBySystem",
+	// The subscription is disabled because the owner is inactive or is missing permissions.
+	DisabledByInactiveIdentity: "disabledByInactiveIdentity",
+}
+
+// Encapsulates the resource version and its data or reference to the compatible version. Only one of the two last fields should be not null.
+type VersionedResource struct {
+	// Gets or sets the reference to the compatible version.
+	CompatibleWith *string `json:"compatibleWith,omitempty"`
+	// Gets or sets the resource data.
+	Resource interface{} `json:"resource,omitempty"`
+	// Gets or sets the version of the resource data.
+	ResourceVersion *string `json:"resourceVersion,omitempty"`
+}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/taskagent/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/taskagent/client.go
@@ -1311,7 +1311,7 @@ func (client *ClientImpl) GetTaskGroups(ctx context.Context, args GetTaskGroupsA
 		queryParams.Add("$top", strconv.Itoa(*args.Top))
 	}
 	if args.ContinuationToken != nil {
-		queryParams.Add("continuationToken", (*args.ContinuationToken).String())
+		queryParams.Add("continuationToken", (*args.ContinuationToken).AsQueryParameter())
 	}
 	if args.QueryOrder != nil {
 		queryParams.Add("queryOrder", string(*args.QueryOrder))

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/test/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/test/client.go
@@ -1719,11 +1719,11 @@ func (client *ClientImpl) QueryTestRuns(ctx context.Context, args QueryTestRunsA
 	if args.MinLastUpdatedDate == nil {
 		return nil, &azuredevops.ArgumentNilError{ArgumentName: "minLastUpdatedDate"}
 	}
-	queryParams.Add("minLastUpdatedDate", (*args.MinLastUpdatedDate).String())
+	queryParams.Add("minLastUpdatedDate", (*args.MinLastUpdatedDate).AsQueryParameter())
 	if args.MaxLastUpdatedDate == nil {
 		return nil, &azuredevops.ArgumentNilError{ArgumentName: "maxLastUpdatedDate"}
 	}
-	queryParams.Add("maxLastUpdatedDate", (*args.MaxLastUpdatedDate).String())
+	queryParams.Add("maxLastUpdatedDate", (*args.MaxLastUpdatedDate).AsQueryParameter())
 	if args.State != nil {
 		queryParams.Add("state", string(*args.State))
 	}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking/client.go
@@ -1715,7 +1715,7 @@ func (client *ClientImpl) GetReportingLinksByLinkType(ctx context.Context, args 
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("b5b5b6d0-0308-40a1-b3f4-b9bb3c66878f")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "5.1", routeValues, queryParams, nil, "", "application/json", nil)
@@ -2046,7 +2046,7 @@ func (client *ClientImpl) GetWorkItem(ctx context.Context, args GetWorkItemArgs)
 		queryParams.Add("fields", listAsString)
 	}
 	if args.AsOf != nil {
-		queryParams.Add("asOf", (*args.AsOf).String())
+		queryParams.Add("asOf", (*args.AsOf).AsQueryParameter())
 	}
 	if args.Expand != nil {
 		queryParams.Add("$expand", string(*args.Expand))
@@ -2253,7 +2253,7 @@ func (client *ClientImpl) GetWorkItems(ctx context.Context, args GetWorkItemsArg
 		queryParams.Add("fields", listAsString)
 	}
 	if args.AsOf != nil {
-		queryParams.Add("asOf", (*args.AsOf).String())
+		queryParams.Add("asOf", (*args.AsOf).AsQueryParameter())
 	}
 	if args.Expand != nil {
 		queryParams.Add("$expand", string(*args.Expand))
@@ -2338,7 +2338,7 @@ func (client *ClientImpl) GetWorkItemTemplate(ctx context.Context, args GetWorkI
 		queryParams.Add("fields", *args.Fields)
 	}
 	if args.AsOf != nil {
-		queryParams.Add("asOf", (*args.AsOf).String())
+		queryParams.Add("asOf", (*args.AsOf).AsQueryParameter())
 	}
 	if args.Expand != nil {
 		queryParams.Add("$expand", string(*args.Expand))
@@ -2774,7 +2774,7 @@ func (client *ClientImpl) ReadReportingRevisionsGet(ctx context.Context, args Re
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	if args.IncludeIdentityRef != nil {
 		queryParams.Add("includeIdentityRef", strconv.FormatBool(*args.IncludeIdentityRef))
@@ -2851,7 +2851,7 @@ func (client *ClientImpl) ReadReportingRevisionsPost(ctx context.Context, args R
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	if args.Expand != nil {
 		queryParams.Add("$expand", string(*args.Expand))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,7 +244,7 @@ github.com/klauspost/compress/zstd/internal/xxhash
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.10
 github.com/mattn/go-isatty
-# github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b3
+# github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 ## explicit
 github.com/microsoft/azure-devops-go-api/azuredevops
 github.com/microsoft/azure-devops-go-api/azuredevops/accounts
@@ -261,12 +261,14 @@ github.com/microsoft/azure-devops-go-api/azuredevops/identity
 github.com/microsoft/azure-devops-go-api/azuredevops/licensing
 github.com/microsoft/azure-devops-go-api/azuredevops/licensingrule
 github.com/microsoft/azure-devops-go-api/azuredevops/memberentitlementmanagement
+github.com/microsoft/azure-devops-go-api/azuredevops/notification
 github.com/microsoft/azure-devops-go-api/azuredevops/operations
 github.com/microsoft/azure-devops-go-api/azuredevops/policy
 github.com/microsoft/azure-devops-go-api/azuredevops/profile
 github.com/microsoft/azure-devops-go-api/azuredevops/release
 github.com/microsoft/azure-devops-go-api/azuredevops/security
 github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint
+github.com/microsoft/azure-devops-go-api/azuredevops/servicehooks
 github.com/microsoft/azure-devops-go-api/azuredevops/system
 github.com/microsoft/azure-devops-go-api/azuredevops/taskagent
 github.com/microsoft/azure-devops-go-api/azuredevops/test

--- a/website/docs/r/servicehook_webhook.html.markdown
+++ b/website/docs/r/servicehook_webhook.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_servicehook_webhook"
+description: |-
+  Manages a Webhook service hook Azure DevOps organization.
+---
+
+# azuredevops_servicehook_webhook (Resource)
+
+Manages a Webhook service hook Azure DevOps organization.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "project" {
+  name               = "Sample Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "repo" {
+  project_id = azuredevops_project.project.id
+  name       = "Sample Empty Git Repository"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_servicehook_webhook" "webhook" {
+  project_id = azuredevops_project.project.id
+  event_type = "git.push"
+  url        = "https://my-webhooks.org"
+
+  # optional
+  basic_auth {
+    username = "my_username"
+    password = "my_password"
+  }
+
+  # optional
+  filters = {
+    repository = azuredevops_git_repository.repo.id
+  }
+
+  # optional
+  http_headers = {
+    Authorization = "Bearer bearing"
+    X-My-Header   = "header value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The project ID or project name.
+- `event_type` - (Required) Event type.
+- `url` - (Required) The url of the hook to invoke.
+- `basic_auth` - (Optional) Basic authentication.
+  - `username`
+  - `password`
+- `filters` - (Optional) Filters that depend on event type.
+- `http_headers` - (Optional) HTTP headers included in request.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The ID of the service hook webhook.
+- `project_id` - The project ID or project name.
+- `event_type` - Event type.
+- `url` - The url of the hook to invoke.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 5.1 - Service hooks](https://docs.microsoft.com/en-us/rest/api/azure/devops/hooks/?view=azure-devops-rest-5.1)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Added:
* resource `azuredevops_servicehook_webhook`
* acceptance tests for `azuredevops_servicehook_webhook` resource
* documentation for `azuredevops_servicehook_webhook` resource

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [x] Yes
- [ ] No

reason:
* minor bump in `azure-devops-go-api` dependency
* service hooks client is now being used

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

## Other information

Locally built and tested manually.