### PR TITLE
Create datasource azuredevops_serviceendpoint_github, add common func…

### DIFF
--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
@@ -32,7 +32,7 @@ func TestAccServiceEndpointAzureRM_with_serviceEndpointID_DataSource(t *testing.
 				Config: createServiceEndpointAzureRMWithServiceEndpointIDData,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointAzureRMName),
-					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "service_endpoint_id"),
 				),
 			},
 		},
@@ -58,7 +58,7 @@ func TestAccServiceEndpointAzureRM_with_serviceEndpointName_DataSource(t *testin
 				Config: createServiceEndpointAzureRMWithServiceEndpointNameData,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointAzureRMName),
-					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "service_endpoint_id"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
@@ -29,7 +29,7 @@ func TestAccServiceEndpointGitHub_with_serviceEndpointID_DataSource(t *testing.T
 				Config: createServiceEndpointGitHubWithServiceEndpointIDData,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointGitHubName),
-					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "service_endpoint_id"),
 				),
 			},
 		},
@@ -53,7 +53,7 @@ func TestAccServiceEndpointGitHub_with_serviceEndpointName_DataSource(t *testing
 				Config: createServiceEndpointGitHubWithServiceEndpointNameData,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointGitHubName),
-					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "service_endpoint_id"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
@@ -1,0 +1,61 @@
+//go:build (all || data_sources || data_serviceendpoint_github) && (!exclude_data_sources || !exclude_data_serviceendpoint_github)
+// +build all data_sources data_serviceendpoint_github
+// +build !exclude_data_sources !exclude_data_serviceendpoint_github
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccServiceEndpointGitHub_with_serviceEndpointID_DataSource(t *testing.T) {
+	serviceEndpointGitHubName := testutils.GenerateResourceName()
+	projectName := testutils.GenerateResourceName()
+	createServiceEndpointGitHubWithServiceEndpointIDData := fmt.Sprintf("%s\n%s",
+		testutils.HclServiceEndpointGitHubResource(projectName, serviceEndpointGitHubName),
+		testutils.HclServiceEndpointGitHubDataSourceWithServiceEndpointID(),
+	)
+
+	tfNode := "data.azuredevops_serviceendpoint_github.serviceendpoint"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: createServiceEndpointGitHubWithServiceEndpointIDData,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointGitHubName),
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceEndpointGitHub_with_serviceEndpointName_DataSource(t *testing.T) {
+	serviceEndpointGitHubName := testutils.GenerateResourceName()
+	projectName := testutils.GenerateResourceName()
+	createServiceEndpointGitHubWithServiceEndpointNameData := fmt.Sprintf("%s\n%s",
+		testutils.HclServiceEndpointGitHubResource(projectName, serviceEndpointGitHubName),
+		testutils.HclServiceEndpointGitHubDataSourceWithServiceEndpointName(serviceEndpointGitHubName),
+	)
+
+	tfNode := "data.azuredevops_serviceendpoint_github.serviceendpoint"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: createServiceEndpointGitHubWithServiceEndpointNameData,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointGitHubName),
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+				),
+			},
+		},
+	})
+}

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -256,7 +256,7 @@ func HclServiceEndpointGitHubDataSourceWithServiceEndpointID() string {
 	serviceEndpointDataSource := fmt.Sprintf(`
 data "azuredevops_serviceendpoint_github" "serviceendpoint" {
   project_id = azuredevops_project.project.id
-  id         = azuredevops_serviceendpoint_github.serviceendpoint.id
+  service_endpoint_id         = azuredevops_serviceendpoint_github.serviceendpoint.id
 }
 `)
 	return fmt.Sprintf("%s", serviceEndpointDataSource)
@@ -428,7 +428,7 @@ func HclServiceEndpointAzureRMDataSourceWithServiceEndpointID() string {
 	serviceEndpointDataSource := fmt.Sprintf(`
 data "azuredevops_serviceendpoint_azurerm" "serviceendpointrm" {
   project_id = azuredevops_project.project.id
-  id         = azuredevops_serviceendpoint_azurerm.serviceendpointrm.id
+  service_endpoint_id         = azuredevops_serviceendpoint_azurerm.serviceendpointrm.id
 }
 `)
 	return fmt.Sprintf("%s", serviceEndpointDataSource)

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -251,6 +251,30 @@ resource "azuredevops_serviceendpoint_github" "serviceendpoint" {
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
+// HclServiceEndpointGitHubDataSourceWithServiceEndpointID HCL describing a data source for an AzDO service endpoint
+func HclServiceEndpointGitHubDataSourceWithServiceEndpointID() string {
+	serviceEndpointDataSource := fmt.Sprintf(`
+data "azuredevops_serviceendpoint_github" "serviceendpoint" {
+  project_id = azuredevops_project.project.id
+  id         = azuredevops_serviceendpoint_github.serviceendpoint.id
+}
+`)
+	return fmt.Sprintf("%s", serviceEndpointDataSource)
+}
+
+// HclServiceEndpointGitHubDataSourceWithServiceEndpointName HCL describing a data source for an AzDO service endpoint
+func HclServiceEndpointGitHubDataSourceWithServiceEndpointName(serviceEndpointName string) string {
+	serviceEndpointDataSource := fmt.Sprintf(`
+data "azuredevops_serviceendpoint_github" "serviceendpoint" {
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  depends_on            = [azuredevops_serviceendpoint_github.serviceendpoint]
+}
+`, serviceEndpointName)
+
+	return fmt.Sprintf("%s", serviceEndpointDataSource)
+}
+
 func HclServiceEndpointGitHubEnterpriseResource(projectName string, serviceEndpointName string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -395,16 +395,16 @@ func dataSourceGenBaseServiceEndpointResource(dataSourceReadFunc schema.ReadFunc
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ExactlyOneOf: []string{"service_endpoint_name", "id"},
+				ExactlyOneOf: []string{"service_endpoint_name", "service_endpoint_id"},
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"id": {
+			"service_endpoint_id": {
 				Description:  "The ID of the serviceendpoint",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ExactlyOneOf: []string{"service_endpoint_name", "id"},
+				ExactlyOneOf: []string{"service_endpoint_name", "service_endpoint_id"},
 				ValidateFunc: validation.IsUUID,
 			},
 
@@ -443,7 +443,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 
 	projectID = &parsedProjectID
 
-	if serviceEndpointIDString, ok := d.GetOk("id"); ok {
+	if serviceEndpointIDString, ok := d.GetOk("service_endpoint_id"); ok {
 		var serviceEndpointID *uuid.UUID
 		parsedServiceEndpointID, err := uuid.Parse(serviceEndpointIDString.(string))
 		if err != nil {

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -481,7 +481,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 
 		return serviceEndpoint, projectID, nil
 	}
-	return nil, nil, nil
+	return nil, projectID, nil
 }
 
 func dataSourceGetServiceEndpointByNameAndProject(clients *client.AggregatedClient, serviceEndpointName string, projectID *uuid.UUID) (*serviceendpoint.ServiceEndpoint, error) {

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -381,3 +381,130 @@ func getServiceEndpoint(client *client.AggregatedClient, serviceEndpointID *uuid
 		return nil, opState.Failed, fmt.Errorf(errMsgServiceCreate, serviceEndpointID, *projectID, serviceEndpoint.OperationStatus)
 	}
 }
+
+func dataSourceGenBaseServiceEndpointResource(dataSourceReadFunc schema.ReadFunc) *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceReadFunc,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"service_endpoint_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"service_endpoint_name", "id"},
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"id": {
+				Description:  "The ID of the serviceendpoint",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"service_endpoint_name", "id"},
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"authorization": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMakeUnprotectedComputedSchema(r *schema.Resource, keyName string) {
+	r.Schema[keyName] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+}
+
+func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*serviceendpoint.ServiceEndpoint, *uuid.UUID, error) {
+	clients := m.(*client.AggregatedClient)
+
+	var projectID *uuid.UUID
+	projectIDString := d.Get("project_id").(string)
+	parsedProjectID, err := uuid.Parse(projectIDString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error parsing projectID from the Terraform data source declaration: %v", err)
+	}
+
+	projectID = &parsedProjectID
+
+	if serviceEndpointIDString, ok := d.GetOk("id"); ok {
+		var serviceEndpointID *uuid.UUID
+		parsedServiceEndpointID, err := uuid.Parse(serviceEndpointIDString.(string))
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error parsing serviceEndpointID from the Terraform data source declaration: %v", err)
+		}
+		serviceEndpointID = &parsedServiceEndpointID
+
+		serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(
+			clients.Ctx,
+			serviceendpoint.GetServiceEndpointDetailsArgs{
+				EndpointId: serviceEndpointID,
+				Project:    converter.String(projectID.String()),
+			},
+		)
+		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				d.SetId("")
+				return nil, projectID, nil
+			}
+			return nil, projectID, fmt.Errorf("Error looking up service endpoint with ID (%v) and projectID (%v): %v", serviceEndpointID, projectID, err)
+		}
+
+		return serviceEndpoint, projectID, nil
+	}
+
+	if serviceEndpointName, ok := d.GetOk("service_endpoint_name"); ok {
+		serviceEndpoint, err := dataSourceGetServiceEndpointByNameAndProject(clients, serviceEndpointName.(string), projectID)
+		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				d.SetId("")
+				return nil, projectID, nil
+			}
+			return nil, projectID, fmt.Errorf("Error looking up service endpoint with name (%v) and projectID (%v): %v", serviceEndpointName, projectID, err)
+		}
+
+		return serviceEndpoint, projectID, nil
+	}
+	return nil, nil, nil
+}
+
+func dataSourceGetServiceEndpointByNameAndProject(clients *client.AggregatedClient, serviceEndpointName string, projectID *uuid.UUID) (*serviceendpoint.ServiceEndpoint, error) {
+	serviceEndpointNameList := &[]string{serviceEndpointName}
+
+	serviceEndpoints, err := clients.ServiceEndpointClient.GetServiceEndpointsByNames(
+		clients.Ctx,
+		serviceendpoint.GetServiceEndpointsByNamesArgs{
+			Project:       converter.String(projectID.String()),
+			EndpointNames: serviceEndpointNameList,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(*serviceEndpoints) == 0 {
+		return nil, fmt.Errorf("%v not found!", serviceEndpointName)
+	}
+
+	if len(*serviceEndpoints) > 1 {
+		return nil, fmt.Errorf("%v returns more than one serviceEndpoint!", serviceEndpointName)
+	}
+
+	return &(*serviceEndpoints)[0], nil
+}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
@@ -22,6 +22,7 @@ func dataSourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{})
 	}
 	if serviceEndpoint != nil {
 		(*serviceEndpoint.Data)["creationMode"] = ""
+		d.Set("service_endpoint_id", serviceEndpoint.Id.String())
 		flattenServiceEndpointAzureRM(d, serviceEndpoint, projectID)
 		return nil
 	}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
@@ -3,166 +3,27 @@ package serviceendpoint
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/serviceendpoint"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
 func DataServiceEndpointAzureRM() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceServiceEndpointAzureRMRead,
-		Schema: map[string]*schema.Schema{
-			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"service_endpoint_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"service_endpoint_name", "id"},
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"id": {
-				Description:  "The ID of the serviceendpoint",
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"service_endpoint_name", "id"},
-				ValidateFunc: validation.IsUUID,
-			},
-
-			"authorization": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
-			"azurerm_management_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"azurerm_management_group_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"azurerm_subscription_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"azurerm_subscription_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"resource_group": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"azurerm_spn_tenantid": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+	r := dataSourceGenBaseServiceEndpointResource(dataSourceServiceEndpointAzureRMRead)
+	schemaKeys := []string{"azurerm_management_group_id", "azurerm_management_group_name", "azurerm_subscription_id", "azurerm_subscription_name", "resource_group", "azurerm_spn_tenantid"}
+	for _, k := range schemaKeys {
+		dataSourceMakeUnprotectedComputedSchema(r, k)
 	}
+	return r
 }
 
 func dataSourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) error {
-	clients := m.(*client.AggregatedClient)
-
-	var projectID *uuid.UUID
-	projectIDString := d.Get("project_id").(string)
-	parsedProjectID, err := uuid.Parse(projectIDString)
+	serviceEndpoint, projectID, err := dataSourceGetBaseServiceEndpoint(d, m)
 	if err != nil {
-		return fmt.Errorf("Error parsing projectID from the Terraform data source declaration: %v", err)
+		return err
 	}
-
-	projectID = &parsedProjectID
-
-	if serviceEndpointIDString, ok := d.GetOk("id"); ok {
-		var serviceEndpointID *uuid.UUID
-		parsedServiceEndpointID, err := uuid.Parse(serviceEndpointIDString.(string))
-		if err != nil {
-			return fmt.Errorf("Error parsing serviceEndpointID from the Terraform data source declaration: %v", err)
-		}
-		serviceEndpointID = &parsedServiceEndpointID
-
-		serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(
-			clients.Ctx,
-			serviceendpoint.GetServiceEndpointDetailsArgs{
-				EndpointId: serviceEndpointID,
-				Project:    converter.String(projectID.String()),
-			},
-		)
-		if err != nil {
-			if utils.ResponseWasNotFound(err) {
-				d.SetId("")
-				return nil
-			}
-			return fmt.Errorf("Error looking up service endpoint with ID (%v) and projectID (%v): %v", serviceEndpointID, projectID, err)
-		}
-
+	if serviceEndpoint != nil {
 		(*serviceEndpoint.Data)["creationMode"] = ""
 		flattenServiceEndpointAzureRM(d, serviceEndpoint, projectID)
 		return nil
 	}
-
-	if serviceEndpointName, ok := d.GetOk("service_endpoint_name"); ok {
-		// get service endpointdetails by name
-		serviceEndpoint, err := getServiceEndpointByNameAndProject(clients, serviceEndpointName.(string), projectID)
-		if err != nil {
-			if utils.ResponseWasNotFound(err) {
-				d.SetId("")
-				return nil
-			}
-			return fmt.Errorf("Error looking up service endpoint with name (%v) and projectID (%v): %v", serviceEndpointName, projectID, err)
-		}
-
-		(*serviceEndpoint.Data)["creationMode"] = ""
-		flattenServiceEndpointAzureRM(d, serviceEndpoint, projectID)
-		return nil
-	}
-	return nil
-}
-
-func getServiceEndpointByNameAndProject(clients *client.AggregatedClient, serviceEndpointName string, projectID *uuid.UUID) (*serviceendpoint.ServiceEndpoint, error) {
-	serviceEndpointNameList := &[]string{serviceEndpointName}
-
-	serviceEndpoints, err := clients.ServiceEndpointClient.GetServiceEndpointsByNames(
-		clients.Ctx,
-		serviceendpoint.GetServiceEndpointsByNamesArgs{
-			Project:       converter.String(projectID.String()),
-			EndpointNames: serviceEndpointNameList,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(*serviceEndpoints) == 0 {
-		return nil, fmt.Errorf("%v not found!", serviceEndpointName)
-	}
-
-	if len(*serviceEndpoints) > 1 {
-		return nil, fmt.Errorf("%v returns more than one serviceEndpoint!", serviceEndpointName)
-	}
-
-	return &(*serviceEndpoints)[0], nil
+	return fmt.Errorf("Error looking up service endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
@@ -1,0 +1,24 @@
+package serviceendpoint
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataServiceEndpointGithub() *schema.Resource {
+	r := dataSourceGenBaseServiceEndpointResource(dataSourceServiceEndpointGithubRead)
+	return r
+}
+
+func dataSourceServiceEndpointGithubRead(d *schema.ResourceData, m interface{}) error {
+	serviceEndpoint, projectID, err := dataSourceGetBaseServiceEndpoint(d, m)
+	if err != nil {
+		return err
+	}
+	if serviceEndpoint != nil {
+		doBaseFlattening(d, serviceEndpoint, projectID)
+		return nil
+	}
+	return fmt.Errorf("Error looking up service endpoint!")
+}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
@@ -17,6 +17,7 @@ func dataSourceServiceEndpointGithubRead(d *schema.ResourceData, m interface{}) 
 		return err
 	}
 	if serviceEndpoint != nil {
+		d.Set("service_endpoint_id", serviceEndpoint.Id.String())
 		doBaseFlattening(d, serviceEndpoint, projectID)
 		return nil
 	}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -104,6 +104,7 @@ func Provider() *schema.Provider {
 			"azuredevops_groups":                  graph.DataGroups(),
 			"azuredevops_variable_group":          taskagent.DataVariableGroup(),
 			"azuredevops_serviceendpoint_azurerm": serviceendpoint.DataServiceEndpointAzureRM(),
+			"azuredevops_serviceendpoint_github":  serviceendpoint.DataServiceEndpointGithub(),
 		},
 		Schema: map[string]*schema.Schema{
 			"org_service_url": {

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -100,6 +100,7 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		"azuredevops_groups",
 		"azuredevops_variable_group",
 		"azuredevops_serviceendpoint_azurerm",
+		"azuredevops_serviceendpoint_github",
 	}
 
 	dataSources := Provider().DataSourcesMap

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -79,6 +79,9 @@
                 <li>
                     <a href="/docs/providers/azuredevops/d/serviceendpoint_azurerm.html">azuredevops_serviceendpoint_azurerm</a>
                 </li>
+                <li>
+                    <a href="/docs/providers/azuredevops/d/serviceendpoint_github.html">azuredevops_serviceendpoint_github</a>
+                </li>
               </ul>
             </li>
 

--- a/website/docs/d/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/d/serviceendpoint_azurerm.html.markdown
@@ -20,7 +20,7 @@ data "azuredevops_project" "sample" {
 
 data "azuredevops_serviceendpoint_azurerm" "serviceendpoint" {
   project_id = data.azuredevops_project.sample.id
-  id         = "00000000-0000-0000-0000-000000000000"
+  service_endpoint_id         = "00000000-0000-0000-0000-000000000000"
 }
 
 output "service_endpoint_name" {
@@ -51,11 +51,11 @@ The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project.
 
-* `id` - (Optional) the ID of the Service Endpoint.
+* `service_endpoint_id` - (Optional) the ID of the Service Endpoint.
 
 * `service_endpoint_name` - (Optional) the Name of the Service Endpoint.
 
-~> **NOTE:** One of either `id` or `service_endpoint_name` must be specified.
+~> **NOTE:** One of either `service_endpoint_id` or `service_endpoint_name` must be specified.
 ~> **NOTE:** When supplying `service_endpoint_name`, take care to ensure that this is a unique name.
 
 ## Attributes Reference

--- a/website/docs/d/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/d/serviceendpoint_azurerm.html.markdown
@@ -19,8 +19,8 @@ data "azuredevops_project" "sample" {
 }
 
 data "azuredevops_serviceendpoint_azurerm" "serviceendpoint" {
-  project_id = data.azuredevops_project.sample.id
-  service_endpoint_id         = "00000000-0000-0000-0000-000000000000"
+  project_id          = data.azuredevops_project.sample.id
+  service_endpoint_id = "00000000-0000-0000-0000-000000000000"
 }
 
 output "service_endpoint_name" {

--- a/website/docs/d/serviceendpoint_github.html.markdown
+++ b/website/docs/d/serviceendpoint_github.html.markdown
@@ -19,8 +19,8 @@ data "azuredevops_project" "sample" {
 }
 
 data "azuredevops_serviceendpoint_github" "serviceendpoint" {
-  project_id = data.azuredevops_project.sample.id
-  service_endpoint_id         = "00000000-0000-0000-0000-000000000000"
+  project_id          = data.azuredevops_project.sample.id
+  service_endpoint_id = "00000000-0000-0000-0000-000000000000"
 }
 
 output "service_endpoint_name" {

--- a/website/docs/d/serviceendpoint_github.html.markdown
+++ b/website/docs/d/serviceendpoint_github.html.markdown
@@ -2,12 +2,12 @@
 layout: "azuredevops"
 page_title: "AzureDevops: Data Source: azuredevops_serviceendpoint_github"
 description: |-
-  Gets information about an existing AzureRM Service Endpoint.
+  Gets information about an existing GitHub Service Endpoint.
 ---
 
 # Data Source : azuredevops_serviceendpoint_github
 
-Use this data source to access information about an existing AzureRM service Endpoint.
+Use this data source to access information about an existing GitHub service Endpoint.
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ data "azuredevops_project" "sample" {
 
 data "azuredevops_serviceendpoint_github" "serviceendpoint" {
   project_id = data.azuredevops_project.sample.id
-  id         = "00000000-0000-0000-0000-000000000000"
+  service_endpoint_id         = "00000000-0000-0000-0000-000000000000"
 }
 
 output "service_endpoint_name" {
@@ -51,11 +51,11 @@ The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project.
 
-* `id` - (Optional) the ID of the Service Endpoint.
+* `service_endpoint_id` - (Optional) the ID of the Service Endpoint.
 
 * `service_endpoint_name` - (Optional) the Name of the Service Endpoint.
 
-~> **NOTE:** One of either `id` or `service_endpoint_name` must be specified.
+~> **NOTE:** One of either `service_endpoint_id` or `service_endpoint_name` must be specified.
 ~> **NOTE:** When supplying `service_endpoint_name`, take care to ensure that this is a unique name.
 
 ## Attributes Reference

--- a/website/docs/d/serviceendpoint_github.html.markdown
+++ b/website/docs/d/serviceendpoint_github.html.markdown
@@ -1,11 +1,11 @@
 ---
 layout: "azuredevops"
-page_title: "AzureDevops: Data Source: azuredevops_serviceendpoint_azurerm"
+page_title: "AzureDevops: Data Source: azuredevops_serviceendpoint_github"
 description: |-
   Gets information about an existing AzureRM Service Endpoint.
 ---
 
-# Data Source : azuredevops_serviceendpoint_azurerm
+# Data Source : azuredevops_serviceendpoint_github
 
 Use this data source to access information about an existing AzureRM service Endpoint.
 
@@ -18,13 +18,13 @@ data "azuredevops_project" "sample" {
   name = "Sample Project"
 }
 
-data "azuredevops_serviceendpoint_azurerm" "serviceendpoint" {
+data "azuredevops_serviceendpoint_github" "serviceendpoint" {
   project_id = data.azuredevops_project.sample.id
   id         = "00000000-0000-0000-0000-000000000000"
 }
 
 output "service_endpoint_name" {
-  value = data.azuredevops_serviceendpoint_azurerm.serviceendpoint.service_endpoint_name
+  value = data.azuredevops_serviceendpoint_github.serviceendpoint.service_endpoint_name
 }
 ```
 
@@ -35,13 +35,13 @@ data "azuredevops_project" "sample" {
   name = "Sample Project"
 }
 
-data "azuredevops_serviceendpoint_azurerm" "serviceendpoint" {
+data "azuredevops_serviceendpoint_github" "serviceendpoint" {
   project_id            = data.azuredevops_project.sample.id
   service_endpoint_name = "Example-Service-Endpoint"
 }
 
 output "service_endpoint_id" {
-  value = data.azuredevops_serviceendpoint_azurerm.serviceendpoint.id
+  value = data.azuredevops_serviceendpoint_github.serviceendpoint.id
 }
 ```
 
@@ -63,10 +63,4 @@ The following arguments are supported:
 In addition to the Arguments list above - the following Attributes are exported:
 
 * `authorization` - Specifies the Authorization Scheme Map.
-* `azurerm_management_group_id` - Specified the Management Group ID of the Service Endpoint is target, if available.
-* `azurerm_management_group_name` - Specified the Management Group Name of the Service Endpoint target, if available.
-* `azurerm_subscription_id` - Specifies the Subscription ID of the Service Endpoint target, if available.
-* `azurerm_subscription_name` - Specifies the Subscription Name of the Service Endpoint target, if available.
-* `resource_group` - Specifies the Resource Group of the Service Endpoint target, if available.
-* `azurerm_spn_tenantid` - Specifies the Tenant ID of the Azure targets.
 * `description` - Specifies the description of the Service Endpoint.


### PR DESCRIPTION
…tions to create datasource schemas, fix documentation

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR adds a new data source `azuredevops_serviceendpoint_github` which returns details of a GitHub service endpoint defined by an `id` or a unique `service_endpoint_name`

Issue Number: #608

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

https://pst.klgrth.io/paste/4t6et


## Other information

Additional functions are added to `azuredevops/internal/service/serviceendpoint/commons.go`  to support common dataSource schemas and serviceendpoint lookup functions

Modifications were made to `azuredevops_serviceendpoint_azurerm` datasource as a result of the aforementioned additions to `commons.go`