### PR TITLE
adding 'DefaultBranch' into match_type setting

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -243,7 +243,7 @@ Config: getMergeTypesHcl(true, true, true, true, true, true, "\"refs/heads/relea
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_with_merge", "true"),
 				),
 			}, {
-				Config: getMergeTypesHcl(false, false, false, false, false, false, "null", "exact"),
+				Config: getMergeTypesHcl(false, false, false, false, false, false, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "false"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -347,7 +347,7 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "DefaultBranch"),
 				),
 			}, {
-				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional", "null", "\"ref/heads/release\"", "prefix"),
+				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional", "null", "\"refs/heads/release\"", "Prefix"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(statusCheckTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "blocking", "false"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -139,7 +139,7 @@ func TestAccBranchPolicyBuildValidation_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),
 				),
 			}, {
-Config: getBuildValidationHcl(false, false, "build validation rename", 720, "\"refs/heads/release\"", "Exact"),
+				Config: getBuildValidationHcl(false, false, "build validation rename", 720, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -342,9 +342,9 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "true"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "default"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.filename_patterns.#", "3"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_id", ""),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", ""),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "DefaultBranch"),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", ""),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", ""),
 				),
 			}, {
 				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional","null", "\"ref/heads/release\"", "prefix"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -356,7 +356,7 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "conditional"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_id", ""),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", "refs/heads/release"),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "prefix"),
+resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "Prefix"),
 				),
 			}, {
 				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "null", "exact"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -23,7 +23,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getMinReviewersHcl(true, true, 1, false, "null", "exact"),
+				Config: getMinReviewersHcl(true, true, 1, false, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "true"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -23,7 +23,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getMinReviewersHcl(true, true, 1, false),
+				Config: getMinReviewersHcl(true, true, 1, false, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "true"),
@@ -36,7 +36,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_push_reset_approved_votes", "true"),
 				),
 			}, {
-				Config: getMinReviewersHcl(false, false, 2, true),
+				Config: getMinReviewersHcl(false, false, 2, true, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "false"),
@@ -58,7 +58,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func getMinReviewersHcl(enabled bool, blocking bool, reviewers int, flag bool) string {
+func getMinReviewersHcl(enabled bool, blocking bool, reviewers int, flag bool, repositoryRef string, matchType string) string {
 	votes := "all"
 	if !flag {
 		votes = "approved"
@@ -73,7 +73,7 @@ func getMinReviewersHcl(enabled bool, blocking bool, reviewers int, flag bool) s
 		on_push_reset_%[3]s_votes = true
 		`, reviewers, flag, votes)
 
-	return getBranchPolicyHcl("azuredevops_branch_policy_min_reviewers", enabled, blocking, settings)
+	return getBranchPolicyHcl("azuredevops_branch_policy_min_reviewers", enabled, blocking, settings, repositoryRef, matchType)
 }
 
 func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
@@ -84,13 +84,13 @@ func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getAutoReviewersHcl(true, true, false, "auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md")),
+				Config: getAutoReviewersHcl(true, true, false, "auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "blocking", "true"),
 				),
 			}, {
-				Config: getAutoReviewersHcl(false, false, true, "new auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md")),
+				Config: getAutoReviewersHcl(false, false, true, "new auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "blocking", "false"),
@@ -105,7 +105,7 @@ func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func getAutoReviewersHcl(enabled bool, blocking bool, submitterCanVote bool, message string, pathFilters string) string {
+func getAutoReviewersHcl(enabled bool, blocking bool, submitterCanVote bool, message string, pathFilters string, repositoryRef string, matchType string) string {
 	settings := fmt.Sprintf(
 		`
 		auto_reviewer_ids  = [azuredevops_user_entitlement.user.id]
@@ -120,7 +120,7 @@ func getAutoReviewersHcl(enabled bool, blocking bool, submitterCanVote bool, mes
 	return strings.Join(
 		[]string{
 			userEntitlement,
-			getBranchPolicyHcl("azuredevops_branch_policy_auto_reviewers", enabled, blocking, settings),
+			getBranchPolicyHcl("azuredevops_branch_policy_auto_reviewers", enabled, blocking, settings, repositoryRef, matchType),
 		},
 		"\n",
 	)
@@ -133,13 +133,13 @@ func TestAccBranchPolicyBuildValidation_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBuildValidationHcl(true, true, "build validation", 0),
+				Config: getBuildValidationHcl(true, true, "build validation", 0, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),
 				),
 			}, {
-				Config: getBuildValidationHcl(false, false, "build validation rename", 720),
+				Config: getBuildValidationHcl(false, false, "build validation rename", 720, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),
@@ -154,7 +154,7 @@ func TestAccBranchPolicyBuildValidation_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func getBuildValidationHcl(enabled bool, blocking bool, displayName string, validDuration int) string {
+func getBuildValidationHcl(enabled bool, blocking bool, displayName string, validDuration int, repositoryRef string, matchType string) string {
 	settings := fmt.Sprintf(
 		`
 		display_name = "%s"
@@ -168,7 +168,7 @@ func getBuildValidationHcl(enabled bool, blocking bool, displayName string, vali
 		`, displayName, validDuration,
 	)
 
-	return getBranchPolicyHcl("azuredevops_branch_policy_build_validation", enabled, blocking, settings)
+	return getBranchPolicyHcl("azuredevops_branch_policy_build_validation", enabled, blocking, settings, repositoryRef, matchType)
 }
 
 func TestAccBranchPolicyWorkItemLinking_CreateAndUpdate(t *testing.T) {
@@ -180,12 +180,12 @@ func TestAccBranchPolicyWorkItemLinking_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBranchPolicyHcl(resourceName, true, true, ""),
+				Config: getBranchPolicyHcl(resourceName, true, true, "", "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "true"),
 				),
 			}, {
-				Config: getBranchPolicyHcl(resourceName, false, false, ""),
+				Config: getBranchPolicyHcl(resourceName, false, false, "", "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "false"),
 				),
@@ -208,12 +208,12 @@ func TestAccBranchPolicyCommentResolution_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBranchPolicyHcl(resourceName, true, true, ""),
+				Config: getBranchPolicyHcl(resourceName, true, true, "", "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "true"),
 				),
 			}, {
-				Config: getBranchPolicyHcl(resourceName, false, false, ""),
+				Config: getBranchPolicyHcl(resourceName, false, false, "", "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "false"),
 				),
@@ -234,7 +234,7 @@ func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getMergeTypesHcl(true, true, true, true, true, true),
+				Config: getMergeTypesHcl(true, true, true, true, true, true, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "true"),
@@ -243,7 +243,7 @@ func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_rebase_with_merge", "true"),
 				),
 			}, {
-				Config: getMergeTypesHcl(false, false, false, false, false, false),
+				Config: getMergeTypesHcl(false, false, false, false, false, false, "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "false"),
@@ -261,7 +261,7 @@ func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func getMergeTypesHcl(enabled bool, blocking bool, allowSquash bool, allowRebase bool, allowNoFastForward bool, allowRebaseMerge bool) string {
+func getMergeTypesHcl(enabled bool, blocking bool, allowSquash bool, allowRebase bool, allowNoFastForward bool, allowRebaseMerge bool, repositoryRef string, matchType string) string {
 	settings := fmt.Sprintf(
 		`
 		allow_squash = %t
@@ -271,10 +271,10 @@ func getMergeTypesHcl(enabled bool, blocking bool, allowSquash bool, allowRebase
 		`, allowSquash, allowRebase, allowNoFastForward, allowRebaseMerge,
 	)
 
-	return getBranchPolicyHcl("azuredevops_branch_policy_merge_types", enabled, blocking, settings)
+	return getBranchPolicyHcl("azuredevops_branch_policy_merge_types", enabled, blocking, settings, repositoryRef, matchType)
 }
 
-func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settings string) string {
+func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settings string, repositoryRef string, matchType string) string {
 	branchPolicy := fmt.Sprintf(`
 	resource "%s" "p" {
 		project_id = azuredevops_project.project.id
@@ -284,12 +284,12 @@ func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settin
 			%s
 			scope {
 				repository_id  = azuredevops_git_repository.repository.id
-				repository_ref = azuredevops_git_repository.repository.default_branch
-				match_type     = "exact"
+				repository_ref = %s
+				match_type     = "%s"
 			}
 		}
 	}
-	`, resourceName, enabled, blocking, settings)
+	`, resourceName, enabled, blocking, settings, repositoryRef, matchType)
 	projectAndRepo := testutils.HclGitRepoResource(testutils.GenerateResourceName(), testutils.GenerateResourceName(), "Clean")
 	buildDef := testutils.HclBuildDefinitionResource(
 		"Sample Build Definition",
@@ -308,4 +308,68 @@ func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settin
 		},
 		"\n",
 	)
+}
+
+func getStatusCheckHcl(enabled bool, blocking bool, name string, invalidateOnUpdate bool, applicability string, repositoryRef string, matchType string) string {
+	settings := fmt.Sprintf(
+		`
+		name = "%s"
+		invalidate_on_update = %t
+		applicability = "%s"
+		filename_patterns =  [
+			"/WebApp/*",
+			"!/WebApp/Tests/*",
+			"*.cs"
+		]
+		`, name, invalidateOnUpdate, applicability,
+	)
+
+	return getBranchPolicyHcl("azuredevops_branch_policy_status_check", enabled, blocking, settings, repositoryRef, matchType)
+}
+
+func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
+	statusCheckTfNode := "azuredevops_branch_policy_status_check.p"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: getStatusCheckHcl(true, true, "abc-1", true, "default", "null", "defaultBranch"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(statusCheckTfNode, "enabled", "true"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "blocking", "true"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "abc-1"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "true"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "default"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.filename_patterns.#", "3"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.match_type", "defaultBranch"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.repository_ref", ""),
+				),
+			}, {
+				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional", "\"ref/heads/release\"", "prefix"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(statusCheckTfNode, "enabled", "false"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "blocking", "false"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "abc-2"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "false"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "conditional"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.repository_ref", "refs/heads/release"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.match_type", "prefix"),
+				),
+			}, {
+				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "exact"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "abc-3"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.match_type", "exact"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.repository_ref", ""),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.match_type", "exact"),
+				),
+			}, {
+				ResourceName:      statusCheckTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(statusCheckTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -36,7 +36,7 @@ func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_push_reset_approved_votes", "true"),
 				),
 			}, {
-				Config: getMinReviewersHcl(false, false, 2, true, "null", "exact"),
+				Config: getMinReviewersHcl(false, false, 2, true, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
 					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "false"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -73,7 +73,7 @@ func getMinReviewersHcl(enabled bool, blocking bool, reviewers int, flag bool, r
 		on_push_reset_%[3]s_votes = true
 		`, reviewers, flag, votes)
 
-	return getBranchPolicyHcl("azuredevops_branch_policy_min_reviewers", enabled, blocking, settings,"azuredevops_git_repository.repository.id", repositoryRef, matchType)
+	return getBranchPolicyHcl("azuredevops_branch_policy_min_reviewers", enabled, blocking, settings, "azuredevops_git_repository.repository.id", repositoryRef, matchType)
 }
 
 func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
@@ -347,7 +347,7 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "DefaultBranch"),
 				),
 			}, {
-				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional","null", "\"ref/heads/release\"", "prefix"),
+				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional", "null", "\"ref/heads/release\"", "prefix"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(statusCheckTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "blocking", "false"),
@@ -359,7 +359,7 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "prefix"),
 				),
 			}, {
-				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional","null", "null", "exact"),
+				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "null", "exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "abc-3"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "exact"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -133,7 +133,7 @@ func TestAccBranchPolicyBuildValidation_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBuildValidationHcl(true, true, "build validation", 0, "null", "exact"),
+				Config: getBuildValidationHcl(true, true, "build validation", 0, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -359,13 +359,12 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "Prefix"),
 				),
 			}, {
-				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "null", "exact"),
+				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.name", "abc-3"),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "exact"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "Exact"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_id", ""),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", ""),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "exact"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", "refs/heads/release"),
 				),
 			}, {
 				ResourceName:      statusCheckTfNode,

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -289,7 +289,7 @@ func getBranchPolicyHcl(resourceName string, enabled bool, blocking bool, settin
 			}
 		}
 	}
