### PR TITLE
fix: `azuredevops_serviceendpoint_kubernetes` kubeconfig update failure and plugin crash

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -106,7 +106,7 @@ func makeSchemaKubeconfig(r *schema.Resource) {
 		},
 	}
 	r.Schema[resourceBlockKubeconfig] = &schema.Schema{
-		Type:        schema.TypeSet,
+		Type:        schema.TypeList,
 		Optional:    true,
 		MinItems:    1,
 		MaxItems:    1,
@@ -201,7 +201,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 			"clusterAdmin":          strconv.FormatBool(configuration["cluster_admin"].(bool)),
 		}
 	case "Kubeconfig":
-		configurationRaw := d.Get(resourceBlockKubeconfig).(*schema.Set).List()
+		configurationRaw := d.Get(resourceBlockKubeconfig).([]interface{})
 		configuration := configurationRaw[0].(map[string]interface{})
 
 		clusterContextInput := configuration["cluster_context"].(string)
@@ -285,7 +285,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 		d.Set(resourceBlockAzSubscription, configItemList)
 	case "Kubeconfig":
 		var kubeconfig map[string]interface{}
-		kubeconfigSet := d.Get("kubeconfig").(*schema.Set).List()
+		kubeconfigSet := d.Get("kubeconfig").([]interface{})
 
 		configuration := kubeconfigSet[0].(map[string]interface{})
 		acceptUntrustedCerts, _ := strconv.ParseBool((*serviceEndpoint.Data)["acceptUntrustedCerts"])

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -95,6 +95,7 @@ func makeSchemaKubeconfig(r *schema.Resource) {
 			"cluster_context": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Context of your cluster",
 			},
 			"accept_untrusted_certs": {
@@ -213,7 +214,7 @@ func expandServiceEndpointKubernetes(d *schema.ResourceData) (*serviceendpoint.S
 				errResult := fmt.Errorf("kube_config contains an invalid YAML: %s", err)
 				return nil, nil, errResult
 			}
-			clusterContextInputList := kubeConfigYAMLUnmarshalled["contexts"].([]interface{})[0].(map[interface{}]interface{})
+			clusterContextInputList := kubeConfigYAMLUnmarshalled["contexts"].([]interface{})[0].(map[string]interface{})
 			clusterContextInput = clusterContextInputList["name"].(string)
 		}
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Terraform now prevents showing sensitive data to log/console. The encoding with `bcrypt` of a kubeconfig file will often leads to no diff detected since `bcrypt` has a limit of only 72 bytes.

As for #619, this removes the hash attribut.

I also included a fix a plugin crash when the `cluster_context` attribut was not specified.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #613, #635

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Remove the hash will not be a breaking change and no diff is shown on plan or apply

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

Plugin crash log when the `cluster_context` attribut was not specified:
```
╷
│ Error: Plugin did not respond
│ 
│   with azuredevops_serviceendpoint_kubernetes.kube_config,
│   on main.tf line 24, in resource "azuredevops_serviceendpoint_kubernetes" "kube_config":
│   24: resource "azuredevops_serviceendpoint_kubernetes" "kube_config" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-azuredevops_v0.0.1 plugin:

panic: interface conversion: interface {} is map[string]interface {}, not map[interface {}]interface {}

goroutine 32 [running]:
github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint.expandServiceEndpointKubernetes(0x1b97600?)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go:213 +0x13c9
github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint.genServiceEndpointCreateFunc.func1(0x0?, {0x18a37a0?, 0xc000168d80})
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/commons.go:167 +0x73
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x1b98ee0?, {0x1b98ee0?, 0xc0002ce150?}, 0xd?, {0x18a37a0?, 0xc000168d80?})
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:330 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0004dbce0, {0x1b98ee0, 0xc0002ce150}, 0xc000793380, 0xc00011d700, {0x18a37a0, 0xc000168d80})
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:472 +0x83a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000304018, {0x1b98e38?, 0xc00011f300?}, 0xc0000c79f0)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:1021 +0xe05
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0002326e0, {0x1b98ee0?, 0xc000511dd0?}, 0xc0008c21c0)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go:812 +0x515
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1a01240?, 0xc0002326e0}, {0x1b98ee0, 0xc000511dd0}, 0xc0002b0600, 0x0)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000138a80, {0x1b9c938, 0xc00031b860}, 0xc000805b00, 0xc00021bbc0, 0x20d9260, 0x0)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/google.golang.org/grpc/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc000138a80, {0x1b9c938, 0xc00031b860}, 0xc000805b00, 0x0)
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/google.golang.org/grpc/server.go:1619 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/google.golang.org/grpc/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/mouellet/workspace/mouellet/terraform-provider-azuredevops/vendor/google.golang.org/grpc/server.go:919 +0x28a

Error: The terraform-provider-azuredevops_v0.0.1 plugin crashed!
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->