### PR TITLE
Bug fix: Update artifact feature name

### DIFF
--- a/azuredevops/internal/service/core/resource_project_features.go
+++ b/azuredevops/internal/service/core/resource_project_features.go
@@ -38,7 +38,7 @@ var projectFeatureNameMap = map[string]ProjectFeatureType{
 	"ms.vss-code.version-control": ProjectFeatureTypeValues.Repositories,
 	"ms.vss-build.pipelines":      ProjectFeatureTypeValues.Pipelines,
 	"ms.vss-test-web.test":        ProjectFeatureTypeValues.TestPlans,
-	"ms.feed.feed":                ProjectFeatureTypeValues.Artifacts,
+	"ms.azure-artifacts.feature":  ProjectFeatureTypeValues.Artifacts,
 }
 
 var projectFeatureNameMapReverse = map[ProjectFeatureType]string{}
@@ -200,7 +200,7 @@ func setProjectFeatureStates(ctx context.Context, fc featuremanagement.Client, p
 			ScopeValue: &projectID,
 		})
 		if nil != err {
-			return err
+			return fmt.Errorf(" Faild to update project features. Feature type: %s,  Error: %+v", f, err)
 		}
 	}
 

--- a/azuredevops/internal/service/core/resource_project_features_test.go
+++ b/azuredevops/internal/service/core/resource_project_features_test.go
@@ -225,7 +225,7 @@ func TestProjectFeatures_SetProjectFeatureStates_HandleError(t *testing.T) {
 
 	err := setProjectFeatureStates(clients.Ctx, clients.FeatureManagementClient, projectID, &featureStates)
 	require.NotNil(t, err)
-	require.Equal(t, errMsg, err.Error())
+	require.Contains(t, err.Error(), errMsg)
 }
 
 func TestProjectFeatures_SetProjectFeatureStates_OnlyValidProjectFeatures(t *testing.T) {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

`azuredevops_project`,  `azuredevops_project_features` : Update feature artifact's type name to correspond to the service definition.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #568 

Actests:
```log
=== RUN   TestAccProject_DataSource
=== RUN   TestAccProject_DataSource/Get_project_with_id
=== PAUSE TestAccProject_DataSource/Get_project_with_id
=== RUN   TestAccProject_DataSource/Get_project_with_name
=== PAUSE TestAccProject_DataSource/Get_project_with_name
=== CONT  TestAccProject_DataSource/Get_project_with_id
=== CONT  TestAccProject_DataSource/Get_project_with_name
--- PASS: TestAccProject_DataSource (0.00s)
    --- PASS: TestAccProject_DataSource/Get_project_with_id (23.86s)
    --- PASS: TestAccProject_DataSource/Get_project_with_name (24.06s)
=== RUN   TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== PAUSE TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== RUN   TestAccProject_DataSource_ErrorWhenDescriptionSet
=== PAUSE TestAccProject_DataSource_ErrorWhenDescriptionSet
=== RUN   TestAccProject_CreateAndUpdate
=== PAUSE TestAccProject_CreateAndUpdate
=== RUN   TestAccProject_CreateAndUpdateWithFeatures
=== PAUSE TestAccProject_CreateAndUpdateWithFeatures
=== CONT  TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== CONT  TestAccProject_CreateAndUpdate
=== CONT  TestAccProject_CreateAndUpdateWithFeatures
=== CONT  TestAccProject_DataSource_ErrorWhenDescriptionSet
--- PASS: TestAccProject_DataSource_ErrorWhenDescriptionSet (0.68s)
--- PASS: TestAccProject_DataSource_ErrorWhenBothNameAndIdSet (1.13s)
=== CONT  TestAccProject_CreateAndUpdateWithFeatures
--- PASS: TestAccProject_CreateAndUpdateWithFeatures (19.69s)
--- PASS: TestAccProject_CreateAndUpdate (37.35s)
PASS
ok    github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        62.138s


=== RUN   TestAccProjectFeatures_EnableUpdateFeature
=== PAUSE TestAccProjectFeatures_EnableUpdateFeature
=== CONT  TestAccProjectFeatures_EnableUpdateFeature
--- PASS: TestAccProjectFeatures_EnableUpdateFeature (28.10s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        28.575s
```



## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->