-	`, resourceName, enabled, blocking, settings, repositoryId repositoryRef, matchType)
+	`, resourceName, enabled, blocking, settings, repositoryId, repositoryRef, matchType)
 	projectAndRepo := testutils.HclGitRepoResource(testutils.GenerateResourceName(), testutils.GenerateResourceName(), "Clean")
 	buildDef := testutils.HclBuildDefinitionResource(
 		"Sample Build Definition",

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -234,7 +234,7 @@ func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getMergeTypesHcl(true, true, true, true, true, true, "null", "exact"),
+Config: getMergeTypesHcl(true, true, true, true, true, true, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "true"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -84,7 +84,7 @@ func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getAutoReviewersHcl(true, true, false, "auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "null", "exact"),
+				Config: getAutoReviewersHcl(true, true, false, "auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "blocking", "true"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -139,7 +139,7 @@ func TestAccBranchPolicyBuildValidation_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),
 				),
 			}, {
-				Config: getBuildValidationHcl(false, false, "build validation rename", 720, "null", "exact"),
+Config: getBuildValidationHcl(false, false, "build validation rename", 720, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.filename_patterns.#", "3"),
@@ -180,12 +180,12 @@ func TestAccBranchPolicyWorkItemLinking_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBranchPolicyHcl(resourceName, true, true, "", "azuredevops_git_repository.repository.id", "null", "exact"),
+				Config: getBranchPolicyHcl(resourceName, true, true, "", "azuredevops_git_repository.repository.id", "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "true"),
 				),
 			}, {
-				Config: getBranchPolicyHcl(resourceName, false, false, "", "azuredevops_git_repository.repository.id", "null", "exact"),
+				Config: getBranchPolicyHcl(resourceName, false, false, "", "azuredevops_git_repository.repository.id", "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "false"),
 				),
@@ -208,12 +208,12 @@ func TestAccBranchPolicyCommentResolution_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: getBranchPolicyHcl(resourceName, true, true, "", "azuredevops_git_repository.repository.id", "null", "exact"),
+				Config: getBranchPolicyHcl(resourceName, true, true, "", "azuredevops_git_repository.repository.id", "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "true"),
 				),
 			}, {
-				Config: getBranchPolicyHcl(resourceName, false, false, "", "azuredevops_git_repository.repository.id", "null", "exact"),
+				Config: getBranchPolicyHcl(resourceName, false, false, "", "azuredevops_git_repository.repository.id", "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(workItemLinkingTfNode, "enabled", "false"),
 				),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -234,7 +234,7 @@ func TestAccBranchPolicyMergeTypes_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-Config: getMergeTypesHcl(true, true, true, true, true, true, "\"refs/heads/release\"", "Exact"),
+				Config: getMergeTypesHcl(true, true, true, true, true, true, "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(buildValidationTfNode, "enabled", "true"),
 					resource.TestCheckResourceAttr(buildValidationTfNode, "settings.0.allow_squash", "true"),
@@ -356,7 +356,7 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "conditional"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_id", ""),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", "refs/heads/release"),
-resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "Prefix"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "Prefix"),
 				),
 			}, {
 				Config: getStatusCheckHcl(false, false, "abc-3", false, "conditional", "null", "\"refs/heads/release\"", "Exact"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -342,8 +342,8 @@ func TestAccBranchPolicyStatusCheck_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.invalidate_on_update", "true"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.applicability", "default"),
 					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.filename_patterns.#", "3"),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.match_type", "defaultBranch"),
-					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.repository_ref", ""),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.match_type", "DefaultBranch"),
+					resource.TestCheckResourceAttr(statusCheckTfNode, "settings.0.scope.0.repository_ref", ""),
 				),
 			}, {
 				Config: getStatusCheckHcl(false, false, "abc-2", false, "conditional", "\"ref/heads/release\"", "prefix"),

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -90,7 +90,7 @@ func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "blocking", "true"),
 				),
 			}, {
-				Config: getAutoReviewersHcl(false, false, true, "new auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "null", "exact"),
+				Config: getAutoReviewersHcl(false, false, true, "new auto reviewer", fmt.Sprintf("\"%s\",\"%s\"", "*/API*.cs", "README.md"), "\"refs/heads/release\"", "Exact"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "enabled", "false"),
 					resource.TestCheckResourceAttr(autoReviewerTfNode, "blocking", "false"),

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -190,14 +190,17 @@ func flattenSettings(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 // baseExpandFunc expands each of the base elements of the schema
 func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
 	projectID := d.Get(SchemaProjectID).(string)
-
+	policySettings, err := expandSettings(d)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error parsing policy configuration settings: (%+v)", err)
+	}
 	policyConfig := policy.PolicyConfiguration{
 		IsEnabled:  converter.Bool(d.Get(SchemaEnabled).(bool)),
 		IsBlocking: converter.Bool(d.Get(SchemaBlocking).(bool)),
 		Type: &policy.PolicyTypeRef{
 			Id: &typeID,
 		},
-		Settings: expandSettings(d),
+		Settings: policySettings,
 	}
 
 	if d.Id() != "" {

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -246,7 +246,7 @@ func expandSettings(d *schema.ResourceData) (map[string]interface{}, error) {
 			return nil, fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
 				scopeSetting["repositoryId"].(string),
 				scopeSetting["refName"].(string),
-				"DefaultBranch")
+				matchTypeDefaultBranch)
 		}
 		scopes[index] = scopeSetting
 	}

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -211,7 +211,7 @@ func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyCon
 	return &policyConfig, &projectID, nil
 }
 
