### PR TITLE
adding statusGenre as optional field, fixing/updating docs as well

### DIFF
--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_status_check.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_status_check.go
@@ -30,6 +30,10 @@ func ResourceBranchPolicyStatusCheck() *schema.Resource {
 		Type:     schema.TypeString,
 		Required: true,
 	}
+	settingsSchema["genre"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
 	settingsSchema["author_id"] = &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
@@ -77,6 +81,7 @@ func statusCheckFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyC
 	settings := settingsList[0].(map[string]interface{})
 
 	settings["name"] = policySettings["statusName"]
+	settings["genre"] = policySettings["statusGenre"]
 	settings["author_id"] = policySettings["authorId"]
 	settings["invalidate_on_update"] = policySettings["invalidateOnSourceUpdate"]
 	settings["display_name"] = policySettings["defaultDisplayName"]
@@ -108,6 +113,7 @@ func statusCheckExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.Po
 
 	policySettings := policyConfig.Settings.(map[string]interface{})
 	policySettings["statusName"] = settings["name"].(string)
+	policySettings["statusGenre"] = settings["genre"].(string)
 	policySettings["authorId"] = settings["author_id"].(string)
 	policySettings["invalidateOnSourceUpdate"] = settings["invalidate_on_update"].(bool)
 	policySettings["defaultDisplayName"] = settings["display_name"].(string)

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -69,7 +69,8 @@ The following arguments are supported:
 
 `settings` block supports the following:
 
-- `status_name` - (Required) The status name to check.
+- `name` - (Required) The status name to check.
+- `genre` - (Optional) The genre of the status to check (see [Microsoft Documentation](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-request-status?view=azure-devops#status-policy))
 - `author_id` - (Optional) The authorized user can post the status.
 - `invalidate_on_update` - (Optional) Reset status whenever there are new changes.
 - `applicability` - (Optional) Policy applicability. If policy `applicability` is `default`, apply unless "Not Applicable" 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

fixes #472 
As described in above issue, the branch policy status check currently does not support setting statusGenre. This PR introduces changes necessary to optionally specify the genre under settings. I have also updated the documentation to reflect this.

Issue Number: #472

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

I will extend the existing acceptance test to cover the new field later tonight if I find time.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->