### PR TITLE
feat: resource_azuredevops_git_repository_branch

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -1,0 +1,225 @@
+//go:build (all || core || resource_git_repository_branch) && !exclude_resource_git_repository_branch
+// +build all core resource_git_repository_branch
+// +build !exclude_resource_git_repository_branch
+
+package acceptancetests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// TestAccGitRepoBranch_CreateUpdateDelete verifies that a branch can
+// be added to a repository and that it can be replaced
+func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
+	var gotBranch git.GitBranchStats
+	var gotBranch2 git.GitBranchStats
+	var gotBranch3 git.GitBranchStats
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+	branchName := testutils.GenerateResourceName()
+	branchNameChanged := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclGitRepoBranches(projectName, gitRepoName, "Uninitialized", branchName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGitRepoBranchExists("foo_orphan", &gotBranch),
+					testAccGitRepoBranchExists("foo_from_ref", &gotBranch2),
+					testAccGitRepoBranchExists("foo_from_sha", &gotBranch3),
+					testAccGitRepoBranchAttributes("foo_orphan", &gotBranch, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch-%s", branchName),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref:        "",
+						source_sha:        false,
+						is_default_branch: true,
+						ref:               fmt.Sprintf("refs/heads/testbranch-%s", branchName),
+						sha:               true,
+					}),
+					testAccGitRepoBranchAttributes("foo_from_ref", &gotBranch2, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch2-%s", branchName),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref: fmt.Sprintf("refs/heads/testbranch-%s", branchName),
+						source_sha: true,
+						ref:        fmt.Sprintf("refs/heads/testbranch2-%s", branchName),
+						sha:        true,
+					}),
+					testAccGitRepoBranchAttributes("foo_from_sha", &gotBranch3, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch3-%s", branchName),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref: "",
+						source_sha: true,
+						ref:        fmt.Sprintf("refs/heads/testbranch3-%s", branchName),
+						sha:        true,
+					}),
+				),
+			},
+			// Test import branch created from ref
+			{
+				ResourceName:            "azuredevops_git_repository_branch.foo_from_ref",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_ref", "source_sha"},
+			},
+			// Test replace/update branch when name changes
+			{
+				Config: hclGitRepoBranches(projectName, gitRepoName, "Uninitialized", branchNameChanged),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGitRepoBranchExists("foo_orphan", &gotBranch),
+					testAccGitRepoBranchExists("foo_from_ref", &gotBranch2),
+					testAccGitRepoBranchExists("foo_from_sha", &gotBranch3),
+					testAccGitRepoBranchAttributes("foo_orphan", &gotBranch, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch-%s", branchNameChanged),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref:        "",
+						source_sha:        false,
+						is_default_branch: true,
+						ref:               fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged),
+						sha:               true,
+					}),
+					testAccGitRepoBranchAttributes("foo_from_ref", &gotBranch2, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch2-%s", branchNameChanged),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref: fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged),
+						source_sha: true,
+						ref:        fmt.Sprintf("refs/heads/testbranch2-%s", branchNameChanged),
+						sha:        true,
+					}),
+					testAccGitRepoBranchAttributes("foo_from_sha", &gotBranch3, &testAccGitRepoBranchExpectedAttributes{
+						Name: fmt.Sprintf("testbranch3-%s", branchNameChanged),
+					}, &testAccGitRepoBranchExpectedStateAttrs{
+						source_ref: "",
+						source_sha: true,
+						ref:        fmt.Sprintf("refs/heads/testbranch3-%s", branchNameChanged),
+						sha:        true,
+					}),
+				),
+			},
+			// Test invalid ref
+			{
+				Config: fmt.Sprintf(`
+%s
+
+resource "azuredevops_git_repository_branch" "foo_nonexistent_tag" {
+	repository_id = azuredevops_git_repository.repository.id
+    name = "testbranch2-non-existent-tag"
+	source_ref = "refs/tags/non-existent"
+}
+`, hclGitRepoBranches(projectName, gitRepoName, "Clean", branchNameChanged)),
+				ExpectError: regexp.MustCompile(`No refs found that match source_ref "refs/tags/non-existent"`),
+			},
+		},
+	},
+	)
+}
+
+func testAccGitRepoBranchAttributes(node string, branch *git.GitBranchStats, want *testAccGitRepoBranchExpectedAttributes, wantState *testAccGitRepoBranchExpectedStateAttrs) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *branch.Name != want.Name {
+			return fmt.Errorf("Error got name %s, want %s", *branch.Name, want.Name)
+		}
+
+		rs, ok := s.RootModule().Resources[fmt.Sprintf("azuredevops_git_repository_branch.%s", node)]
+		if !ok {
+			return fmt.Errorf("Not found: %s", node)
+		}
+
+		sourceRef := rs.Primary.Attributes["source_ref"]
+		if wantState.source_ref != sourceRef {
+			return fmt.Errorf("azuredevops_git_repository_branch.%s.source_ref = %s, want %s", node, sourceRef, wantState.source_ref)
+		}
+
+		sourceSha := rs.Primary.Attributes["source_sha"]
+		if wantState.source_sha && sourceSha == "" {
+			return fmt.Errorf("azuredevops_git_repository_branch.%s.source_sha is not set", node)
+		}
+
+		isDefaultBranch := rs.Primary.Attributes["is_default_branch"]
+		if wantState.is_default_branch && isDefaultBranch != "true" {
+			return fmt.Errorf("azuredevops_git_repository_branch.%s.is_default_branch = %s, want %v", node, isDefaultBranch, wantState.is_default_branch)
+		}
+
+		ref := rs.Primary.Attributes["ref"]
+		if wantState.ref != ref {
+			return fmt.Errorf("azuredevops_git_repository_branch.%s.ref = %s, want %s", node, ref, wantState.ref)
+		}
+
+		sha := rs.Primary.Attributes["sha"]
+		if wantState.sha && sha == "" {
+			return fmt.Errorf("azuredevops_git_repository_branch.%s.ref = %s, want %s", node, ref, wantState.ref)
+		}
+
+		return nil
+	}
+}
+
+func testAccGitRepoBranchExists(node string, gotBranch *git.GitBranchStats) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[fmt.Sprintf("azuredevops_git_repository_branch.%s", node)]
+		if !ok {
+			return fmt.Errorf("Not found: %s", node)
+		}
+
+		repoID, branchName, err := tfhelper.ParseGitRepoBranchID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error in parsing branch ID: %w", err)
+		}
+
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+		branch, err := clients.GitReposClient.GetBranch(clients.Ctx, git.GetBranchArgs{
+			RepositoryId: &repoID,
+			Name:         &branchName,
+		})
+		if err != nil {
+			return err
+		}
+		*gotBranch = *branch
+
+		return nil
+	}
+}
+
+func hclGitRepoBranches(projectName, gitRepoName, initType, branchName string) string {
+	gitRepoResource := testutils.HclGitRepoResource(projectName, gitRepoName, initType)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuredevops_git_repository_branch" "foo_orphan" {
+	repository_id = azuredevops_git_repository.repository.id
+	name = "testbranch-%[2]s"
+}
+resource "azuredevops_git_repository_branch" "foo_from_ref" {
+	repository_id = azuredevops_git_repository.repository.id
+    name = "testbranch2-%[2]s"
+	source_ref = azuredevops_git_repository_branch.foo_orphan.ref
+}
+resource "azuredevops_git_repository_branch" "foo_from_sha" {
+	repository_id = azuredevops_git_repository.repository.id
+    name = "testbranch3-%[2]s"
+	source_sha = azuredevops_git_repository_branch.foo_orphan.sha
+}
+  `, gitRepoResource, branchName)
+}
+
+type testAccGitRepoBranchExpectedStateAttrs struct {
+	source_ref        string
+	source_sha        bool
+	is_default_branch bool
+	ref               string
+	sha               bool
+}
+
+type testAccGitRepoBranchExpectedAttributes struct {
+	Name string
+}

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -30,14 +30,14 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// test-branch
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchName)),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref", "master"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref_branch", "master"),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchName)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "branch_head"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "last_commit_id"),
 					// test-branch2
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchName)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "commit_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "ref_commit_id"),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchName)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "branch_head"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "last_commit_id"),
 				),
 			},
 			// Test import branch created from ref, ignore fields set only on create
@@ -45,7 +45,7 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 				ResourceName:            "azuredevops_git_repository_branch.from_master",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ref", "tag", "commit_id"},
+				ImportStateVerifyIgnore: []string{"ref_branch", "ref_tag", "ref_commit_id"},
 			},
 			// Test replace/update branch when name changes
 			{
@@ -53,14 +53,14 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// test-branch
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchNameChanged)),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref", "master"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref_branch", "master"),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "branch_head"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "last_commit_id"),
 					// test-branch2
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchNameChanged)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "commit_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "ref_commit_id"),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchNameChanged)),
-					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "branch_head"),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "last_commit_id"),
 				),
 			},
 			// Test invalid ref
@@ -71,7 +71,7 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 resource "azuredevops_git_repository_branch" "from_nonexistent_tag" {
 	repository_id = azuredevops_git_repository.repository.id
     name = "testbranch-non-existent-tag"
-	tag = "0.0.0"
+	ref_tag = "0.0.0"
 }
 `, hclGitRepoBranches(projectName, gitRepoName, "Clean", branchNameChanged)),
 				ExpectError: regexp.MustCompile(`No refs found that match ref "refs/tags/0.0.0"`),
