### PR TITLE
Bugfix/513 pipline folder path validation

### DIFF
--- a/azuredevops/internal/utils/validate/file_path.go
+++ b/azuredevops/internal/utils/validate/file_path.go
@@ -24,6 +24,10 @@ func Path(i interface{}, k string) (warnings []string, errors []error) {
 		errors = append(errors, fmt.Errorf("path must start with backslash"))
 	}
 
+	if len(v) >= 2 && v[len(v)-1:] == `\` {
+		errors = append(errors, fmt.Errorf("path must not end with backslash when not the root path"))
+	}
+
 	p := InvalidWindowsPathRegExp.MatchString(v)
 	if p {
 		errors = append(errors, fmt.Errorf("<>|:$@\"/%%+*? are not allowed in path"))

--- a/azuredevops/internal/utils/validate/file_path_test.go
+++ b/azuredevops/internal/utils/validate/file_path_test.go
@@ -20,6 +20,21 @@ func TestPathValidation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    `\SomePath`,
+			TestName: "Custom Path",
+			ErrCount: 0,
+		},
+		{
+			Value:    `\Some Path`,
+			TestName: "Custom Path With Whitespace",
+			ErrCount: 0,
+		},
+		{
+			Value:    `\Some Path\With Nested\Folders`,
+			TestName: "Custom Nested Path",
+			ErrCount: 0,
+		},
+		{
 			Value:    "",
 			TestName: "Empty Path",
 			ErrCount: 1,
@@ -27,6 +42,11 @@ func TestPathValidation(t *testing.T) {
 		{
 			Value:    "A",
 			TestName: "Wrong Starting Character",
+			ErrCount: 1,
+		},
+		{
+			Value:    "\Some Path\",
+			TestName: "Wrong Ending Character",
 			ErrCount: 1,
 		},
 	}

--- a/azuredevops/internal/utils/validate/file_path_test.go
+++ b/azuredevops/internal/utils/validate/file_path_test.go
@@ -1,3 +1,4 @@
+//go:build all || utils || path
 // +build all utils path
 
 package validate
@@ -35,17 +36,17 @@ func TestPathValidation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "",
+			Value:    ``,
 			TestName: "Empty Path",
 			ErrCount: 1,
 		},
 		{
-			Value:    "A",
+			Value:    `A`,
 			TestName: "Wrong Starting Character",
 			ErrCount: 1,
 		},
 		{
-			Value:    "\Some Path\",
+			Value:    `\Some Path\`,
 			TestName: "Wrong Ending Character",
 			ErrCount: 1,
 		},

--- a/website/docs/r/build_definition.html.markdown
+++ b/website/docs/r/build_definition.html.markdown
@@ -361,6 +361,17 @@ The `schedules` block exports the following:
 
 - `schedule_job_id` - The ID of the schedule job 
 
+## Remarks
+
+The path attribute can not end in `\` unless the path is the root value of `\`. 
+
+Valid path values (yaml encoded) include:
+- `\\`
+- `\\ExampleFolder`
+- `\\Nested\\Example Folder`
+
+The value of `\\ExampleFolder\\` would be invalid.
+
 ## Relevant Links
 
 - [Azure DevOps Service REST API 5.1 - Build Definitions](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/definitions?view=azure-devops-rest-5.1)


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

**NOTE:** I don't know go or have any tools installed to validate these changes. Although the change itself and related unit tests are trivial, I have taken a best guess at what the correct outcome should be.

## What about the current behavior has changed?

Added validation of build/pipeline to ensure that path that should not end with a backslash when not the root path.

Issue Number: #513 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Yes in that a plan that previously passed would now produce an error. No from a pure hcl point of view.

The fix is for developers to follow the validation failure on build definition path and remove trailing backslash characters.

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->