-func expandSettings(d *schema.ResourceData) map[string]interface{} {
+func expandSettings(d *schema.ResourceData) (map[string]interface{}, error) {
 	settingsList := d.Get(SchemaSettings).([]interface{})
 	settings := settingsList[0].(map[string]interface{})
 	settingsScopes := settings[SchemaScope].([]interface{})
@@ -243,7 +243,7 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 			}
 		}
 		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
-			return fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
+			return nil, fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
 				scopeSetting["repositoryId"].(string),
 				scopeSetting["refName"].(string),
 				"DefaultBranch")
@@ -252,7 +252,7 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 	}
 	return map[string]interface{}{
 		SchemaScope: scopes,
-	}
+	}, nil
 }
 
 //lint:ignore SA1019 SDKv2 migration  - staticcheck's own linter directives are currently being ignored under golanci-lint

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -48,8 +48,9 @@ const (
 
 // The type of repository branch name matching strategy used by the policy
 const (
-	matchTypeExact  string = "Exact"
-	matchTypePrefix string = "Prefix"
+	matchTypeExact         string = "Exact"
+	matchTypePrefix        string = "Prefix"
+	matchTypeDefaultBranch string = "DefaultBranch"
 )
 
 // policyCrudArgs arguments for genBasePolicyResource
@@ -113,7 +114,7 @@ func genBasePolicyResource(crudArgs *policyCrudArgs) *schema.Resource {
 										Default:          matchTypeExact,
 										DiffSuppressFunc: suppress.CaseDifference,
 										ValidateFunc: validation.StringInSlice([]string{
-											matchTypeExact, matchTypePrefix,
+											matchTypeExact, matchTypePrefix, matchTypeDefaultBranch,
 										}, true),
 									},
 								},

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -219,7 +219,7 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 	for index, scope := range settingsScopes {
 		scopeMap := scope.(map[string]interface{})
 
-		scopeSetting := map[string]interface{}{}		
+		scopeSetting := map[string]interface{}{}
 		if repoID, ok := scopeMap[SchemaRepositoryID]; ok {
 			if repoID == "" {
 				scopeSetting["repositoryId"] = nil
@@ -239,7 +239,7 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 				scopeSetting["matchKind"] = nil
 			} else {
 				scopeSetting["matchKind"] = matchType
-			}	
+			}
 		}
 		scopes[index] = scopeSetting
 	}

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -243,8 +244,8 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 		}
 		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
 			return fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
