### PR TITLE
feat: create azuredevops_project_pipeline_settings resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
@@ -1,0 +1,50 @@
+//go:build (all || core || resource_project || resource_project_features) && !exclude_resource_project_features
+// +build all core resource_project resource_project_features
+// +build !exclude_resource_project_features
+
+package acceptancetests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccProjectPipelineSettings_Enabled(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_project_pipeline_settings.this"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.HclProjectPipelineSettings(projectName, false, false, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "enforce_job_scope", "false"),
+					resource.TestCheckResourceAttr(tfNode, "enforce_referenced_repo_scoped_token", "false"),
+					resource.TestCheckResourceAttr(tfNode, "enforce_settable_var", "false"),
+					resource.TestCheckResourceAttr(tfNode, "publish_pipeline_metadata", "false"),
+					resource.TestCheckResourceAttr(tfNode, "status_badges_are_private", "false"),
+				),
+				Destroy: false,
+			},
+			{
+				Config: testutils.HclProjectPipelineSettings(projectName, true, true, true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "enforce_job_scope", "true"),
+					resource.TestCheckResourceAttr(tfNode, "enforce_referenced_repo_scoped_token", "true"),
+					resource.TestCheckResourceAttr(tfNode, "enforce_settable_var", "true"),
+					resource.TestCheckResourceAttr(tfNode, "publish_pipeline_metadata", "true"),
+					resource.TestCheckResourceAttr(tfNode, "status_badges_are_private", "true"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
@@ -28,7 +28,6 @@ func TestAccProjectPipelineSettings_Enabled(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "publish_pipeline_metadata", "false"),
 					resource.TestCheckResourceAttr(tfNode, "status_badges_are_private", "false"),
 				),
-				Destroy: false,
 			},
 			{
 				Config: testutils.HclProjectPipelineSettings(projectName, true, true, true, true, true),

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -128,7 +128,6 @@ resource "azuredevops_project_features" "project-features" {
 
 // HclProjectFeatures HCL describing an AzDO project including feature setup using azuredevops_git_repositories
 func HclProjectPipelineSettings(projectName string, enforceJobAuthScope bool, enforceReferencedRepoScopedToken bool, enforceSettableVar bool, publishPipelineMetadata bool, statusBadgesArePrivate bool) string {
-
 	projectPipelineSettings := fmt.Sprintf(`
 resource "azuredevops_project_pipeline_settings" "this" {
 	project_id = azuredevops_project.project.id
@@ -138,7 +137,6 @@ resource "azuredevops_project_pipeline_settings" "this" {
 	enforce_settable_var = %t
 	publish_pipeline_metadata = %t
 	status_badges_are_private = %t
-
 }`, enforceJobAuthScope, enforceReferencedRepoScopedToken, enforceSettableVar, publishPipelineMetadata, statusBadgesArePrivate)
 
 	projectResource := HclProjectResource(projectName)

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -126,6 +126,25 @@ resource "azuredevops_project_features" "project-features" {
 	return fmt.Sprintf("%s\n%s", projectResource, projectFeatures)
 }
 
+// HclProjectFeatures HCL describing an AzDO project including feature setup using azuredevops_git_repositories
+func HclProjectPipelineSettings(projectName string, enforceJobAuthScope bool, enforceReferencedRepoScopedToken bool, enforceSettableVar bool, publishPipelineMetadata bool, statusBadgesArePrivate bool) string {
+
+	projectPipelineSettings := fmt.Sprintf(`
+resource "azuredevops_project_pipeline_settings" "this" {
+	project_id = azuredevops_project.project.id
+
+	enforce_job_scope = %t
+	enforce_referenced_repo_scoped_token = %t
+	enforce_settable_var = %t
+	publish_pipeline_metadata = %t
+	status_badges_are_private = %t
+
+}`, enforceJobAuthScope, enforceReferencedRepoScopedToken, enforceSettableVar, publishPipelineMetadata, statusBadgesArePrivate)
+
+	projectResource := HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, projectPipelineSettings)
+}
+
 // HclProjectsDataSource HCL describing a data source for multiple AzDO projects
 func HclProjectsDataSource(projectName string) string {
 	projectResource := HclProjectResource(projectName)

--- a/azuredevops/internal/service/core/resource_project_pipeline_settings.go
+++ b/azuredevops/internal/service/core/resource_project_pipeline_settings.go
@@ -70,10 +70,10 @@ func resourceProjectPipelineSettingsCreateUpdate(ctx context.Context, d *schema.
 
 	err := configureProjectPipelineGeneralSettings(clients, projectID, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error creating/updating project build general settings: %v", err))
+		return diag.FromErr(fmt.Errorf(" creating/updating project build general settings: %v", err))
 	}
 	d.SetId(projectID)
-	return nil
+	return resourceProjectPipelineSettingsRead(ctx, d, m)
 }
 
 func resourceProjectPipelineSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -99,7 +99,6 @@ func resourceProjectPipelineSettingsRead(ctx context.Context, d *schema.Resource
 	d.Set("enforce_settable_var", buildSettings.EnforceSettableVar)
 	d.Set("publish_pipeline_metadata", buildSettings.PublishPipelineMetadata)
 	d.Set("status_badges_are_private", buildSettings.StatusBadgesArePrivate)
-
 	return nil
 }
 

--- a/azuredevops/internal/service/core/resource_project_pipeline_settings.go
+++ b/azuredevops/internal/service/core/resource_project_pipeline_settings.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/build"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+func ResourceProjectPipelineSettings() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceProjectPipelineSettingsCreateUpdate,
+		ReadContext:   resourceProjectPipelineSettingsRead,
+		UpdateContext: resourceProjectPipelineSettingsCreateUpdate,
+		DeleteContext: resourceProjectPipelineSettingsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"enforce_job_scope": {
+				Description: "Limit job authorization scope to current project for non-release pipelines",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+			"enforce_referenced_repo_scoped_token": {
+				Description: "Protect access to repositories in YAML pipelines",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+			"enforce_settable_var": {
+				Description: "Limit variables that can be set at queue time",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+			"publish_pipeline_metadata": {
+				Description: "Publish metadata from pipelines",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+			"status_badges_are_private": {
+				Description: "Disable anonymous access to badges",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceProjectPipelineSettingsCreateUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	projectID := d.Get("project_id").(string)
+
+	err := configureProjectPipelineGeneralSettings(clients, projectID, d)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error creating/updating project build general settings: %v", err))
+	}
+	d.SetId(projectID)
+	return nil
+}
+
+func resourceProjectPipelineSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectId := d.Id()
+	getSettings := build.GetBuildGeneralSettingsArgs{
+		Project: converter.String(projectId),
+	}
+
+	buildSettings, err := clients.BuildClient.GetBuildGeneralSettings(ctx, getSettings)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error reading project build general settings: %v", err))
+	}
+
+	d.Set("project_id", projectId)
+	d.Set("enforce_job_scope", buildSettings.EnforceJobAuthScope)
+	d.Set("enforce_referenced_repo_scoped_token", buildSettings.EnforceReferencedRepoScopedToken)
+	d.Set("enforce_settable_var", buildSettings.EnforceSettableVar)
+	d.Set("publish_pipeline_metadata", buildSettings.PublishPipelineMetadata)
+	d.Set("status_badges_are_private", buildSettings.StatusBadgesArePrivate)
+
+	return nil
+}
+
+func resourceProjectPipelineSettingsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// nothing to do, as the original settings are unknown.
+	return nil
+}
+
+func configureProjectPipelineGeneralSettings(clients *client.AggregatedClient, projectId string, d *schema.ResourceData) error {
+	settings := build.UpdateBuildGeneralSettingsArgs{
+		Project:     converter.String(projectId),
+		NewSettings: &build.PipelineGeneralSettings{},
+	}
+
+	// must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, ok := d.GetOkExists("enforce_job_scope"); ok {
+		settings.NewSettings.EnforceJobAuthScope = converter.Bool(val.(bool))
+	}
+
+	if val, ok := d.GetOkExists("enforce_referenced_repo_scoped_token"); ok {
+		settings.NewSettings.EnforceReferencedRepoScopedToken = converter.Bool(val.(bool))
+	}
+
+	if val, ok := d.GetOkExists("enforce_settable_var"); ok {
+		settings.NewSettings.EnforceSettableVar = converter.Bool(val.(bool))
+	}
+
+	if val, ok := d.GetOkExists("publish_pipeline_metadata"); ok {
+		settings.NewSettings.PublishPipelineMetadata = converter.Bool(val.(bool))
+	}
+
+	if val, ok := d.GetOkExists("status_badges_are_private"); ok {
+		settings.NewSettings.StatusBadgesArePrivate = converter.Bool(val.(bool))
+	}
+
+	_, err := clients.BuildClient.UpdateBuildGeneralSettings(clients.Ctx, settings)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/azuredevops/internal/service/core/resource_project_pipeline_settings.go
+++ b/azuredevops/internal/service/core/resource_project_pipeline_settings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/build"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
@@ -85,6 +86,10 @@ func resourceProjectPipelineSettingsRead(ctx context.Context, d *schema.Resource
 
 	buildSettings, err := clients.BuildClient.GetBuildGeneralSettings(ctx, getSettings)
 	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("Error reading project build general settings: %v", err))
 	}
 

--- a/azuredevops/internal/service/core/resource_project_pipeline_settings.go
+++ b/azuredevops/internal/service/core/resource_project_pipeline_settings.go
@@ -109,24 +109,28 @@ func configureProjectPipelineGeneralSettings(clients *client.AggregatedClient, p
 		NewSettings: &build.PipelineGeneralSettings{},
 	}
 
-	// must use GetOkExists to determine if the boolean property has been set from the resource
-	if val, ok := d.GetOkExists("enforce_job_scope"); ok {
+	//lint:ignore SA1019 - must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, exists := d.GetOkExists("enforce_job_scope"); exists { //nolint:staticcheck
 		settings.NewSettings.EnforceJobAuthScope = converter.Bool(val.(bool))
 	}
 
-	if val, ok := d.GetOkExists("enforce_referenced_repo_scoped_token"); ok {
+	//lint:ignore SA1019 - must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, exists := d.GetOkExists("enforce_referenced_repo_scoped_token"); exists { //nolint:staticcheck
 		settings.NewSettings.EnforceReferencedRepoScopedToken = converter.Bool(val.(bool))
 	}
 
-	if val, ok := d.GetOkExists("enforce_settable_var"); ok {
+	//lint:ignore SA1019 - must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, exists := d.GetOkExists("enforce_settable_var"); exists { //nolint:staticcheck
 		settings.NewSettings.EnforceSettableVar = converter.Bool(val.(bool))
 	}
 
-	if val, ok := d.GetOkExists("publish_pipeline_metadata"); ok {
+	//lint:ignore SA1019 - must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, exists := d.GetOkExists("publish_pipeline_metadata"); exists { //nolint:staticcheck
 		settings.NewSettings.PublishPipelineMetadata = converter.Bool(val.(bool))
 	}
 
-	if val, ok := d.GetOkExists("status_badges_are_private"); ok {
+	//lint:ignore SA1019 - must use GetOkExists to determine if the boolean property has been set from the resource
+	if val, exists := d.GetOkExists("status_badges_are_private"); exists { //nolint:staticcheck
 		settings.NewSettings.StatusBadgesArePrivate = converter.Bool(val.(bool))
 	}
 

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -35,6 +35,7 @@ func Provider() *schema.Provider {
 			"azuredevops_build_definition":                       build.ResourceBuildDefinition(),
 			"azuredevops_project":                                core.ResourceProject(),
 			"azuredevops_project_features":                       core.ResourceProjectFeatures(),
+			"azuredevops_project_pipeline_settings":              core.ResourceProjectPipelineSettings(),
 			"azuredevops_variable_group":                         taskagent.ResourceVariableGroup(),
 			"azuredevops_repository_policy_author_email_pattern": repository.ResourceRepositoryPolicyAuthorEmailPatterns(),
 			"azuredevops_repository_policy_file_path_pattern":    repository.ResourceRepositoryFilePathPatterns(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -21,6 +21,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_branch_policy_status_check",
 		"azuredevops_project",
 		"azuredevops_project_features",
+		"azuredevops_project_pipeline_settings",
 		"azuredevops_serviceendpoint_github",
 		"azuredevops_serviceendpoint_github_enterprise",
 		"azuredevops_serviceendpoint_dockerregistry",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -89,6 +89,9 @@
                   <a href="/docs/providers/azuredevops/r/area_permissions.html">azuredevops_area_permissions</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/project_pipeline_settings.html">azuredevops_project_pipeline_settings</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_auto_reviewers.html">azuredevops_branch_policy_auto_reviewers</a>
                 </li>
                 <li>

--- a/website/docs/r/project_pipeline_settings.html.markdown
+++ b/website/docs/r/project_pipeline_settings.html.markdown
@@ -49,7 +49,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No attributes are exported
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the project.
 
 ## Relevant Links
 
@@ -65,4 +67,4 @@ terraform import azuredevops_project_pipeline_settings.example 00000000-0000-000
 
 ## PAT Permissions Required
 
-- **Project & Team**: Read, Write, & Manage
+- Full Access

--- a/website/docs/r/project_pipeline_settings.html.markdown
+++ b/website/docs/r/project_pipeline_settings.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_project_pipeline_settings"
+description: |-
+  Manages Pipeline Settings for Azure DevOps projects.
+---
+
+# azuredevops_project_pipeline_settings
+
+Manages Pipeline Settings for Azure DevOps projects
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_project_pipeline_settings" "example" {
+  project_id = azuredevops_project.example.id
+
+  enforce_job_scope = true
+  enforce_referenced_repo_scoped_token = false
+  enforce_settable_var = true
+  publish_pipeline_metadata = false
+  status_badges_are_private = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The `id` of the project for which the project pipeline settings will be managed.
+- `enforce_job_scope` - (Optional) Limit job authorization scope to current project for non-release pipelines.
+- `enforce_referenced_repo_scoped_token` - (Optional) Protect access to repositories in YAML pipelines.
+- `enforce_settable_var` - (Optional) Limit variables that can be set at queue time.
+- `publish_pipeline_metadata` - (Optional) Publish metadata from pipelines.
+- `status_badges_are_private` - (Optional) Disable anonymous access to badges.
+
+> **NOTE:**  
+> The settings at the organization will override settings specified on the project.
+> For example, if `enforce_job_scope` is true at the organization, the `azuredevops_project_pipeline_settings` resource cannot set it to false.
+> In this scenario, the plan will always show that the resource is trying to change `enforce_job_scope` from `true` to `false`.
+
+## Attributes Reference
+
+No attributes are exported
+
+## Relevant Links
+
+No official documentation available
+
+## Import
+
+Azure DevOps feature settings can be imported using the project id, e.g.
+
+```sh
+terraform import azuredevops_project_pipeline_settings.example 00000000-0000-0000-0000-000000000000
+```
+
+## PAT Permissions Required
+
+- **Project & Team**: Read, Write, & Manage


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This PR creates a new resource - `azuredevops_project_pipeline_settings` - which addresses #410

Note: linting warns about using `d.GetOkExists`, but I need to use the function to determine if the `bool` property has been specified in the resource.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
