### PR TITLE
feat: add a new resource azuredevops_environment

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_environment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_test.go
@@ -1,0 +1,133 @@
+//go:build (all || resource_environment) && !exclude_resource_environment
+// +build all resource_environment
+// +build !exclude_resource_environment
+
+package acceptancetests
+
+import (
+	"fmt"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// Verifies that the following sequence of events occurrs without error:
+//	(1) TF apply creates environment
+//	(2) TF state values are set
+//	(3) Environment can be queried by ID and has expected name
+//	(4) TF apply updates environment with new name
+//	(5) Environment can be queried by ID and has expected name
+//	(6) TF destroy deletes environment
+//	(7) Environment can no longer be queried by ID
+func TestAccEnvironment_CreateAndUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	environmentNameFirst := testutils.GenerateResourceName()
+	environmentNameSecond := testutils.GenerateResourceName()
+	tfNode := "azuredevops_environment.environment"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkEnvironmentDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.HclEnvironmentResource(projectName, environmentNameFirst),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "name", environmentNameFirst),
+					resource.TestCheckResourceAttr(tfNode, "description", ""),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					checkEnvironmentExists(environmentNameFirst),
+				),
+			},
+			{
+				Config: testutils.HclEnvironmentResource(projectName, environmentNameSecond),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "name", environmentNameSecond),
+					resource.TestCheckResourceAttr(tfNode, "description", ""),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					checkEnvironmentExists(environmentNameSecond),
+				),
+			},
+			{
+				// Resource Acceptance Testing https://www.terraform.io/docs/extend/resources/import.html#resource-acceptance-testing-implementation
+				ResourceName:      tfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Given the name of an environment, this will return a function that will check whether
+// or not the environment (1) exists in the state and (2) exist in AzDO and (3) has the correct name
+func checkEnvironmentExists(expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, ok := s.RootModule().Resources["azuredevops_environment.environment"]
+		if !ok {
+			return fmt.Errorf("Did not find an environment in the TF state")
+		}
+
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+		id, err := strconv.Atoi(resource.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Parse ID error, ID:  %v !. Error= %v", resource.Primary.ID, err)
+		}
+		projectID := resource.Primary.Attributes["project_id"]
+
+		environment, err := readEnvironment(clients, id, projectID)
+
+		if err != nil {
+			return fmt.Errorf("Environment with ID=%d cannot be found!. Error=%v", id, err)
+		}
+
+		if *environment.Name != expectedName {
+			return fmt.Errorf("Environment with ID=%d has Name=%s, but expected Name=%s", id, *environment.Name, expectedName)
+		}
+
+		return nil
+	}
+}
+
+// verifies that environment referenced in the state is destroyed. This will be invoked
+// *after* terraform destroys the resource but *before* the state is wiped clean.
+func checkEnvironmentDestroyed(s *terraform.State) error {
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+
+	// verify that every environment referenced in the state does not exist in AzDO
+	for _, resource := range s.RootModule().Resources {
+		if resource.Type != "azuredevops_environment" {
+			continue
+		}
+
+		id, err := strconv.Atoi(resource.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Environment ID=%d cannot be parsed!. Error=%v", id, err)
+		}
+		projectID := resource.Primary.Attributes["project_id"]
+
+		// indicates the environment still exists - this should fail the test
+		if _, err := readEnvironment(clients, id, projectID); err == nil {
+			return fmt.Errorf("Environment ID %d should not exist", id)
+		}
+	}
+
+	return nil
+}
+
+// Lookup an Environment using the ID and the project ID.
+func readEnvironment(clients *client.AggregatedClient, environmentID int, projectID string) (*taskagent.EnvironmentInstance, error) {
+	return clients.TaskAgentClient.GetEnvironmentById(
+		clients.Ctx,
+		taskagent.GetEnvironmentByIdArgs{
+			Project:       converter.String(projectID),
+			EnvironmentId: &environmentID,
+		},
+	)
+}

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -913,3 +913,19 @@ resource "azuredevops_team" "team" {
 }
 `, teamResource)
 }
+
+func getEnvironmentResource(environmentName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_environment" "environment" {
+	project_id = azuredevops_project.project.id
+	name       = "%s"
+}`, environmentName)
+}
+
+// HclEnvironmentResource HCL describing an AzDO environment resource
+func HclEnvironmentResource(projectName string, environmentName string) string {
+	azureEnvironmentResource := getEnvironmentResource(environmentName)
+
+	projectResource := HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, azureEnvironmentResource)
+}

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -113,12 +113,11 @@ func resourceEnvironmentRead(d *schema.ResourceData, m interface{}) error {
 		Project:       converter.String(d.Get(projectID).(string)),
 	})
 