-				scopeSetting["repositoryId"],
-				scopeSetting["refName"],
+				scopeSetting["repositoryId"].(string),
+				scopeSetting["refName"].(string,
 				"DefaultBranch")
 		}
 		scopes[index] = scopeSetting

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -245,7 +245,7 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
 			return fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
 				scopeSetting["repositoryId"].(string),
-				scopeSetting["refName"].(string,
+				scopeSetting["refName"].(string),
 				"DefaultBranch")
 		}
 		scopes[index] = scopeSetting

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -219,15 +219,27 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 	for index, scope := range settingsScopes {
 		scopeMap := scope.(map[string]interface{})
 
-		scopeSetting := map[string]interface{}{}
+		scopeSetting := map[string]interface{}{}		
 		if repoID, ok := scopeMap[SchemaRepositoryID]; ok {
-			scopeSetting["repositoryId"] = repoID
+			if repoID == "" {
+				scopeSetting["repositoryId"] = nil
+			} else {
+				scopeSetting["repositoryId"] = repoID
+			}
 		}
 		if repoRef, ok := scopeMap[SchemaRepositoryRef]; ok {
-			scopeSetting["refName"] = repoRef
+			if repoRef == "" {
+				scopeSetting["refName"] = nil
+			} else {
+				scopeSetting["refName"] = repoRef
+			}
 		}
 		if matchType, ok := scopeMap[SchemaMatchType]; ok {
-			scopeSetting["matchKind"] = matchType
+			if matchType == "" {
+				scopeSetting["matchKind"] = nil
+			} else {
+				scopeSetting["matchKind"] = matchType
+			}	
 		}
 		scopes[index] = scopeSetting
 	}

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -247,9 +247,6 @@ func expandSettings(d *schema.ResourceData) (map[string]interface{}, error) {
 		}
 		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
 			return nil, fmt.Errorf(" neither 'repository_id' nor 'repository_ref' can be set when 'match_type=DefaultBranch'")
