### PR TITLE
Fix `azuredevops_branch_policy_build_validation.file_pattern` order

### DIFF
--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
@@ -64,7 +64,7 @@ func ResourceBranchPolicyBuildValidation() *schema.Resource {
 		ValidateFunc: validation.IntAtLeast(0),
 	}
 	settingsSchema[filenamePatterns] = &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
@@ -119,16 +119,15 @@ func buildValidationExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*polic
 	policySettings["manualQueueOnly"] = settings[manualQueueOnly].(bool)
 	policySettings["queueOnSourceUpdateOnly"] = settings[queueOnSourceUpdateOnly].(bool)
 	policySettings["validDuration"] = settings[validDuration].(int)
-	policySettings["filenamePatterns"] = expandFilenamePatterns(settings[filenamePatterns].(*schema.Set))
+	policySettings["filenamePatterns"] = expandFilenamePatterns(settings[filenamePatterns].([]interface{}))
 
 	return policyConfig, projectID, nil
 }
 
-func expandFilenamePatterns(patterns *schema.Set) *[]string {
-	patternsList := patterns.List()
-	patternsArray := make([]string, len(patternsList))
+func expandFilenamePatterns(patterns []interface{}) *[]string {
+	patternsArray := make([]string, len(patterns))
 
-	for i, variableGroup := range patternsList {
+	for i, variableGroup := range patterns {
 		patternsArray[i] = variableGroup.(string)
 	}
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #539

The file pattern have order constraint,  the defined order should not be changed.

```log
=== RUN   TestAccBranchPolicyAutoReviewers_CreateAndUpdate
=== PAUSE TestAccBranchPolicyAutoReviewers_CreateAndUpdate
=== CONT  TestAccBranchPolicyAutoReviewers_CreateAndUpdate
--- PASS: TestAccBranchPolicyAutoReviewers_CreateAndUpdate (121.73s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        123.289s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->