### PR TITLE
fix: allow generic groups to be returned when searching the organization

### DIFF
--- a/azuredevops/internal/service/graph/data_group.go
+++ b/azuredevops/internal/service/graph/data_group.go
@@ -113,18 +113,26 @@ func getGroupsForDescriptor(clients *client.AggregatedClient, projectDescriptor 
 		if err != nil {
 			return nil, err
 		}
+
 		if newGroups != nil && len(*newGroups) > 0 {
 			if projectDescriptor == "" {
 				// filter on collection groups
 				filteredGroups := []graph.GraphGroup{}
 				for _, grp := range *newGroups {
-					if grp.Domain != nil && strings.HasPrefix(strings.ToLower(*grp.Domain), "vstfs:///framework/identitydomain") {
+					if grp.Domain == nil {
+						continue
+					}
+
+					domain := strings.ToLower(*grp.Domain)
+					if strings.HasPrefix(domain, "vstfs:///framework/identitydomain") ||
+						(strings.HasPrefix(domain, "vstfs:///framework/generic")) {
 						filteredGroups = append(filteredGroups, grp)
 					}
 				}
-				newGroups = &filteredGroups
+				groups = append(groups, filteredGroups...)
+			} else {
+				groups = append(groups, *newGroups...)
 			}
-			groups = append(groups, *newGroups...)
 		}
 		hasMore = currentToken != ""
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~I have updated the documentation accordingly.~
* [ ] ~I have added tests to cover my changes.~
    Adding new tests is not possible, as I believe the bug only present itself in old AZDO organizations.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Some Azure Devops Groups are not returned when searching in the organization.

I have compared the payloads from 2 organizations and have noticed that the domain suffix is different.
`vstfs:///Framework/Generic` compared with `vstfs:///Framework/IdentityDomain`

One difference between the organizations is their age; one is quite old and one was created very recently.

### Old Org
```bash
curl -LsS -u "user:$AZDO_PERSONAL_ACCESS_TOKEN" -H 'Accept:application/json' https://vssps.dev.azure.com/oldOrg/_apis/graph/groups\?api-version\=6.0-preview.1 | jq '.value[] | select(.displayName == "test")'

{
  "subjectKind": "group",
  "description": "",
  "domain": "vstfs:///Framework/Generic/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
  "principalName": "[oldOrg]\\test",
  "mailAddress": null,
  "origin": "vsts",
  "originId": "...",
  "displayName": "test",
  "_links": {
  "self": {
      "href": "..."
  },
  "memberships": {
      "href": "..."
  },
  "membershipState": {
      "href": "..."
  },
  "storageKey": {
      "href": "..."
  }
  },
  "url": "https://vssps.dev.azure.com/oldOrg/_apis/Graph/Groups/...",
  "descriptor": "..."
}
```

### New Org

```bash
curl -LsS -u "user:$AZDO_PERSONAL_ACCESS_TOKEN" -H 'Accept:application/json' https://vssps.dev.azure.com/newOrg/_apis/graph/groups\?api-version\=6.0-preview.1 | jq '.value[] | select(.displayName == "test")'

{
  "subjectKind": "group",
  "description": "",
  "domain": "vstfs:///Framework/IdentityDomain/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
  "principalName": "[newOrg]\\test",
  "mailAddress": null,
  "origin": "vsts",
  "originId": "...",
  "displayName": "test",
  "_links": {
    "self": {
      "href": "..."
    },
    "memberships": {
      "href": "..."
    },
    "membershipState": {
      "href": "..."
    },
    "storageKey": {
      "href": "..."
    }
  },
  "url": "https://vssps.dev.azure.com/newOrg/_apis/Graph/Groups/...",
  "descriptor": "..."
}
```

Issue Number: #485

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