-	if utils.ResponseWasNotFound(err) {
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading the environment resource: %+v", err)
 	}
 

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -61,39 +61,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	flattenEnvironment(d, createdEnvironment)
-
 	return resourceEnvironmentRead(d, m)
-}
-
-func expandEnvironment(d *schema.ResourceData) (*taskagent.EnvironmentInstance, error) {
-	projectId, err := uuid.Parse(d.Get(envProjectId).(string))
-	if err != nil {
-		return nil, fmt.Errorf(" faild parse project ID to UUID: %s, %+v", projectID, err)
-	}
-	environment := &taskagent.EnvironmentInstance{
-		Name:        converter.String(d.Get(envName).(string)),
-		Description: converter.String(d.Get(envDescription).(string)),
-		Project: &taskagent.ProjectReference{
-			Id: &projectId,
-		},
-	}
-	// Look for the ID. This may not exist if we are within the context of a "create" operation,
-	// so it is OK if it is missing.
-	if d.Id() != "" {
-		environmentId, err := strconv.Atoi(d.Id())
-		if err != nil {
-			return nil, fmt.Errorf("Error getting environment id: %+v", err)
-		}
-		environment.Id = &environmentId
-	}
-	return environment, nil
-}
-
-func flattenEnvironment(d *schema.ResourceData, environment *taskagent.EnvironmentInstance) {
-	d.SetId(strconv.Itoa(*environment.Id))
-	d.Set(envProjectId, environment.Project.Id.String())
-	d.Set(envName, *environment.Name)
-	d.Set(envDescription, converter.ToString(environment.Description, ""))
 }
 
 func resourceEnvironmentRead(d *schema.ResourceData, m interface{}) error {
@@ -117,7 +85,6 @@ func resourceEnvironmentRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	flattenEnvironment(d, environment)
-
 	return nil
 }
 
@@ -179,4 +146,35 @@ func updateEnvironment(clients *client.AggregatedClient, environment *taskagent.
 				Description: environment.Description,
 			},
 		})
