### PR TITLE
[azuredevops_git_repository] Enhance initialization checks for default_branch

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -157,7 +157,8 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	repo, initialization, projectID, err := expandGitRepository(d)
 	if err != nil {
-		return fmt.Errorf("Error expanding repository resource data: %+v", err)
+		return fmt.Errorf(" failed expanding repository resource data (ProjectID:  %s, Repository: %s) Error: %+v",
+			d.Get("project_id").(string), d.Get("name").(string), err)
 	}
 
 	var parentRepoRef *git.GitRepositoryRef = nil
@@ -465,6 +466,13 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 			initialization.sourceURL = ""
 			initialization.serviceConnectionID = ""
 		}
+
+		if _, ok := d.GetOk("default_branch"); ok {
+			if strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Uninitialized)) {
+				return nil, nil, nil, fmt.Errorf(" Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannt not be set.")
+			}
+		}
+
 	} else if len(initData) > 1 {
 		return nil, nil, nil, fmt.Errorf("Multiple initialization blocks")
 	}

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -472,7 +472,6 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 				return nil, nil, nil, fmt.Errorf(" Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannt not be set.")
 			}
 		}
-
 	} else if len(initData) > 1 {
 		return nil, nil, nil, fmt.Errorf("Multiple initialization blocks")
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
Enhance `default_branch` checks. This is a workaround for current `azuredevops_git_repository` resource,  better choice is separate the initialization types to difference resources.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #498 

AccTests
```log
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== RUN   TestAccGitRepo_PrivateImport_BranchNotEmpty
=== PAUSE TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
=== CONT  TestAccGitRepo_Create_Import
=== CONT  TestAccGitRepo_CreateAndUpdate
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (0.11s)
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (55.40s)
--- PASS: TestAccGitRepository_DataSource (94.90s)
--- PASS: TestAccGitRepo_Create_Import (107.92s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (126.24s)
--- PASS: TestAccGitRepo_CreateAndUpdate (153.49s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (154.43s)
--- PASS: TestAccGitRepo_PrivateImport_BranchNotEmpty (157.74s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        342.106s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->