-				scopeSetting["repositoryId"].(string),
-				scopeSetting["refName"].(string),
-				matchTypeDefaultBranch)
 		}
 		scopes[index] = scopeSetting
 	}

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -246,7 +246,7 @@ func expandSettings(d *schema.ResourceData) (map[string]interface{}, error) {
 			}
 		}
 		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
-			return nil, fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
+			return nil, fmt.Errorf(" neither 'repository_id' nor 'repository_ref' can be set when 'match_type=DefaultBranch'")
 				scopeSetting["repositoryId"].(string),
 				scopeSetting["refName"].(string),
 				matchTypeDefaultBranch)

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -241,6 +241,12 @@ func expandSettings(d *schema.ResourceData) map[string]interface{} {
 				scopeSetting["matchKind"] = matchType
 			}
 		}
+		if strings.EqualFold(scopeSetting["matchKind"].(string), matchTypeDefaultBranch) && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
+			return fmt.Errorf("conflicting settings, 'repository_id' is set to %q and 'repository_ref' is set to %q but neither must be set when using a 'match_type' of %q, ",
+				scopeSetting["repositoryId"],
+				scopeSetting["refName"],
+				"DefaultBranch")
+		}
 		scopes[index] = scopeSetting
 	}
 	return map[string]interface{}{

--- a/website/docs/r/branch_policy_auto_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_auto_reviewers.html.markdown
@@ -69,9 +69,9 @@ The following arguments are supported:
 
   `scope` block supports the following:
 
-  - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-  - `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-  - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_build_validation.html.markdown
+++ b/website/docs/r/branch_policy_build_validation.html.markdown
@@ -64,9 +64,7 @@ resource "azuredevops_branch_policy_build_validation" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
       match_type     = "DefaultBranch"
-      repository_ref = null
     }
   }
 }

--- a/website/docs/r/branch_policy_build_validation.html.markdown
+++ b/website/docs/r/branch_policy_build_validation.html.markdown
@@ -62,6 +62,12 @@ resource "azuredevops_branch_policy_build_validation" "example" {
       repository_ref = "refs/heads/releases"
       match_type     = "Prefix"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      match_type     = "DefaultBranch"
+      repository_ref = null
+    }
   }
 }
 ```
@@ -87,9 +93,9 @@ A `settings` block supports the following:
 
 A `settings` `scope` block supports the following:
 
-- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_comment_resolution.html.markdown
+++ b/website/docs/r/branch_policy_comment_resolution.html.markdown
@@ -45,9 +45,7 @@ resource "azuredevops_branch_policy_comment_resolution" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
       match_type     = "DefaultBranch"
-      repository_ref = null
     }
   }
 }