@@ -89,12 +89,12 @@ func hclGitRepoBranches(projectName, gitRepoName, initType, branchName string) s
 resource "azuredevops_git_repository_branch" "from_master" {
 	repository_id = azuredevops_git_repository.repository.id
 	name = "testbranch-%[2]s"
-    ref = "master"
+    ref_branch = "master"
 }
 resource "azuredevops_git_repository_branch" "from_commit_id" {
 	repository_id = azuredevops_git_repository.repository.id
     name = "testbranch2-%[2]s"
-	commit_id = azuredevops_git_repository_branch.from_master.branch_head
+	ref_commit_id = azuredevops_git_repository_branch.from_master.last_commit_id
 }
   `, gitRepoResource, branchName)
 }

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -31,12 +31,10 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 					// test-branch
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchName)),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref_branch", "master"),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchName)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "last_commit_id"),
 					// test-branch2
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchName)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "ref_commit_id"),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchName)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "last_commit_id"),
 				),
 			},
@@ -54,12 +52,10 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 					// test-branch
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchNameChanged)),
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref_branch", "master"),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "last_commit_id"),
 					// test-branch2
 					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchNameChanged)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "ref_commit_id"),
-					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchNameChanged)),
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "last_commit_id"),
 				),
 			},

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -10,19 +10,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
 
 // TestAccGitRepoBranch_CreateUpdateDelete verifies that a branch can
 // be added to a repository and that it can be replaced
 func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
-	var gotBranch git.GitBranchStats
-	var gotBranch2 git.GitBranchStats
-	var gotBranch3 git.GitBranchStats
 	projectName := testutils.GenerateResourceName()
 	gitRepoName := testutils.GenerateResourceName()
 	branchName := testutils.GenerateResourceName()
@@ -33,77 +26,41 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: hclGitRepoBranches(projectName, gitRepoName, "Uninitialized", branchName),
+				Config: hclGitRepoBranches(projectName, gitRepoName, "Clean", branchName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGitRepoBranchExists("foo_orphan", &gotBranch),
-					testAccGitRepoBranchExists("foo_from_ref", &gotBranch2),
-					testAccGitRepoBranchExists("foo_from_sha", &gotBranch3),
-					testAccGitRepoBranchAttributes("foo_orphan", &gotBranch, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch-%s", branchName),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref:        "",
-						source_sha:        false,
-						is_default_branch: true,
-						ref:               fmt.Sprintf("refs/heads/testbranch-%s", branchName),
-						sha:               true,
-					}),
-					testAccGitRepoBranchAttributes("foo_from_ref", &gotBranch2, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch2-%s", branchName),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref: fmt.Sprintf("refs/heads/testbranch-%s", branchName),
-						source_sha: true,
-						ref:        fmt.Sprintf("refs/heads/testbranch2-%s", branchName),
-						sha:        true,
-					}),
-					testAccGitRepoBranchAttributes("foo_from_sha", &gotBranch3, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch3-%s", branchName),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref: "",
-						source_sha: true,
-						ref:        fmt.Sprintf("refs/heads/testbranch3-%s", branchName),
-						sha:        true,
-					}),
+					// test-branch
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchName)),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref", "master"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchName)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "branch_head"),
+					// test-branch2
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchName)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "commit_id"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchName)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "branch_head"),
 				),
 			},
-			// Test import branch created from ref
+			// Test import branch created from ref, ignore fields set only on create
 			{
-				ResourceName:            "azuredevops_git_repository_branch.foo_from_ref",
+				ResourceName:            "azuredevops_git_repository_branch.from_master",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"source_ref", "source_sha"},
+				ImportStateVerifyIgnore: []string{"ref", "tag", "commit_id"},
 			},
 			// Test replace/update branch when name changes
 			{
-				Config: hclGitRepoBranches(projectName, gitRepoName, "Uninitialized", branchNameChanged),
+				Config: hclGitRepoBranches(projectName, gitRepoName, "Clean", branchNameChanged),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGitRepoBranchExists("foo_orphan", &gotBranch),
-					testAccGitRepoBranchExists("foo_from_ref", &gotBranch2),
-					testAccGitRepoBranchExists("foo_from_sha", &gotBranch3),
-					testAccGitRepoBranchAttributes("foo_orphan", &gotBranch, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch-%s", branchNameChanged),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref:        "",
-						source_sha:        false,
-						is_default_branch: true,
-						ref:               fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged),
-						sha:               true,
-					}),
-					testAccGitRepoBranchAttributes("foo_from_ref", &gotBranch2, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch2-%s", branchNameChanged),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref: fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged),
-						source_sha: true,
-						ref:        fmt.Sprintf("refs/heads/testbranch2-%s", branchNameChanged),
-						sha:        true,
-					}),
-					testAccGitRepoBranchAttributes("foo_from_sha", &gotBranch3, &testAccGitRepoBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch3-%s", branchNameChanged),
-					}, &testAccGitRepoBranchExpectedStateAttrs{
-						source_ref: "",
-						source_sha: true,
-						ref:        fmt.Sprintf("refs/heads/testbranch3-%s", branchNameChanged),
-						sha:        true,
-					}),
+					// test-branch
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "name", fmt.Sprintf("testbranch-%s", branchNameChanged)),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "ref", "master"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_master", "branch_reference", fmt.Sprintf("refs/heads/testbranch-%s", branchNameChanged)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_master", "branch_head"),
+					// test-branch2
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "name", fmt.Sprintf("testbranch2-%s", branchNameChanged)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "commit_id"),
+					resource.TestCheckResourceAttr("azuredevops_git_repository_branch.from_commit_id", "branch_reference", fmt.Sprintf("refs/heads/testbranch2-%s", branchNameChanged)),
+					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "branch_head"),
 				),
 			},
 			// Test invalid ref
@@ -111,83 +68,17 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 				Config: fmt.Sprintf(`
 %s
 
