### PR TITLE
Bug fix - `azuredevops_git_repository_file ` Recreate file if deleted

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -179,7 +179,7 @@ func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error 
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
-			return err
+			return nil
 		}
 		return fmt.Errorf("Query repository item failed, repositoryID: %s, branch: %s, file: %s . Error:  %+v", repoId, branch, file, err)
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #677 

AccTest:
```log
=== RUN   TestAccGitRepoFile_CreateAndUpdate
--- PASS: TestAccGitRepoFile_CreateAndUpdate (48.75s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        54.678s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->