### PR TITLE
feat: allow environment specification in AzureRM service endpoint

### DIFF
--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -91,13 +91,13 @@ resource "azuredevops_serviceendpoint_azurerm" "example" {
 The following arguments are supported:
 
 - `project_id` - (Required) The ID of the project.
-- `service_endpoint_name` - (Required) The Service Endpoint name.
-- `azurerm_spn_tenantid` - (Required) The tenant id if the service principal.
-- `azurerm_management_group_id` - (Optional) The management group Id of the Azure targets.
-- `azurerm_management_group_name` - (Optional) The management group Name of the targets.
-- `azurerm_subscription_id` - (Optional) The subscription Id of the Azure targets.
-- `azurerm_subscription_name` - (Optional) The subscription Name of the targets.
-- `environment` - (Optional) cloud environment to use, can be `AzureCloud` (which is default) or `AzureChinaCloud`.
+- `service_endpoint_name` - (Required) The Service Endpoint Name.
+- `azurerm_spn_tenantid` - (Required) The Tenant ID if the service principal.
+- `azurerm_management_group_id` - (Optional) The Management group ID of the Azure targets.
+- `azurerm_management_group_name` - (Optional) The Management group Name of the targets.
+- `azurerm_subscription_id` - (Optional) The Subscription ID of the Azure targets.
+- `azurerm_subscription_name` - (Optional) The Subscription Name of the targets.
+- `environment` - (Optional) The Cloud Environment to use. Defaults to `AzureCloud`. Possible values are `AzureCloud`, `AzureChinaCloud`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** One of either `Subscription` scoped i.e. `azurerm_subscription_id`, `azurerm_subscription_name` or `ManagementGroup` scoped i.e. `azurerm_management_group_id`, `azurerm_management_group_name` values must be specified.
 

--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -97,6 +97,7 @@ The following arguments are supported:
 - `azurerm_management_group_name` - (Optional) The management group Name of the targets.
 - `azurerm_subscription_id` - (Optional) The subscription Id of the Azure targets.
 - `azurerm_subscription_name` - (Optional) The subscription Name of the targets.
+- `environment` - (Optional) cloud environment to use, can be `AzureCloud` (which is default) or `AzureChinaCloud`.
 
 ~> **NOTE:** One of either `Subscription` scoped i.e. `azurerm_subscription_id`, `azurerm_subscription_name` or `ManagementGroup` scoped i.e. `azurerm_management_group_id`, `azurerm_management_group_name` values must be specified.
 


### PR DESCRIPTION
In order to allow creation of AzureRM service endpoints in Azure China cloud, environment and different endpoint URL must be used.

Refs: microsoft/terraform-provider-azuredevops#27

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->