-resource "azuredevops_git_repository_branch" "foo_nonexistent_tag" {
+resource "azuredevops_git_repository_branch" "from_nonexistent_tag" {
 	repository_id = azuredevops_git_repository.repository.id
-    name = "testbranch2-non-existent-tag"
-	source_ref = "refs/tags/non-existent"
+    name = "testbranch-non-existent-tag"
+	tag = "0.0.0"
 }
 `, hclGitRepoBranches(projectName, gitRepoName, "Clean", branchNameChanged)),
-				ExpectError: regexp.MustCompile(`No refs found that match source_ref "refs/tags/non-existent"`),
+				ExpectError: regexp.MustCompile(`No refs found that match ref "refs/tags/0.0.0"`),
 			},
 		},
 	},
 	)
-}
-
-func testAccGitRepoBranchAttributes(node string, branch *git.GitBranchStats, want *testAccGitRepoBranchExpectedAttributes, wantState *testAccGitRepoBranchExpectedStateAttrs) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *branch.Name != want.Name {
-			return fmt.Errorf("Error got name %s, want %s", *branch.Name, want.Name)
-		}
-
-		rs, ok := s.RootModule().Resources[fmt.Sprintf("azuredevops_git_repository_branch.%s", node)]
-		if !ok {
-			return fmt.Errorf("Not found: %s", node)
-		}
-
-		sourceRef := rs.Primary.Attributes["source_ref"]
-		if wantState.source_ref != sourceRef {
-			return fmt.Errorf("azuredevops_git_repository_branch.%s.source_ref = %s, want %s", node, sourceRef, wantState.source_ref)
-		}
-
-		sourceSha := rs.Primary.Attributes["source_sha"]
-		if wantState.source_sha && sourceSha == "" {
-			return fmt.Errorf("azuredevops_git_repository_branch.%s.source_sha is not set", node)
-		}
-
-		isDefaultBranch := rs.Primary.Attributes["is_default_branch"]
-		if wantState.is_default_branch && isDefaultBranch != "true" {
-			return fmt.Errorf("azuredevops_git_repository_branch.%s.is_default_branch = %s, want %v", node, isDefaultBranch, wantState.is_default_branch)
-		}
-
-		ref := rs.Primary.Attributes["ref"]
-		if wantState.ref != ref {
-			return fmt.Errorf("azuredevops_git_repository_branch.%s.ref = %s, want %s", node, ref, wantState.ref)
-		}
-
-		sha := rs.Primary.Attributes["sha"]
-		if wantState.sha && sha == "" {
-			return fmt.Errorf("azuredevops_git_repository_branch.%s.ref = %s, want %s", node, ref, wantState.ref)
-		}
-
-		return nil
-	}
-}
-
-func testAccGitRepoBranchExists(node string, gotBranch *git.GitBranchStats) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[fmt.Sprintf("azuredevops_git_repository_branch.%s", node)]
-		if !ok {
-			return fmt.Errorf("Not found: %s", node)
-		}
-
-		repoID, branchName, err := tfhelper.ParseGitRepoBranchID(rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("Error in parsing branch ID: %w", err)
-		}
-
-		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
-		branch, err := clients.GitReposClient.GetBranch(clients.Ctx, git.GetBranchArgs{
-			RepositoryId: &repoID,
-			Name:         &branchName,
-		})
-		if err != nil {
-			return err
-		}
-		*gotBranch = *branch
-
-		return nil
-	}
 }
 
 func hclGitRepoBranches(projectName, gitRepoName, initType, branchName string) string {
@@ -195,31 +86,15 @@ func hclGitRepoBranches(projectName, gitRepoName, initType, branchName string) s
 	return fmt.Sprintf(`
 %[1]s
 
-resource "azuredevops_git_repository_branch" "foo_orphan" {
+resource "azuredevops_git_repository_branch" "from_master" {
 	repository_id = azuredevops_git_repository.repository.id
 	name = "testbranch-%[2]s"
+    ref = "master"
 }
-resource "azuredevops_git_repository_branch" "foo_from_ref" {
+resource "azuredevops_git_repository_branch" "from_commit_id" {
 	repository_id = azuredevops_git_repository.repository.id
     name = "testbranch2-%[2]s"
-	source_ref = azuredevops_git_repository_branch.foo_orphan.ref
-}
-resource "azuredevops_git_repository_branch" "foo_from_sha" {
-	repository_id = azuredevops_git_repository.repository.id
-    name = "testbranch3-%[2]s"
-	source_sha = azuredevops_git_repository_branch.foo_orphan.sha
+	commit_id = azuredevops_git_repository_branch.from_master.branch_head
 }
   `, gitRepoResource, branchName)
-}
-
-type testAccGitRepoBranchExpectedStateAttrs struct {
-	source_ref        string
-	source_sha        bool
-	is_default_branch bool
-	ref               string
-	sha               bool
-}
-
-type testAccGitRepoBranchExpectedAttributes struct {
-	Name string
 }

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -38,13 +38,6 @@ func TestAccGitRepoBranch_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet("azuredevops_git_repository_branch.from_commit_id", "last_commit_id"),
 				),
 			},
-			// Test import branch created from ref, ignore fields set only on create
-			{
-				ResourceName:            "azuredevops_git_repository_branch.from_master",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ref_branch", "ref_tag", "ref_commit_id"},
-			},
 			// Test replace/update branch when name changes
 			{
 				Config: hclGitRepoBranches(projectName, gitRepoName, "Clean", branchNameChanged),

--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -8,9 +8,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
-
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -26,9 +26,6 @@ func ResourceGitRepositoryBranch() *schema.Resource {
 		CreateContext: resourceGitRepositoryBranchCreate,
 		ReadContext:   resourceGitRepositoryBranchRead,
 		DeleteContext: resourceGitRepositoryBranchDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceGitRepositoryBranchImport,
-		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -213,14 +210,6 @@ func resourceGitRepositoryBranchDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	return nil
-}
-
-func resourceGitRepositoryBranchImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	_, _, err := tfhelper.ParseGitRepoBranchID(d.Id())
-	if err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }
 
 func updateRefs(clients *client.AggregatedClient, args git.UpdateRefsArgs) (*[]git.GitRefUpdateResult, error) {

--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -1,0 +1,285 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// ResourceGitRepositoryBranch schema to manage the lifecycle of a git repository branch
+func ResourceGitRepositoryBranch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGitRepositoryBranchCreate,
+		ReadContext:   resourceGitRepositoryBranchRead,
+		DeleteContext: resourceGitRepositoryBranchDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGitRepositoryBranchImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Sensitive:    false,
+			},
+			"repository_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"source_ref": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"source_sha": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"is_default_branch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ref": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGitRepositoryBranchCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	repoId := d.Get("repository_id").(string)
+	branchName := d.Get("name").(string)
+	branchRef := withRefsHeadsPrefix(branchName)
+	sourceRef, hasSourceRef := d.GetOk("source_ref")
+	_, hasSourceSha := d.GetOk("source_sha")
+
+	// Initialise new orphan branch
+	if !hasSourceRef && !hasSourceSha {
+		args := branchCreatePushArgs(branchRef, repoId)
+
+		_, err := clients.GitReposClient.CreatePush(clients.Ctx, args)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error initialising new branch: %w", err))
+		}
+
+		d.SetId(fmt.Sprintf("%s:%s", repoId, branchName))
+
+		return resourceGitRepositoryBranchRead(ctx, d, m)
+	}
+
+	// Get sha from source ref which can be a branch or a tag
+	if !hasSourceSha {
+		// Azuredevops GetRefs api returns refs whose "prefix" matches Filter sorted from shortest to longest
+		// Top1 should return best match
+		sourceRefName := sourceRef.(string)
+		filter := strings.TrimPrefix(sourceRefName, "refs/")
+
+		gotRefs, err := clients.GitReposClient.GetRefs(clients.Ctx, git.GetRefsArgs{
+			RepositoryId: converter.String(repoId),
+			Filter:       converter.String(filter),
+			Top:          converter.Int(1),
+			PeelTags:     converter.Bool(true),
+		})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error getting refs matching %q: %w", filter, err))
+		}
+
+		if len(gotRefs.Value) == 0 {
+			return diag.FromErr(fmt.Errorf("No refs found that match source_ref %q.", sourceRefName))
+		}
+
+		gotRef := gotRefs.Value[0]
+		if gotRef.Name == nil {
+			return diag.FromErr(fmt.Errorf("Got unexpected GetRefs response, a ref without a name was returned."))
+		}
+
+		// Check for complete match. Sometimes refs exist that match prefix with Ref, but do not match completely.
+		if *gotRef.Name != sourceRefName {
+			return diag.FromErr(fmt.Errorf("Ref %q not found, closest match is %q.", filter, *gotRef.Name))
+		}
+
+		// Check if ref was a tag and we need to use PeeledObjectId to get the commit id of the tag
+		var refObjectIdSha *string
+		if gotRef.PeeledObjectId != nil {
+			refObjectIdSha = gotRef.PeeledObjectId
+		} else if gotRef.ObjectId != nil {
+			refObjectIdSha = gotRef.ObjectId
+		} else {
+			return diag.FromErr(fmt.Errorf("GetRefs response doesn't have a valid commit id."))
+		}
+		d.Set("source_sha", *refObjectIdSha)
+	}
+	newObjectId := d.Get("source_sha").(string)
+
+	_, err := updateRefs(clients, git.UpdateRefsArgs{
+		RefUpdates: &[]git.GitRefUpdate{{
+			Name:        &branchRef,
+			NewObjectId: &newObjectId,
+			OldObjectId: converter.String("0000000000000000000000000000000000000000"),
+		}},
+		RepositoryId: converter.String(repoId),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error creating branch %q: %w", branchName, err))
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", repoId, branchName))
+
+	return resourceGitRepositoryBranchRead(ctx, d, m)
+}
+
+func resourceGitRepositoryBranchRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	repoId, name, err := tfhelper.ParseGitRepoBranchID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	branchStats, err := clients.GitReposClient.GetBranch(clients.Ctx, git.GetBranchArgs{
+		RepositoryId: converter.String(repoId),
+		Name:         converter.String(name),
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("Error reading branch %q: %w", name, err))
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", repoId, name))
+	d.Set("name", name)
+	d.Set("repository_id", repoId)
+	d.Set("is_default_branch", *branchStats.IsBaseVersion)
+	d.Set("ref", converter.String(withRefsHeadsPrefix(name)))
+	d.Set("sha", *branchStats.Commit.CommitId)
+
+	return nil
+}
+
+func resourceGitRepositoryBranchDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	repoId, name, err := tfhelper.ParseGitRepoBranchID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	branchStats, err := clients.GitReposClient.GetBranch(clients.Ctx, git.GetBranchArgs{
+		RepositoryId: converter.String(repoId),
+		Name:         converter.String(name),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error getting latest commit of %q: %w", name, err))
+	}
+
+	_, err = updateRefs(clients, git.UpdateRefsArgs{
+		RefUpdates: &[]git.GitRefUpdate{{
+			Name:        converter.String(withRefsHeadsPrefix(name)),
+			OldObjectId: branchStats.Commit.CommitId,
+			NewObjectId: converter.String("0000000000000000000000000000000000000000"),
+		}},
+		RepositoryId: converter.String(repoId),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error deleting branch %q: %w", name, err))
+	}
+
+	return nil
+}
+
+func resourceGitRepositoryBranchImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	_, branchName, err := tfhelper.ParseGitRepoBranchID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	diags := resourceGitRepositoryBranchRead(ctx, d, m)
+	if diags.HasError() {
+		return nil, fmt.Errorf(diags[0].Summary)
+	}
+
+	if d.Id() == "" {
+		return nil, fmt.Errorf("Branch %q not found", branchName)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func branchCreatePushArgs(name, repoId string) git.CreatePushArgs {
+	args := git.CreatePushArgs{
+		RepositoryId: converter.String(repoId),
+		Push: &git.GitPush{
+			RefUpdates: &[]git.GitRefUpdate{
+				{
+					Name:        converter.String(name),
+					OldObjectId: converter.String("0000000000000000000000000000000000000000"),
+				},
+			},
+			Commits: &[]git.GitCommitRef{
+				{
+					Comment: converter.String("Initial commit."),
+					Changes: &[]interface{}{
+						git.Change{
+							ChangeType: &git.VersionControlChangeTypeValues.Add,
+							Item: git.GitItem{
+								Path: converter.String("/readme.md"),
+							},
+							NewContent: &git.ItemContent{
+								ContentType: &git.ItemContentTypeValues.RawText,
+								Content:     converter.String("Branch initialized with azuredevops terraform provider"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return args
+}
+
+func updateRefs(clients *client.AggregatedClient, args git.UpdateRefsArgs) (*[]git.GitRefUpdateResult, error) {
+	updateRefResults, err := clients.GitReposClient.UpdateRefs(clients.Ctx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, refUpdate := range *updateRefResults {
+		if !*refUpdate.Success {
+			return nil, fmt.Errorf("Error got invalid GitRefUpdate.UpdateStatus: %s", *refUpdate.UpdateStatus)
+		}
+	}
+
+	return updateRefResults, nil
+}
+
+func withRefsHeadsPrefix(branchName string) string {
+	prefix := "refs/heads/"
+	if strings.HasPrefix(branchName, prefix) {
+		return branchName
+	}
+	return prefix + branchName
+}

--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -60,7 +60,6 @@ func ResourceGitRepositoryBranch() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				Computed:      true,
 				ValidateFunc:  validation.StringIsNotEmpty,
 				ConflictsWith: []string{"ref_branch", "ref_tag"},
 			},
@@ -128,7 +127,6 @@ func resourceGitRepositoryBranchCreate(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf("GetRefs response doesn't have a valid commit id."))
 		}
 	}
-
 
 	_, err := updateRefs(clients, git.UpdateRefsArgs{
 		RefUpdates: &[]git.GitRefUpdate{{

--- a/azuredevops/internal/service/git/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch_test.go
@@ -1,0 +1,293 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+func TestGitRepositoryBranch_Create(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		d   *schema.ResourceData
+		m   interface{}
+	}
+	tests := []struct {
+		name string
+		args func(g *azdosdkmocks.MockGitClient) args
+		want diag.Diagnostics
+	}{
+		{
+			"When source_ref is not given, create push does not swallow error",
+			func(g *azdosdkmocks.MockGitClient) args {
+				clients := &client.AggregatedClient{
+					GitReposClient: g,
+					Ctx:            context.Background(),
+				}
+				expectedArgs := branchCreatePushArgs(withRefsHeadsPrefix("a-branch"), "a-repo")
+				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
+				d.Set("name", "a-branch")
+				d.Set("repository_id", "a-repo")
+
+				g.EXPECT().
+					CreatePush(clients.Ctx, expectedArgs).
+					Return(nil, fmt.Errorf("an-error"))
+				return args{
+					context.Background(),
+					d,
+					clients,
+				}
+			},
+			diag.FromErr(fmt.Errorf("Error initialising new branch: an-error")),
+		},
+		{
+			"When source_ref is given, refs update does not swallow error",
+			func(g *azdosdkmocks.MockGitClient) args {
+				clients := &client.AggregatedClient{
+					GitReposClient: g,
+					Ctx:            context.Background(),
+				}
+				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
+				source_ref := "refs/heads/another-branch"
+				commit := "a-commit"
+				branchName := "a-branch"
+				repoId := "a-repo"
+				d.Set("source_ref", source_ref)
+				d.Set("name", branchName)
+				d.Set("repository_id", repoId)
+
+				g.EXPECT().
+					GetRefs(clients.Ctx, git.GetRefsArgs{
+						RepositoryId: &repoId,
+						Filter:       converter.String(strings.TrimPrefix(source_ref, "refs/")),
+						Top:          converter.Int(1),
+						PeelTags:     converter.Bool(true),
+					}).
+					Return(&git.GetRefsResponseValue{
+						Value: []git.GitRef{{
+							Name:     &source_ref,
+							ObjectId: &commit,
+						}},
+					}, nil)
+
+				g.EXPECT().
+					UpdateRefs(clients.Ctx, git.UpdateRefsArgs{
+						RefUpdates: &[]git.GitRefUpdate{{
+							Name:        converter.String(withRefsHeadsPrefix("a-branch")),
+							NewObjectId: &commit,
+							OldObjectId: converter.String("0000000000000000000000000000000000000000"),
+						}},
+						RepositoryId: converter.String("a-repo"),
+					}).
+					Return(nil, fmt.Errorf("an-error"))
+				return args{
+					context.Background(),
+					d,
+					clients,
+				}
+			},
+			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": an-error")),
+		},
+		{
+			"When invalid RefUpdate UpdateStatus, throw error",
+			func(g *azdosdkmocks.MockGitClient) args {
+				clients := &client.AggregatedClient{
+					GitReposClient: g,
+					Ctx:            context.Background(),
+				}
+				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
+				source_ref := "refs/heads/another-branch"
+				commit := "a-commit"
+				branchName := "a-branch"
+				repoId := "a-repo"
+				d.Set("source_ref", source_ref)
+				d.Set("name", branchName)
+				d.Set("repository_id", repoId)
+
+				g.EXPECT().
+					GetRefs(clients.Ctx, git.GetRefsArgs{
+						RepositoryId: &repoId,
+						Filter:       converter.String(strings.TrimPrefix(source_ref, "refs/")),
+						Top:          converter.Int(1),
+						PeelTags:     converter.Bool(true),
+					}).
+					Return(&git.GetRefsResponseValue{
+						Value: []git.GitRef{{
+							Name:     &source_ref,
+							ObjectId: &commit,
+						}},
+					}, nil)
+
+				g.EXPECT().
+					UpdateRefs(clients.Ctx, git.UpdateRefsArgs{
+						RefUpdates: &[]git.GitRefUpdate{{
+							Name:        converter.String(withRefsHeadsPrefix("a-branch")),
+							NewObjectId: &commit,
+							OldObjectId: converter.String("0000000000000000000000000000000000000000"),
+						}},
+						RepositoryId: converter.String("a-repo"),
+					}).
+					Return(&[]git.GitRefUpdateResult{{
+						Success:      converter.Bool(false),
+						UpdateStatus: &git.GitRefUpdateStatusValues.InvalidRefName,
+					}}, nil)
+				return args{
+					context.Background(),
+					d,
+					clients,
+				}
+			},
+			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": Error got invalid GitRefUpdate.UpdateStatus: invalidRefName")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			gitClient := azdosdkmocks.NewMockGitClient(ctrl)
+			testArgs := tt.args(gitClient)
+
+			if got := resourceGitRepositoryBranchCreate(testArgs.ctx, testArgs.d, testArgs.m); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resourceGitRepositoryBranchCreate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitRepositoryBranch_Read(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		d   *schema.ResourceData
+		m   interface{}
+	}
+	tests := []struct {
+		name string
+		args func(g *azdosdkmocks.MockGitClient) args
+		want diag.Diagnostics
+	}{
+		{
+			"Read does not swallow error.",
+			func(g *azdosdkmocks.MockGitClient) args {
+				clients := &client.AggregatedClient{
+					GitReposClient: g,
+					Ctx:            context.Background(),
+				}
+
+				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
+				d.Set("ref", "another-branch")
+				d.Set("name", "a-branch")
+				d.Set("repository_id", "a-repo")
+				d.SetId("a-repo:a-branch")
+
+				g.EXPECT().
+					GetBranch(clients.Ctx, git.GetBranchArgs{
+						RepositoryId: converter.String("a-repo"),
+						Name:         converter.String("a-branch"),
+					}).
+					Return(nil, fmt.Errorf("an-error"))
+
+				return args{
+					ctx: context.Background(),
+					d:   d,
+					m:   clients,
+				}
+			},
+			diag.FromErr(fmt.Errorf("Error reading branch \"a-branch\": an-error")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			gitClient := azdosdkmocks.NewMockGitClient(ctrl)
+			testArgs := tt.args(gitClient)
+
+			if got := resourceGitRepositoryBranchRead(testArgs.ctx, testArgs.d, testArgs.m); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resourceGitRepositoryBranchCreate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitRepositoryBranch_Delete(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		d   *schema.ResourceData
+		m   interface{}
+	}
+	tests := []struct {
+		name string
+		args func(g *azdosdkmocks.MockGitClient) args
+		want diag.Diagnostics
+	}{
+		{
+			"Delete based on repositoryId:branchName does not swallow error.",
+			func(g *azdosdkmocks.MockGitClient) args {
+				clients := &client.AggregatedClient{
+					GitReposClient: g,
+					Ctx:            context.Background(),
+				}
+
+				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
+				d.Set("ref", "another-branch")
+				d.Set("name", "a-branch")
+				d.Set("repository_id", "a-repo")
+				d.SetId("a-repo:a-branch")
+
+				g.EXPECT().
+					GetBranch(clients.Ctx, git.GetBranchArgs{
+						RepositoryId: converter.String("a-repo"),
+						Name:         converter.String("a-branch"),
+					}).
+					Return(&git.GitBranchStats{
+						Commit: &git.GitCommitRef{
+							CommitId: converter.String("a-commit"),
+						},
+					}, nil)
+
+				g.EXPECT().
+					UpdateRefs(clients.Ctx, git.UpdateRefsArgs{
+						RefUpdates: &[]git.GitRefUpdate{{
+							Name:        converter.String(withRefsHeadsPrefix("a-branch")),
+							OldObjectId: converter.String("a-commit"),
+							NewObjectId: converter.String("0000000000000000000000000000000000000000"),
+						}},
+						RepositoryId: converter.String("a-repo"),
+					}).
+					Return(nil, fmt.Errorf("an-error"))
+
+				return args{
+					ctx: clients.Ctx,
+					d:   d,
+					m:   clients,
+				}
+			},
+			diag.FromErr(fmt.Errorf("Error deleting branch \"a-branch\": an-error")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			gitClient := azdosdkmocks.NewMockGitClient(ctrl)
+			testArgs := tt.args(gitClient)
+
+			if got := resourceGitRepositoryBranchDelete(testArgs.ctx, testArgs.d, testArgs.m); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resourceGitRepositoryBranchDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/azuredevops/internal/service/git/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch_test.go
@@ -39,7 +39,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 				fakeCommitId := "a-commit"
 				branchName := "a-branch"
 				repoId := "a-repo"
-				d.Set("ref", ref)
+				d.Set("ref_branch", ref)
 				d.Set("name", branchName)
 				d.Set("repository_id", repoId)
 
@@ -76,19 +76,19 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": an-error")),
 		},
 		{
-			"When more than one of commitId, tag, or ref are given, the first one from left to right wins",
+			"When more than one of ref_commit_id, ref_tag, or ref_branch are given, the first one from left to right wins",
 			func(g *azdosdkmocks.MockGitClient) args {
 				clients := &client.AggregatedClient{
 					GitReposClient: g,
 					Ctx:            context.Background(),
 				}
 				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
-				tag := "refs/tag/v1.0.0"
+				tag := "refs/tags/v1.0.0"
 				fakeCommitId := "a-commit"
 				branchName := "a-branch"
 				repoId := "a-repo"
-				d.Set("commit_id", fakeCommitId)
-				d.Set("tag", tag)
+				d.Set("ref_commit_id", fakeCommitId)
+				d.Set("ref_tag", tag)
 				d.Set("name", branchName)
 				d.Set("repository_id", repoId)
 
@@ -122,7 +122,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 				fakeCommitId := "a-commit"
 				branchName := "a-branch"
 				repoId := "a-repo"
-				d.Set("ref", ref)
+				d.Set("ref_branch", ref)
 				d.Set("name", branchName)
 				d.Set("repository_id", repoId)
 
@@ -197,7 +197,7 @@ func TestGitRepositoryBranch_Read(t *testing.T) {
 				}
 
 				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
-				d.Set("ref", "another-branch")
+				d.Set("ref_branch", "another-branch")
 				d.Set("name", "a-branch")
 				d.Set("repository_id", "a-repo")
 				d.SetId("a-repo:a-branch")
@@ -253,7 +253,7 @@ func TestGitRepositoryBranch_Delete(t *testing.T) {
 				}
 
 				d := schema.TestResourceDataRaw(t, ResourceGitRepositoryBranch().Schema, nil)
-				d.Set("ref", "another-branch")
+				d.Set("ref_branch", "another-branch")
 				d.Set("name", "a-branch")
 				d.Set("repository_id", "a-repo")
 				d.SetId("a-repo:a-branch")

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -106,9 +106,14 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 	if err := checkRepositoryBranchExists(clients, repoId, branch); err != nil {
 		return err
 	}
+	version := shortBranchName(branch)
 	repoItem, err := clients.GitReposClient.GetItem(ctx, git.GetItemArgs{
 		RepositoryId: &repoId,
 		Path:         &file,
+		VersionDescriptor: &git.GitVersionDescriptor{
+			Version:     &version,
+			VersionType: &git.GitVersionTypeValues.Branch,
+		},
 	})
 	if err != nil && !utils.ResponseWasNotFound(err) {
 		return fmt.Errorf("Repository branch not found, repositoryID: %s, branch: %s. Error:  %+v", repoId, branch, err)

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testRepoProjectID = uuid.New()
-var testRepoID = uuid.New()
+var (
+	testRepoProjectID = uuid.New()
+	testRepoID        = uuid.New()
+)
 
 // This definition matches the overall structure of what a configured git repository would
 // look like. Note that the ID and Name attributes match -- this is the service-side behavior

--- a/azuredevops/internal/utils/tfhelper/tfhelper.go
+++ b/azuredevops/internal/utils/tfhelper/tfhelper.go
@@ -110,6 +110,18 @@ func ParseProjectIDAndResourceID(d *schema.ResourceData) (string, int, error) {
 	return projectID, resourceID, err
 }
 
+func ParseGitRepoBranchID(id string) (string, string, error) {
+	return parseTwoPartID(id, ":", "repositoryID:branchName")
+}
+
+func parseTwoPartID(id, sep, want string) (string, string, error) {
+	parts := strings.SplitN(id, sep, 2)
+	if len(parts) != 2 || strings.EqualFold(parts[0], "") || strings.EqualFold(parts[1], "") {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected %s", id, want)
+	}
+	return parts[0], parts[1], nil
+}
+
 // ParseImportedID parse the imported int Id from the terraform import
 func ParseImportedID(id string) (string, int, error) {
 	parts := strings.SplitN(id, "/", 2)
@@ -175,7 +187,6 @@ func ImportProjectQualifiedResource() *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 			projectNameOrID, resourceID, err := ParseImportedName(d.Id())
-
 			if err != nil {
 				return nil, fmt.Errorf("error parsing the resource ID from the Terraform resource data: %v", err)
 			}
@@ -198,7 +209,6 @@ func ImportProjectQualifiedResourceInteger() *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 			projectNameOrID, resourceID, err := ParseImportedName(d.Id())
-
 			if err != nil {
 				return nil, fmt.Errorf("error parsing the resource ID from the Terraform resource data: %v", err)
 			}
@@ -226,7 +236,6 @@ func ImportProjectQualifiedResourceUUID() *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 			projectNameOrID, resourceID, err := ParseImportedUUID(d.Id())
-
 			if err != nil {
 				return nil, fmt.Errorf("error parsing the resource ID from the Terraform resource data: %v", err)
 			}
@@ -243,7 +252,7 @@ func ImportProjectQualifiedResourceUUID() *schema.ResourceImporter {
 
 // Get real project ID
 func GetRealProjectId(projectNameOrID string, meta interface{}) (string, error) {
-	//If request params is project name, try get the project ID
+	// If request params is project name, try get the project ID
 	if _, err := uuid.ParseUUID(projectNameOrID); err != nil {
 		clients := meta.(*client.AggregatedClient)
 		project, err := clients.CoreClient.GetProject(clients.Ctx, core.GetProjectArgs{

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -68,6 +68,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_generic_git":            serviceendpoint.ResourceServiceEndpointGenericGit(),
 			"azuredevops_serviceendpoint_externaltfs":            serviceendpoint.ResourceServiceEndpointExternalTFS(),
 			"azuredevops_git_repository":                         git.ResourceGitRepository(),
+			"azuredevops_git_repository_branch":                  git.ResourceGitRepositoryBranch(),
 			"azuredevops_git_repository_file":                    git.ResourceGitRepositoryFile(),
 			"azuredevops_user_entitlement":                       memberentitlementmanagement.ResourceUserEntitlement(),
 			"azuredevops_group_membership":                       graph.ResourceGroupMembership(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -53,6 +53,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_repository_policy_reserved_names",
 		"azuredevops_repository_policy_check_credentials",
 		"azuredevops_git_repository",
+		"azuredevops_git_repository_branch",
 		"azuredevops_git_repository_file",
 		"azuredevops_user_entitlement",
 		"azuredevops_group_membership",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -143,6 +143,9 @@
                   <a href="/docs/providers/azuredevops/r/git_repository_file.html">azuredevops_git_repository_file</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/git_repository_branch.html">azuredevops_git_repository_branch</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/group.html">azuredevops_group</a>
                 </li>
                 <li>

--- a/website/docs/r/git_repository_branch.html.markdown
+++ b/website/docs/r/git_repository_branch.html.markdown
@@ -48,11 +48,11 @@ The following arguments are supported:
 
 - `repository_id` - (Required) The ID of the repository the branch is created against.
 
-- `ref_branch` - (Optional) The reference to the source branch to create the branch from, in `<name>` or `refs/heads/<name>` format. Throws error if set when `ref_tag` or `ref_commit_id` is also set.
+- `ref_branch` - (Optional) The reference to the source branch to create the branch from, in `<name>` or `refs/heads/<name>` format. Conflict with `ref_tag`, `ref_commit_id`.
 
-- `ref_tag` - (Optional) The reference to the tag to create the branch from, in `<name>` or `refs/tags/<name>` format. Throws error if set when `ref_branch` or `ref_commit_id` is also set.
+- `ref_tag` - (Optional) The reference to the tag to create the branch from, in `<name>` or `refs/tags/<name>` format. Conflict with `ref_branch`, `ref_commit_id`.
 
-- `ref_commit_id` - (Optional) The commit object id to create the branch from. Throws error if set when `ref_branch` or `ref_tag` is also set.
+- `ref_commit_id` - (Optional) The commit object ID to create the branch from. Conflict with `ref_branch`, `ref_tag`.
 
 ## Attributes Reference
 
@@ -60,4 +60,4 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 - `id` - The ID of the Git Repository Branch, in the format `<repository_id>:<name>`.
 
-- `last_commit_id` - The commit object id of last commit on the branch.
+- `last_commit_id` - The commit object ID of last commit on the branch.

--- a/website/docs/r/git_repository_branch.html.markdown
+++ b/website/docs/r/git_repository_branch.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_git_repository_branch"
+description: |-
+  Manages a Git Repository Branch.
+---
+
+# azuredevops_git_repository_branch
+
+Manages a Git Repository Branch.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Git Repository"
+  initialization {
+    init_type = "Uninitialized"
+  }
+}
+
+resource "azuredevops_git_repository_branch" "example_orphan" {
+  repository_id = azuredevops_git_repository.example.id
+  name          = "master"
+}
+
+resource "azuredevops_git_repository_branch" "example_from_ref" {
+  repository_id = azuredevops_git_repository.example.id
+  name          = "develop"
+  source_ref    = azuredevops_git_repository_branch.example_orphan.ref
+}
+
+resource "azuredevops_git_repository_branch" "example_from_sha" {
+  repository_id = azuredevops_git_repository.example.id
+  name          = "somebranch"
+  source_sha    = azuredevops_git_repository_branch.example_orphan.sha
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the branch (not prefixed with `refs/heads/`).
+
+- `repository_id` - (Required) The ID of the repository the branch is created against.
+
+- `source_ref` - (Optional) The ref the branch is created from. (prefixed with `refs/heads/` or `refs/tags/`)
+
+- `source_sha` - (Optional) The commit object id the branch is created from. Set to commit object id of `source_ref` if not given. Otherwise, `source_ref` is ignored.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+- `id` - The ID of the Git Repository Branch.
+
+- `is_default_branch` - True if the branch is the default branch of the git repository.
+
+- `ref` - The branch reference in `refs/heads/<name>` format.
+
+- `sha` - The commit SHA1 object id of the branch tip.
+
+## Import
+
+Git Repository Branches can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azuredevops_git_repository_branch.example 00000000-0000-0000-0000-000000000000:master
+```

--- a/website/docs/r/git_repository_branch.html.markdown
+++ b/website/docs/r/git_repository_branch.html.markdown
@@ -23,25 +23,20 @@ resource "azuredevops_git_repository" "example" {
   project_id = azuredevops_project.example.id
   name       = "Example Git Repository"
   initialization {
-    init_type = "Uninitialized"
+    init_type = "Clean"
   }
 }
 
-resource "azuredevops_git_repository_branch" "example_orphan" {
+resource "azuredevops_git_repository_branch" "example" {
   repository_id = azuredevops_git_repository.example.id
-  name          = "master"
+  name          = "example-branch-name"
+  ref_branch    = azuredevops_git_repository.example.default_branch
 }
 
-resource "azuredevops_git_repository_branch" "example_from_ref" {
+resource "azuredevops_git_repository_branch" "example_from_commit_id" {
   repository_id = azuredevops_git_repository.example.id
-  name          = "develop"
-  source_ref    = azuredevops_git_repository_branch.example_orphan.ref
-}
-
-resource "azuredevops_git_repository_branch" "example_from_sha" {
-  repository_id = azuredevops_git_repository.example.id
-  name          = "somebranch"
-  source_sha    = azuredevops_git_repository_branch.example_orphan.sha
+  name          = "example-from-commit-id"
+  ref_commit_id = azuredevops_git_repository_branch.example.last_commit_id
 }
 ```
 
@@ -49,30 +44,20 @@ resource "azuredevops_git_repository_branch" "example_from_sha" {
 
 The following arguments are supported:
 
-- `name` - (Required) The name of the branch (not prefixed with `refs/heads/`).
+- `name` - (Required) The name of the branch in short format not prefixed with `refs/heads/`.
 
 - `repository_id` - (Required) The ID of the repository the branch is created against.
 
-- `source_ref` - (Optional) The ref the branch is created from. (prefixed with `refs/heads/` or `refs/tags/`)
+- `ref_branch` - (Optional) The reference to the source branch to create the branch from, in `<name>` or `refs/heads/<name>` format. Throws error if set when `ref_tag` or `ref_commit_id` is also set.
 
-- `source_sha` - (Optional) The commit object id the branch is created from. Set to commit object id of `source_ref` if not given. Otherwise, `source_ref` is ignored.
+- `ref_tag` - (Optional) The reference to the tag to create the branch from, in `<name>` or `refs/tags/<name>` format. Throws error if set when `ref_branch` or `ref_commit_id` is also set.
+
+- `ref_commit_id` - (Optional) The commit object id to create the branch from. Throws error if set when `ref_branch` or `ref_tag` is also set.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-- `id` - The ID of the Git Repository Branch.
+- `id` - The ID of the Git Repository Branch, in the format `<repository_id>:<name>`.
 
-- `is_default_branch` - True if the branch is the default branch of the git repository.
-
-- `ref` - The branch reference in `refs/heads/<name>` format.
-
-- `sha` - The commit SHA1 object id of the branch tip.
-
-## Import
-
-Git Repository Branches can be imported using the `resource id`, e.g.
-
-```shell
-terraform import azuredevops_git_repository_branch.example 00000000-0000-0000-0000-000000000000:master
-```
+- `last_commit_id` - The commit object id of last commit on the branch.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #663

Introduce the ability to manage files on branches that are managed by terraform.  Maybe an extra acceptance test case should be included that creates/updates a file on a branch managed by terraform that is not the default branch.

Basically, I took inspiration from [gitlab_branch](https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/blob/main/internal/provider/sdk/resource_gitlab_branch.go) and [github_branch](https://github.com/integrations/terraform-provider-github/blob/main/github/resource_github_branch.go).

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

To reproduce bug from linked issue:
1. Create file on branch called test that is not default branch.
2. apply something like this
```hcl
data "azuredevops_project" "example" {
  name = "cdktf-test-project"
}

resource "azuredevops_git_repository" "example" {
  project_id = data.azuredevops_project.example.id
  name       = "Example Git Repository"
  initialization {
    init_type = "Clean"
  }
}

resource "azuredevops_git_repository_branch" "example" {
  repository_id = azuredevops_git_repository.example.id
  name          = "test"
}

resource "azuredevops_git_repository_file" "example" {
  repository_id       = azuredevops_git_repository.example.id
  file                = "hello"
  content             = "you"
  branch              = azuredevops_git_repository_branch.example.ref
  commit_message      = "test"
  overwrite_on_create = true
}
```

3. get logs like this

```
[mike@lemptop:~/project/fork-azdo-provider/mytests]$ terraform apply
data.azuredevops_project.example: Reading...
data.azuredevops_project.example: Read complete after 0s [id=3151f6cf-4e03-4f18-b8aa-43ffa0b1634d]
azuredevops_git_repository.example: Refreshing state... [id=d8b105e2-a69a-4ee4-ad8e-7afa5fd68d7d]
azuredevops_git_repository_branch.example: Refreshing state... [id=d8b105e2-a69a-4ee4-ad8e-7afa5fd68d7d:test]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # azuredevops_git_repository_file.example will be created
  + resource "azuredevops_git_repository_file" "example" {
      + branch              = "refs/heads/test"
      + commit_message      = "test"
      + content             = "you"
      + file                = "hello"
      + id                  = (known after apply)
      + overwrite_on_create = true
      + repository_id       = "d8b105e2-a69a-4ee4-ad8e-7afa5fd68d7d"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azuredevops_git_repository_file.example: Creating...
╷
│ Error: Create repositroy file failed, repositoryID: d8b105e2-a69a-4ee4-ad8e-7afa5fd68d7d, branch: refs/heads/test, file: hello. 
Error:  The path 'hello' specified in the add operation already exists. Please specify a new path.
│ Parameter name: newPush
│ 
│   with azuredevops_git_repository_file.example,
│   on main.tf line 27, in resource "azuredevops_git_repository_file" "example":
│   27: resource "azuredevops_git_repository_file" "example" {
│ 
╵
```

Should be fixed in second commit of this pull request. Basically we check if the file exists on the right branch as suggested in the original issue and set the ChangeType accordingly.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
