### PR TITLE
fix/576, corrected service_account update in serviceendpoint_kubernetes resource

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -140,7 +140,8 @@ func makeSchemaServiceAccount(r *schema.Resource) {
 	makeProtectedSchema(resourceElemSchema, "ca_cert", "AZDO_KUBERNETES_SERVICE_CONNECTION_SERVICE_ACCOUNT_CERT", "Secret cert")
 	makeProtectedSchema(resourceElemSchema, "token", "AZDO_KUBERNETES_SERVICE_CONNECTION_SERVICE_ACCOUNT_TOKEN", "Secret token")
 	r.Schema[resourceBlockServiceAccount] = &schema.Schema{
-		Type:        schema.TypeSet,
+		Type:        schema.TypeList,
+		MaxItems:    1,
 		Optional:    true,
 		Description: "'ServiceAccount'-type of configuration",
 		Elem:        resourceElemSchema,
@@ -226,7 +227,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 			"acceptUntrustedCerts": fmt.Sprintf("%v", configuration["accept_untrusted_certs"].(bool)),
 		}
 	case "ServiceAccount":
-		configurationRaw := d.Get(resourceBlockServiceAccount).(*schema.Set).List()
+		configurationRaw := d.Get(resourceBlockServiceAccount).([]interface {})
 		configuration := configurationRaw[0].(map[string]interface{})
 
 		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
@@ -298,7 +299,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 		d.Set(resourceBlockKubeconfig, kubeconfigList)
 	case "ServiceAccount":
 		var serviceAccount map[string]interface{}
-		serviceAccountSet := d.Get("service_account").(*schema.Set).List()
+		serviceAccountSet := d.Get("service_account").([]interface {})
 
 		if len(serviceAccountSet) == 0 {
 			newHashToken, hashKeyToken := tfhelper.HelpFlattenSecretNested(d, resourceBlockServiceAccount, nil, "token")

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -227,7 +227,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 			"acceptUntrustedCerts": fmt.Sprintf("%v", configuration["accept_untrusted_certs"].(bool)),
 		}
 	case "ServiceAccount":
-		configurationRaw := d.Get(resourceBlockServiceAccount).([]interface {})
+		configurationRaw := d.Get(resourceBlockServiceAccount).([]interface{})
 		configuration := configurationRaw[0].(map[string]interface{})
 
 		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
@@ -299,7 +299,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 		d.Set(resourceBlockKubeconfig, kubeconfigList)
 	case "ServiceAccount":
 		var serviceAccount map[string]interface{}
-		serviceAccountSet := d.Get("service_account").([]interface {})
+		serviceAccountSet := d.Get("service_account").([]interface{})
 
 		if len(serviceAccountSet) == 0 {
 			newHashToken, hashKeyToken := tfhelper.HelpFlattenSecretNested(d, resourceBlockServiceAccount, nil, "token")


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

* fixing `service_account` update behavior for `azuredevops_serviceendpoint_kubernetes` resource
* `service_account` schema change: (1) TypeSet -> TypeList  and (2) enforcing MaxItems = 1 
* type casting changes for adding/updating logic in the provider resource

Issue Number: 576, https://github.com/microsoft/terraform-provider-azuredevops/issues/576

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?
n/a

## Other information
Some TLDR, more contexts in issue https://github.com/microsoft/terraform-provider-azuredevops/issues/576 

* TypeSet appears to make TF struggle to notice diff in `service_account` value change
* changing to TypeList with MaxItems = 1 enforcement helps
* all tests passed
* tested with TF running on custom-built provider, add/update logic across several projects