+}
+
+func expandEnvironment(d *schema.ResourceData) (*taskagent.EnvironmentInstance, error) {
+	projectId, err := uuid.Parse(d.Get(envProjectId).(string))
+	if err != nil {
+		return nil, fmt.Errorf(" faild parse project ID to UUID: %s, %+v", projectID, err)
+	}
+	environment := &taskagent.EnvironmentInstance{
+		Name:        converter.String(d.Get(envName).(string)),
+		Description: converter.String(d.Get(envDescription).(string)),
+		Project: &taskagent.ProjectReference{
+			Id: &projectId,
+		},
+	}
+	// Look for the ID. This may not exist if we are within the context of a "create" operation,
+	// so it is OK if it is missing.
+	if d.Id() != "" {
+		environmentId, err := strconv.Atoi(d.Id())
+		if err != nil {
+			return nil, fmt.Errorf("Error getting environment id: %+v", err)
+		}
+		environment.Id = &environmentId
+	}
+	return environment, nil
+}
+
+func flattenEnvironment(d *schema.ResourceData, environment *taskagent.EnvironmentInstance) {
+	d.SetId(strconv.Itoa(*environment.Id))
+	d.Set(envProjectId, environment.Project.Id.String())
+	d.Set(envName, *environment.Name)
+	d.Set(envDescription, converter.ToString(environment.Description, ""))
 }

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -1,0 +1,199 @@
+package taskagent
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+const (
+	envProjectId   = "project_id"
+	envName        = "name"
+	envDescription = "description"
+)
+
+// ResourceEnvironment schema and implementation for environment resource
+func ResourceEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceEnvironmentCreate,
+		Read:     resourceEnvironmentRead,
+		Update:   resourceEnvironmentUpdate,
+		Delete:   resourceEnvironmentDelete,
+		Importer: tfhelper.ImportProjectQualifiedResourceInteger(),
+		Schema: map[string]*schema.Schema{
+			envProjectId: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			envName: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			envDescription: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+		},
+	}
+}
+
+func resourceEnvironmentCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	environment, err := expandEnvironment(d, true)
+	if err != nil {
+		return fmt.Errorf("Error expanding the environment resource from state: %+v", err)
+	}
+
+	createdEnvironment, err := createEnvironment(clients, environment)
+	if err != nil {
+		return fmt.Errorf("Error creating environment in Azure DevOps: %+v", err)
+	}
+
+	err = flattenEnvironment(d, createdEnvironment)
+
+	if err != nil {
+		return fmt.Errorf("Error flattening environment: %+v", err)
+	}
+
+	return resourceEnvironmentRead(d, m)
+}
+
+func expandEnvironment(d *schema.ResourceData, forCreate bool) (*taskagent.EnvironmentInstance, error) {
+	// Look for the ID. This may not exist if we are within the context of a "create" operation,
+	// so it is OK if it is missing.
+	environmentId, err := strconv.Atoi(d.Id())
+	if !forCreate && err != nil {
+		return nil, fmt.Errorf("Error getting environment id: %+v", err)
+	}
+
+	projectId, err := uuid.Parse(d.Get(envProjectId).(string))
+	if err != nil {
+		return nil, fmt.Errorf(" faild parse project ID to UUID: %s, %+v", projectID, err)
+	}
+	environment := &taskagent.EnvironmentInstance{
+		Id:          &environmentId,
+		Name:        converter.String(d.Get(envName).(string)),
+		Description: converter.String(d.Get(envDescription).(string)),
+		Project: &taskagent.ProjectReference{
+			Id: &projectId,
+		},
+	}
+
+	return environment, nil
+}
+
+func flattenEnvironment(d *schema.ResourceData, environment *taskagent.EnvironmentInstance) error {
+	d.SetId(strconv.Itoa(*environment.Id))
+	d.Set(envProjectId, environment.Project.Id.String())
+	d.Set(envName, *environment.Name)
+	d.Set(envDescription, converter.ToString(environment.Description, ""))
+	return nil
+}
+
+func resourceEnvironmentRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	environmentID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error getting environment Id: %+v", err)
+	}
+
+	environment, err := clients.TaskAgentClient.GetEnvironmentById(clients.Ctx, taskagent.GetEnvironmentByIdArgs{
+		EnvironmentId: &environmentID,
+		Project:       converter.String(d.Get(projectID).(string)),
+	})
+
+	if utils.ResponseWasNotFound(err) {
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error reading the environment resource: %+v", err)
+	}
+
+	err = flattenEnvironment(d, environment)
+
+	if err != nil {
+		return fmt.Errorf("Error flattening environment: %+v", err)
+	}
+
+	return nil
+}
+
+func resourceEnvironmentUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	environment, err := expandEnvironment(d, false)
+	if err != nil {
+		return fmt.Errorf("Error converting terraform data model to AzDO environment reference: %+v", err)
+	}
+
+	_, err = updateEnvironment(clients, environment)
+	if err != nil {
+		return fmt.Errorf("Error updating environment in Azure DevOps: %+v", err)
+	}
+
+	return resourceEnvironmentRead(d, m)
+}
+
+func resourceEnvironmentDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	environmentId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error getting environment id: %+v", err)
+	}
+
+	err = clients.TaskAgentClient.DeleteEnvironment(clients.Ctx, taskagent.DeleteEnvironmentArgs{
+		Project:       converter.String(d.Get(projectID).(string)),
+		EnvironmentId: &environmentId,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting environment: %+v", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func createEnvironment(clients *client.AggregatedClient, environment *taskagent.EnvironmentInstance) (*taskagent.EnvironmentInstance, error) {
+	projectID := environment.Project.Id.String()
+
+	createParams := taskagent.EnvironmentCreateParameter{
+		Name:        environment.Name,
+		Description: environment.Description,
+	}
+
+	args := taskagent.AddEnvironmentArgs{
+		Project:                    &projectID,
+		EnvironmentCreateParameter: &createParams,
+	}
+
+	newEnvironment, err := clients.TaskAgentClient.AddEnvironment(clients.Ctx, args)
+
+	return newEnvironment, err
+}
+
+func updateEnvironment(clients *client.AggregatedClient, environment *taskagent.EnvironmentInstance) (*taskagent.EnvironmentInstance, error) {
+	projectID := environment.Project.Id.String()
+	return clients.TaskAgentClient.UpdateEnvironment(
+		clients.Ctx,
+		taskagent.UpdateEnvironmentArgs{
+			Project:       &projectID,
+			EnvironmentId: environment.Id,
+			EnvironmentUpdateParameter: &taskagent.EnvironmentUpdateParameter{
+				Name:        environment.Name,
+				Description: environment.Description,
+			},
+		})
+}

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/taskagent/validate"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
@@ -36,8 +37,9 @@ func ResourceEnvironment() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 			envName: {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.EnvironmentName,
 			},
 			envDescription: {
 				Type:     schema.TypeString,

--- a/azuredevops/internal/service/taskagent/resource_environment_test.go
+++ b/azuredevops/internal/service/taskagent/resource_environment_test.go
@@ -1,0 +1,150 @@
+//go:build (all || resource_environment) && !exclude_resource_environment
+// +build all resource_environment
+// +build !exclude_resource_environment
+
+package taskagent
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+)
+
+var testEnvironmentProjectId = uuid.New()
+var testEnvironmentId = rand.Intn(100)
+
+var testEnvironment = taskagent.EnvironmentInstance{
+	Id:          &testEnvironmentId,
+	Name:        converter.String("EnvironmentName"),
+	Description: converter.String(""),
+	Project: &taskagent.ProjectReference{
+		Id: &testEnvironmentProjectId,
+	},
+}
+
+// verifies that the flatten/expand round trip yields the same definition
+func TestEnvironment_ExpandFlatten_Roundtrip(t *testing.T) {
+	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
+	flattenEnvironment(resourceData, &testEnvironment)
+	environmentAfterRoundTrip, err := expandEnvironment(resourceData, true)
+	require.Nil(t, err)
+	require.Equal(t, testEnvironment, *environmentAfterRoundTrip)
+}
+
+// verifies that the create operation is considered failed if the API call fails.
+func TestEnvironment_CreateEnvironment_DoesNotSwallowErrorFromFailedAddAgentCall(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	taskAgentClient := azdosdkmocks.NewMockTaskagentClient(ctrl)
+	clients := &client.AggregatedClient{
+		TaskAgentClient: taskAgentClient,
+		Ctx:             context.Background(),
+	}
+
+	projectId := testEnvironment.Project.Id.String()
+	expectedArgs := taskagent.AddEnvironmentArgs{
+		Project: &projectId,
+		EnvironmentCreateParameter: &taskagent.EnvironmentCreateParameter{
+			Name:        testEnvironment.Name,
+			Description: testEnvironment.Description,
+		},
+	}
+
+	taskAgentClient.
+		EXPECT().
+		AddEnvironment(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("AddEnvironment() Failed")).
+		Times(1)
+
+	newEnvironment, err := createEnvironment(clients, &testEnvironment)
+	require.Nil(t, newEnvironment)
+	require.Equal(t, "AddEnvironment() Failed", err.Error())
+}
+
+func TestEnvironment_DeleteEnvironment_ReturnsErrorIfIdReadFails(t *testing.T) {
+	client := &client.AggregatedClient{}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
+	flattenEnvironment(resourceData, &testEnvironment)
+	resourceData.SetId("")
+
+	err := resourceEnvironmentDelete(resourceData, client)
+	require.Equal(t, "Error getting environment id: strconv.Atoi: parsing \"\": invalid syntax", err.Error())
+}
+
+func TestEnvironment_UpdateEnvironment_ReturnsErrorIfIdReadFails(t *testing.T) {
+	client := &client.AggregatedClient{}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
+	flattenEnvironment(resourceData, &testEnvironment)
+	resourceData.SetId("")
+
+	err := resourceEnvironmentUpdate(resourceData, client)
+	require.Equal(t, "Error converting terraform data model to AzDO environment reference: Error getting environment id: strconv.Atoi: parsing \"\": invalid syntax", err.Error())
+}
+
+func TestEnvironment_UpdateEnvironment_UpdateAndRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	taskAgentClient := azdosdkmocks.NewMockTaskagentClient(ctrl)
+	clients := &client.AggregatedClient{
+		TaskAgentClient: taskAgentClient,
+		Ctx:             context.Background(),
+	}
+
+	environmentToUpdate := taskagent.EnvironmentInstance{
+		Id:          &testEnvironmentId,
+		Name:        converter.String("Updated Name"),
+		Description: converter.String("Some Description"),
+		Project: &taskagent.ProjectReference{
+			Id: &testEnvironmentProjectId,
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
+	flattenEnvironment(resourceData, &environmentToUpdate)
+
+	projectIdString := testEnvironmentProjectId.String()
+	taskAgentClient.
+		EXPECT().
+		UpdateEnvironment(clients.Ctx, taskagent.UpdateEnvironmentArgs{
+			Project:       &projectIdString,
+			EnvironmentId: &testEnvironmentId,
+			EnvironmentUpdateParameter: &taskagent.EnvironmentUpdateParameter{
+				Name:        environmentToUpdate.Name,
+				Description: environmentToUpdate.Description,
+			},
+		}).
+		Return(&environmentToUpdate, nil).
+		Times(1)
+
+	taskAgentClient.
+		EXPECT().
+		GetEnvironmentById(clients.Ctx, taskagent.GetEnvironmentByIdArgs{
+			Project:       &projectIdString,
+			EnvironmentId: &testEnvironmentId,
+		}).
+		Return(&environmentToUpdate, nil).
+		Times(1)
+
+	err := resourceEnvironmentUpdate(resourceData, clients)
+	require.Nil(t, err)
+
+	updatedEnvironment, _ := expandEnvironment(resourceData, false)
+	require.Equal(t, environmentToUpdate.Id, updatedEnvironment.Id)
+	require.Equal(t, environmentToUpdate.Name, updatedEnvironment.Name)
+	require.Equal(t, environmentToUpdate.Description, updatedEnvironment.Description)
+	require.Equal(t, environmentToUpdate.Project.Id, updatedEnvironment.Project.Id)
+}

--- a/azuredevops/internal/service/taskagent/resource_environment_test.go
+++ b/azuredevops/internal/service/taskagent/resource_environment_test.go
@@ -36,7 +36,7 @@ var testEnvironment = taskagent.EnvironmentInstance{
 func TestEnvironment_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
 	flattenEnvironment(resourceData, &testEnvironment)
-	environmentAfterRoundTrip, err := expandEnvironment(resourceData, true)
+	environmentAfterRoundTrip, err := expandEnvironment(resourceData)
 	require.Nil(t, err)
 	require.Equal(t, testEnvironment, *environmentAfterRoundTrip)
 }
@@ -88,10 +88,10 @@ func TestEnvironment_UpdateEnvironment_ReturnsErrorIfIdReadFails(t *testing.T) {
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceEnvironment().Schema, nil)
 	flattenEnvironment(resourceData, &testEnvironment)
-	resourceData.SetId("")
+	resourceData.SetId("some-other-id")
 
 	err := resourceEnvironmentUpdate(resourceData, client)
-	require.Equal(t, "Error converting terraform data model to AzDO environment reference: Error getting environment id: strconv.Atoi: parsing \"\": invalid syntax", err.Error())
+	require.Equal(t, "Error converting terraform data model to AzDO environment reference: Error getting environment id: strconv.Atoi: parsing \"some-other-id\": invalid syntax", err.Error())
 }
 
 func TestEnvironment_UpdateEnvironment_UpdateAndRead(t *testing.T) {
@@ -142,7 +142,7 @@ func TestEnvironment_UpdateEnvironment_UpdateAndRead(t *testing.T) {
 	err := resourceEnvironmentUpdate(resourceData, clients)
 	require.Nil(t, err)
 
-	updatedEnvironment, _ := expandEnvironment(resourceData, false)
+	updatedEnvironment, _ := expandEnvironment(resourceData)
 	require.Equal(t, environmentToUpdate.Id, updatedEnvironment.Id)
 	require.Equal(t, environmentToUpdate.Name, updatedEnvironment.Name)
 	require.Equal(t, environmentToUpdate.Description, updatedEnvironment.Description)

--- a/azuredevops/internal/service/taskagent/validate/environment_name.go
+++ b/azuredevops/internal/service/taskagent/validate/environment_name.go
@@ -1,0 +1,18 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func EnvironmentName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	// Portal: The value must contain only alphanumeric characters or the following: -
+	if matched := regexp.MustCompile(`^[^,^"^/^\\^\[^\]^:^|^<^>^+^=^;^?^*]{0,127}$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("test: %s, Environment name '%s' is not valid. "+
+			"A valid name is less than 128 characters in length and does not contain the following "+
+			"characters: ',', '\"', '/', '\\', '[', ']', ':', '|', '<', '>', '+', '=', ';', '?', '*', '.'", k, v))
+	}
+	return warnings, errors
+}

--- a/azuredevops/internal/service/taskagent/validate/environment_name_test.go
+++ b/azuredevops/internal/service/taskagent/validate/environment_name_test.go
@@ -1,0 +1,80 @@
+package validate
+
+import "testing"
+
+func TestEnvironmentName(t *testing.T) {
+	testData := []struct {
+		Value string
+		Error bool
+	}{
+		{
+			Value: "a1",
+			Error: false,
+		},
+		{
+			Value: "11",
+			Error: false,
+		},
+		{
+			Value: "1a",
+			Error: false,
+		},
+		{
+			Value: "aa",
+			Error: false,
+		},
+		{
+			Value: "1-1",
+			Error: false,
+		},
+		{
+			Value: "a",
+			Error: false,
+		},
+		{
+			Value: "1",
+			Error: false,
+		},
+		{
+			Value: "1-",
+			Error: false,
+		},
+		{
+			Value: "a-",
+			Error: false,
+		},
+		{
+			Value: "a1-",
+			Error: false,
+		},
+		{
+			Value: "1a--1-1-a-",
+			Error: false,
+		},
+		{
+			Value: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde123",
+			Error: false,
+		},
+		{
+			Value: "[]",
+			Error: true,
+		},
+		{
+			Value: "\"/\\[]:|<>+=;,?*.",
+			Error: true,
+		},
+		{
+			Value: "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Value)
+
+		_, err := EnvironmentName(v.Value, "unit test")
+		if err != nil && !v.Error {
+			t.Fatalf("Expected pass but got an error: %s", err)
+		}
+	}
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -77,6 +77,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_permissions":            permissions.ResourceServiceEndpointPermissions(),
 			"azuredevops_servicehook_permissions":                permissions.ResourceServiceHookPermissions(),
 			"azuredevops_tagging_permissions":                    permissions.ResourceTaggingPermissions(),
+			"azuredevops_environment":                            taskagent.ResourceEnvironment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"azuredevops_agent_pool":       taskagent.DataAgentPool(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -65,6 +65,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_permissions",
 		"azuredevops_servicehook_permissions",
 		"azuredevops_tagging_permissions",
+		"azuredevops_environment",
 	}
 
 	resources := Provider().ResourcesMap

--- a/website/docs/r/environment.html.markdown
+++ b/website/docs/r/environment.html.markdown
@@ -12,11 +12,11 @@ Manages an Environment.
 ## Example Usage
 
 ```hcl
-resource "azuredevops_project" "p" {
+resource "azuredevops_project" "example" {
   name = "Sample Project"
 }
 
-resource "azuredevops_environment" "env" {
+resource "azuredevops_environment" "example" {
   project_id = azuredevops_project.p.id
   name       = "Sample Environment"
 }
@@ -47,5 +47,5 @@ In addition to the Arguments listed above - the following Attributes are exporte
 Azure DevOps Environments can be imported using the project ID and environment ID, e.g.:
 
 ```shell
-terraform import azuredevops_environment.example 00000000-0000-0000-0000-000000000000/0
+$ terraform import azuredevops_environment.example 00000000-0000-0000-0000-000000000000/0
 ```

--- a/website/docs/r/environment.html.markdown
+++ b/website/docs/r/environment.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_environment"
+description: |-
+  Manages an Environment.
+---
+
+# azuredevops_environment
+
+Manages an Environment.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "p" {
+  name = "Sample Project"
+}
+
+resource "azuredevops_environment" "env" {
+  project_id = azuredevops_project.p.id
+  name       = "Sample Environment"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Environment.
+
+* `project_id` - (Required) The ID of the project. Changing this forces a new Environment to be created.
+
+---
+
+* `description` - (Optional) A description for the Environment.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Environment.
+
+
+
+## Import
+
+Azure DevOps Environments can be imported using the project ID and environment ID, e.g.:
+
+```shell
+terraform import azuredevops_environment.example 00000000-0000-0000-0000-000000000000/0
+```


### PR DESCRIPTION

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This pull request implements a new resource `azuredevops_environment`.
https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/environments?view=azure-devops-rest-6.0

Issue Number: #143 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

All unit tests pass and the new acceptance test passes. I also tested manually.

`make ci` does find 9 errors in its last step `==> Checking documentation for errors...`.
Those 9 errors are in unrelated website markdown files and its always missing whitespaces at the beginning of the newline in the `description` of the header.


## Other information

Closes: #143 

I'm not that firm in golang yet, but I try :)

I was not able to add the possibility to add approvals and checks, because they need api version 6.1.
https://docs.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/check-configurations/add?view=azure-devops-rest-6.1