### PR TITLE
Bug fix - `azuredevops_serviceendpoint_artifactory` - Read sensitive data from local config

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -144,10 +144,8 @@ func flattenServiceEndpointArtifactory(d *schema.ResourceData, serviceEndpoint *
 			if len(authList) > 0 {
 				newHash, hashKey := tfhelper.HelpFlattenSecretNested(d, "authentication_token", authList, "token")
 				auth[hashKey] = newHash
+				auth["token"] = authList["token"]
 			}
-		}
-		if serviceEndpoint.Authorization != nil && serviceEndpoint.Authorization.Parameters != nil {
-			auth["token"] = (*serviceEndpoint.Authorization.Parameters)["apitoken"]
 		}
 		d.Set("authentication_token", []interface{}{auth})
 	} else if strings.EqualFold(*serviceEndpoint.Authorization.Scheme, "UsernamePassword") {
@@ -159,11 +157,10 @@ func flattenServiceEndpointArtifactory(d *schema.ResourceData, serviceEndpoint *
 				auth[hashKey] = newHash
 				newHash, hashKey = tfhelper.HelpFlattenSecretNested(d, "authentication_basic", oldAuthList, "username")
 				auth[hashKey] = newHash
+
+				auth["password"] = oldAuthList["password"]
+				auth["username"] = oldAuthList["username"]
 			}
-		}
-		if serviceEndpoint.Authorization != nil && serviceEndpoint.Authorization.Parameters != nil {
-			auth["password"] = (*serviceEndpoint.Authorization.Parameters)["password"]
-			auth["username"] = (*serviceEndpoint.Authorization.Parameters)["username"]
 		}
 		d.Set("authentication_basic", []interface{}{auth})
 	} else {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -140,11 +140,11 @@ func flattenServiceEndpointArtifactory(d *schema.ResourceData, serviceEndpoint *
 	if strings.EqualFold(*serviceEndpoint.Authorization.Scheme, "Token") {
 		auth := make(map[string]interface{})
 		if x, ok := d.GetOk("authentication_token"); ok {
-			authList := x.([]interface{})[0].(map[string]interface{})
-			if len(authList) > 0 {
-				newHash, hashKey := tfhelper.HelpFlattenSecretNested(d, "authentication_token", authList, "token")
+			authMap := x.([]interface{})[0].(map[string]interface{})
+			if len(authMap) > 0 {
+				newHash, hashKey := tfhelper.HelpFlattenSecretNested(d, "authentication_token", authMap, "token")
 				auth[hashKey] = newHash
-				auth["token"] = authList["token"]
+				auth["token"] = authMap["token"]
 			}
 		}
 		d.Set("authentication_token", []interface{}{auth})


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Service will not return any sensitive data: password, secret etc. Get these data from local config in case the second update set these sensitive data to `null/""`
Issue Number: #422 

```log
=== RUN   TestAccServiceEndpointArtifactory_basic
=== PAUSE TestAccServiceEndpointArtifactory_update
=== RUN   TestAccServiceEndpointArtifactory_update_usernamepassword
=== PAUSE TestAccServiceEndpointArtifactory_update_usernamepassword
=== RUN   TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== RUN   TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== PAUSE TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArtifactory_basic
=== CONT  TestAccServiceEndpointArtifactory_update
=== CONT  TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointArtifactory_basic_usernamepassword
=== CONT  TestAccServiceEndpointArtifactory_complete_token
=== CONT  TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArtifactory_update_usernamepassword
=== CONT  TestAccServiceEndpointArtifactory_complete_usernamepassword
--- PASS: TestAccServiceEndpointArtifactory_complete_token (55.78s)
--- PASS: TestAccServiceEndpointArtifactory_complete_usernamepassword (63.90s)
--- PASS: TestAccServiceEndpointArtifactory_basic (66.23s)
--- PASS: TestAccServiceEndpointArtifactory_basic_usernamepassword (67.64s)
--- PASS: TestAccServiceEndpointArtifactory_RequiresImportErrorStep (69.39s)
--- PASS: TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword (69.66s)
--- PASS: TestAccServiceEndpointArtifactory_update_usernamepassword (86.82s)
--- PASS: TestAccServiceEndpointArtifactory_update (87.18s)
PASS

```
## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->