### PR TITLE
fix: flatten project falls back to organization default template ID

### DIFF
--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -33,11 +33,11 @@ The following arguments are supported:
 - `description` - (Optional) The Description of the Project.
 - `visibility` - (Optional) Specifies the visibility of the Project. Valid values: `private` or `public`. Defaults to `private`.
 - `version_control` - (Optional) Specifies the version control system. Valid values: `Git` or `Tfvc`. Defaults to `Git`.
-- `work_item_template` - (Optional) Specifies the work item template. Valid values: `Agile`, `Basic`, `CMMI` or `Scrum`. Defaults to `Agile`.
-- `features` - (Optional) Defines the status (`enabled`, `disabled`) of the project features.  
+- `work_item_template` - (Optional) Specifies the work item template. Valid values: `Agile`, `Basic`, `CMMI`, `Scrum` or a custom, pre-existing one. Defaults to `Agile`. An empty string will use the parent organization default.
+- `features` - (Optional) Defines the status (`enabled`, `disabled`) of the project features.
    Valid features are `boards`, `repositories`, `pipelines`, `testplans`, `artifacts`
 
-> **NOTE:**  
+> **NOTE:**
 > It's possible to define project features both within the [`azuredevops_project_features` resource](project_features.html) and
 > via the `features` block by using the [`azuredevops_project` resource](project.html).
 > However it's not possible to use both methods to manage features, since there'll be conflicts.


### PR DESCRIPTION
The Azure DevOps API does not guarantee a process template ID will be returned when getting a project detail. This seems to be caused for projects which use the organisation default template. As such, the lookup logic should allow to fallback to that value, if none is present at the project level.

The changes introduced allow an empty work item template parameter, which will force a lookup on the organisation level. The default value is kept as `Agile` for compatibility and design choices.

Fixes #199

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->