### PR TITLE
feat: add attribute minimum_number_of_reviewers to resource azuredevops_branch_policy_auto_reviewers

### DIFF
--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers.go
@@ -11,10 +11,11 @@ import (
 )
 
 type autoReviewerPolicySettings struct {
-	SubmitterCanVote bool     `json:"creatorVoteCounts"`
-	AutoReviewerIds  []string `json:"requiredReviewerIds"`
-	PathFilters      []string `json:"filenamePatterns"`
-	DisplayMessage   string   `json:"message"`
+	SubmitterCanVote     bool     `json:"creatorVoteCounts"`
+	AutoReviewerIds      []string `json:"requiredReviewerIds"`
+	PathFilters          []string `json:"filenamePatterns"`
+	DisplayMessage       string   `json:"message"`
+	MinimumApproverCount int      `json:"minimumApproverCount"`
 }
 
 const (
@@ -22,6 +23,7 @@ const (
 	pathFilters            = "path_filters"
 	displayMessage         = "message"
 	schemaSubmitterCanVote = "submitter_can_vote"
+	minimumApproverCount   = "minimum_number_of_reviewers"
 )
 
 // ResourceBranchPolicyAutoReviewers schema and implementation for automatic code reviewer policy resource
@@ -59,6 +61,12 @@ func ResourceBranchPolicyAutoReviewers() *schema.Resource {
 		Default:  false,
 		Optional: true,
 	}
+	settingsSchema[minimumApproverCount] = &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Default:      1,
+		ValidateFunc: validation.IntAtLeast(1),
+	}
 
 	return resource
 }
@@ -86,6 +94,7 @@ func autoReviewersFlattenFunc(d *schema.ResourceData, policyConfig *policy.Polic
 	settings[autoReviewerIds] = policySettings.AutoReviewerIds
 	settings[pathFilters] = policySettings.PathFilters
 	settings[displayMessage] = policySettings.DisplayMessage
+	settings[minimumApproverCount] = policySettings.MinimumApproverCount
 	_ = d.Set(SchemaSettings, settingsList)
 	return nil
 }
@@ -102,6 +111,7 @@ func autoReviewersExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.
 	policySettings := policyConfig.Settings.(map[string]interface{})
 	policySettings["creatorVoteCounts"] = settings[schemaSubmitterCanVote].(bool)
 	policySettings["message"] = settings[displayMessage].(string)
+	policySettings["minimumApproverCount"] = settings[minimumApproverCount].(int)
 
 	if value, ok := settings[autoReviewerIds]; ok {
 		var reviewersID []string

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers_test.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_auto_reviewers_test.go
@@ -1,0 +1,53 @@
+//go:build (all || resource_branchpolicy_auto_reviewers) && !exclude_resource_branchpolicy_auto_reviewers
+// +build all resource_branchpolicy_auto_reviewers
+// +build !exclude_resource_branchpolicy_auto_reviewers
+
+package branch
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/policy"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// verifies that the flatten/expand round trip path produces repeatable results
+func TestBranchPolicyAutoReviewers_ExpandFlatten_Roundtrip(t *testing.T) {
+	var projectID = uuid.New().String()
+	var randomUUID = uuid.New()
+	var testPolicy = &policy.PolicyConfiguration{
+		Id:         converter.Int(1),
+		IsEnabled:  converter.Bool(true),
+		IsBlocking: converter.Bool(true),
+		Type: &policy.PolicyTypeRef{
+			Id: &randomUUID,
+		},
+		Settings: map[string]interface{}{
+			"scope": []map[string]interface{}{
+				{
+					"repositoryId": "test-repo-id",
+					"refName":      "test-ref-name",
+					"matchKind":    "test-match-kind",
+				},
+			},
+			"creatorVoteCounts":    false,
+			"filenamePatterns":     []string{"*"},
+			"requiredReviewerIds":  []string{"some-group"},
+			"minimumApproverCount": 1,
+			"message":              "",
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceBranchPolicyAutoReviewers().Schema, nil)
+	err := autoReviewersFlattenFunc(resourceData, testPolicy, &projectID)
+	require.Nil(t, err)
+	expandedPolicy, expandedProjectID, err := autoReviewersExpandFunc(resourceData, randomUUID)
+	require.Nil(t, err)
+
+	require.Equal(t, testPolicy, expandedPolicy)
+	require.Equal(t, projectID, *expandedProjectID)
+}

--- a/website/docs/r/branch_policy_auto_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_auto_reviewers.html.markdown
@@ -65,9 +65,13 @@ The following arguments are supported:
 - `path_filters` - (Optional) Filter path(s) on which the policy is applied. Supports absolute paths, wildcards and multiple paths. Example: /WebApp/Models/Data.cs, /WebApp/* or *.cs,/WebApp/Models/Data.cs;ClientApp/Models/Data.cs.
 - `submitter_can_vote` - (Optional) Controls whether or not the submitter's vote counts. Defaults to `false`.
 - `message` - (Optional) Activity feed message, Message will appear in the activity feed of pull requests with automatically added reviewers.
+- `minimum_number_of_reviewers` - (Optional) Minimum number of required reviewers. Defaults to `1`.
+
+-> **Note** Has to be greater than `0`. Can only be greater than `1` when attribute `auto_reviewer_ids` contains exactly one group! Only has an effect when attribute `blocking` is set to `true`.
+
 - `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
 
-  `scope` block supports the following:
+A `settings` `scope` block supports the following:
 
 - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
 - `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #667

resolves #667

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

for me locally
- `fmtcheck` fails for quite some files not connected to this PR
- unit tests from file `azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go` fail with `panic: interface conversion: interface {} is nil, not map[string]interface {}`
- `website-lint` fails for some of the html.markdown files with the same error: wanting a line break at line 4 after `description: |-`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I don't think we can handle the special case mentioned in the issue (that you can only set the `minimum_number_of_reviewers` greater than 1 when only using one group) during `terraform plan` (because we do not know whether the id is a user or a group).

The error will occur during `terraform apply` and says: `Error: Error updating policy in Azure DevOps: TF402457: The settings for this policy are not correctly formatted. Error: The number of required approvals available for single groups only.`
 which seems good.

For that I added a note in the documentation.
