### PR TITLE
Remove "ConflictsWith" to fix broken reset all branch policy

### DIFF
--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
@@ -16,9 +16,9 @@ type minReviewerPolicySettings struct {
 	ApprovalCount                     int  `json:"minimumApproverCount" tf:"reviewer_count"`
 	SubmitterCanVote                  bool `json:"creatorVoteCounts" tf:"submitter_can_vote"`
 	AllowCompletionWithRejectsOrWaits bool `json:"allowDownvotes" tf:"allow_completion_with_rejects_or_waits"`
-	OnPushResetApprovedVotes          bool `json:"resetOnSourcePush" tf:"on_push_reset_approved_votes" ConflictsWith:"on_push_reset_all_votes"`
+	OnPushResetApprovedVotes          bool `json:"resetOnSourcePush" tf:"on_push_reset_approved_votes"`
 	OnLastIterationRequireVote        bool `json:"requireVoteOnLastIteration" tf:"on_last_iteration_require_vote"`
-	OnPushResetAllVotes               bool `json:"resetRejectionsOnSourcePush" tf:"on_push_reset_all_votes" ConflictsWith:"on_push_reset_approved_votes"`
+	OnPushResetAllVotes               bool `json:"resetRejectionsOnSourcePush" tf:"on_push_reset_all_votes"`
 	LastPusherCannotVote              bool `json:"blockLastPusherVote" tf:"last_pusher_cannot_approve"`
 }
 

--- a/website/docs/r/branch_policy_min_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_min_reviewers.html.markdown
@@ -72,7 +72,7 @@ A `settings` block supports the following:
 - `on_push_reset_all_votes` (Optional) When new changes are pushed reset all code reviewer votes. Defaults to `false`.
 - `on_last_iteration_require_vote` (Optional) On last iteration require vote. Defaults to `false`.
 
-Only one of `on_push_reset_all_votes` or `on_push_reset_approved_votes` may be specified. 
+If `on_push_reset_all_votes` is `true`, then `on_push_reset_approved_votes` also must be `true`.
 
 - `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The provider currently does not build a minimum reviewers branch policy properly if the "Reset all code reviewer votes" option is selected - if new changes are pushed, existing "Approved" votes are not removed.

Having a closer look at the rest api results for a valid policy using "Reset all code reviewer votes" shows the following settings:

``` json
"settings": {
        "minimumApproverCount": 1,
        "creatorVoteCounts": false,
        "allowDownvotes": false,
        "resetOnSourcePush": true,
        "requireVoteOnLastIteration": false,
        "resetRejectionsOnSourcePush": true,
        "blockLastPusherVote": true,
        "scope": [
          {
            "refName": "refs/heads/main",
            "matchKind": "Exact",
            "repositoryId": "306e0555-774a-4952-b729-e0607c4a49c0"
          }
        ]
      }
```
Notice that the both the `resetOnSourcePush` and `resetRejectionsOnSourcePush` are both true at the same time in this case ...

This seems to indicate that the `ConflictsWith: resetOnSourcePush` and `ConflictsWith: resetRejectionsOnSourcePush` tags are actually incorrect and causing the problem.

I am proposing to remove the `ConflictsWith` tags, but there might be a better way as I am not very familiar with go. ...

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->