--- a/website/docs/r/branch_policy_comment_resolution.html.markdown
+++ b/website/docs/r/branch_policy_comment_resolution.html.markdown
@@ -43,6 +43,12 @@ resource "azuredevops_branch_policy_comment_resolution" "example" {
       repository_ref = "refs/heads/releases"
       match_type     = "Prefix"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      match_type     = "DefaultBranch"
+      repository_ref = null
+    }
   }
 }
 ```

--- a/website/docs/r/branch_policy_comment_resolution.html.markdown
+++ b/website/docs/r/branch_policy_comment_resolution.html.markdown
@@ -68,9 +68,9 @@ A `settings` block supports the following:
 
 A `settings` `scope` block supports the following:
 
-- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_merge_types.html.markdown
+++ b/website/docs/r/branch_policy_merge_types.html.markdown
@@ -49,9 +49,7 @@ resource "azuredevops_branch_policy_merge_types" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
       match_type     = "DefaultBranch"
-      repository_ref = null
     }
   }
 }

--- a/website/docs/r/branch_policy_merge_types.html.markdown
+++ b/website/docs/r/branch_policy_merge_types.html.markdown
@@ -47,6 +47,12 @@ resource "azuredevops_branch_policy_merge_types" "example" {
       repository_ref = "refs/heads/releases"
       match_type     = "Prefix"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      match_type     = "DefaultBranch"
+      repository_ref = null
+    }
   }
 }
 ```
@@ -71,9 +77,9 @@ A `settings` block supports the following:
 
 A `settings` `scope` block supports the following:
 
-- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_min_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_min_reviewers.html.markdown
@@ -49,6 +49,12 @@ resource "azuredevops_branch_policy_min_reviewers" "example" {
       repository_ref = "refs/heads/releases"
       match_type     = "Prefix"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      repository_ref = null
+      match_type     = "DefaultBranch"
+    }
   }
 }
 ```
@@ -78,9 +84,9 @@ Only one of `on_push_reset_all_votes` or `on_push_reset_approved_votes` may be s
 
 A `settings` `scope` block supports the following:
 
-- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_min_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_min_reviewers.html.markdown
@@ -51,8 +51,6 @@ resource "azuredevops_branch_policy_min_reviewers" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
-      repository_ref = null
       match_type     = "DefaultBranch"
     }
   }

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
       qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such
       as `refs/heads/releases`.
     - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default)
-      or `Prefix`.
+      , `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -54,6 +54,12 @@ resource "azuredevops_branch_policy_status_check" "example" {
       repository_ref = azuredevops_git_repository.example.default_branch
       match_type     = "Exact"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      match_type     = "DefaultBranch"
+      repository_ref = null
+    }
   }
 }
 ```
@@ -83,13 +89,9 @@ The following arguments are supported:
 
   `scope` block supports the following:
 
-    - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single
-      repository.
-    - `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a
-      qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such
-      as `refs/heads/releases`.
-    - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default)
-      , `Prefix` or `DefaultBranch`.
+    - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+    - `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+    - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 

--- a/website/docs/r/branch_policy_status_check.html.markdown
+++ b/website/docs/r/branch_policy_status_check.html.markdown
@@ -56,9 +56,7 @@ resource "azuredevops_branch_policy_status_check" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
       match_type     = "DefaultBranch"
-      repository_ref = null
     }
   }
 }

--- a/website/docs/r/branch_policy_work_item_linking.html.markdown
+++ b/website/docs/r/branch_policy_work_item_linking.html.markdown
@@ -45,9 +45,7 @@ resource "azuredevops_branch_policy_work_item_linking" "example" {
     }
     
     scope {
-      repository_id  = azuredevops_git_repository.example.id
       match_type     = "DefaultBranch"
-      repository_ref = null
     }
   }
 }

--- a/website/docs/r/branch_policy_work_item_linking.html.markdown
+++ b/website/docs/r/branch_policy_work_item_linking.html.markdown
@@ -43,6 +43,12 @@ resource "azuredevops_branch_policy_work_item_linking" "example" {
       repository_ref = "refs/heads/releases"
       match_type     = "Prefix"
     }
+    
+    scope {
+      repository_id  = azuredevops_git_repository.example.id
+      match_type     = "DefaultBranch"
+      repository_ref = null
+    }
   }
 }
 ```
@@ -62,9 +68,9 @@ A `settings` block supports the following:
 
 A `settings` `scope` block supports the following:
 
-- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository.
-- `repository_ref` - (Optional) The ref pattern to use for the match. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
-- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default) or `Prefix`.
+- `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+- `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+- `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The API accept passing a match_type that is 'DefaultBranch' to match the default defined for a repo, this PR is simply to add the missing value to the list of possible value we can passed to the Azure Devops API.

Issue Number: [issues 305](https://github.com/microsoft/terraform-provider-azuredevops/issues/305)

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?

 Error: expected settings.0.scope.0.match_type to be one of [Exact Prefix], got DefaultBranch


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->