### PR TITLE
Fix `file_pattern` → `filename_patterns` in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ FEATURES:
 
 BUG FIX:
 * `azuredevops_group` - Fix scope not set [#542](https://github.com/microsoft/terraform-provider-azuredevops/issues/542)
-* `azuredevops_branch_policy_build_validation` - Fix `file_pattern` disordered.  [#539](https://github.com/microsoft/terraform-provider-azuredevops/issues/539)
+* `azuredevops_branch_policy_build_validation` - Fix `filename_patterns` disordered.  [#539](https://github.com/microsoft/terraform-provider-azuredevops/issues/539)
 * `azuredevops_variable_group` - Fix create 401 authorization error.  [#541](https://github.com/microsoft/terraform-provider-azuredevops/issues/541)
 * `azuredevops_group` - Can not create group at project level.  [#558](https://github.com/microsoft/terraform-provider-azuredevops/issues/558)
 * `azuredevops_project` - Unable disable/enable project feature artifacts.  [#568](https://github.com/microsoft/terraform-provider-azuredevops/issues/568)


### PR DESCRIPTION
The property is called `filename_patterns`, so the changelog entry is almost impossible to find with Ctrl + F, `git grep` etc when it says `file_pattern`.

💡 `git show --color-words=.`

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

Issue Number: #539 perhaps

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
