### PR TITLE
[bug fix]azuredevops_project - sync project staus 

### DIFF
--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -231,12 +231,18 @@ func projectRead(clients *client.AggregatedClient, projectID string, projectName
 			IncludeHistory:      converter.Bool(false),
 		})
 		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				return resource.NonRetryableError(err)
+			}
 			return resource.RetryableError(err)
 		}
 		return nil
 	})
 
 	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			return nil, err
+		}
 		return nil, fmt.Errorf(" Project not found. (ID: %s or name: %s), Error: %+v", projectID, projectName, err)
 	}
 	return project, nil


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Handle 404 error as special error, sync project status when `plan/refresh`

Issue Number: #614 
```log
=== RUN   TestAccProject_DataSource
=== RUN   TestAccProject_DataSource/Get_project_with_id
=== PAUSE TestAccProject_DataSource/Get_project_with_id
=== RUN   TestAccProject_DataSource/Get_project_with_name
=== PAUSE TestAccProject_DataSource/Get_project_with_name
=== CONT  TestAccProject_DataSource/Get_project_with_id
=== CONT  TestAccProject_DataSource/Get_project_with_name
--- PASS: TestAccProject_DataSource (0.00s)
    --- PASS: TestAccProject_DataSource/Get_project_with_id (36.32s)
    --- PASS: TestAccProject_DataSource/Get_project_with_name (37.07s)
=== RUN   TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== PAUSE TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== RUN   TestAccProject_DataSource_ErrorWhenDescriptionSet
=== PAUSE TestAccProject_DataSource_ErrorWhenDescriptionSet
=== RUN   TestAccProject_CreateAndUpdate
=== PAUSE TestAccProject_CreateAndUpdate
=== RUN   TestAccProject_CreateAndUpdateWithFeatures
=== PAUSE TestAccProject_CreateAndUpdateWithFeatures
=== CONT  TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== CONT  TestAccProject_CreateAndUpdate
=== CONT  TestAccProject_CreateAndUpdateWithFeatures
=== CONT  TestAccProject_DataSource_ErrorWhenDescriptionSet
--- PASS: TestAccProject_DataSource_ErrorWhenDescriptionSet (0.74s)
--- PASS: TestAccProject_DataSource_ErrorWhenBothNameAndIdSet (1.40s)
--- PASS: TestAccProject_CreateAndUpdate (39.41s)
--- PASS: TestAccProject_CreateAndUpdateWithFeatures (45.80s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        83.970s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->