### PR TITLE
`azuredevops_build_folder_permissions` - Avoid potential null pointer

### DIFF
--- a/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
@@ -104,7 +104,11 @@ func createBuildFolderToken(d *schema.ResourceData, clients *client.AggregatedCl
 	})
 
 	if err != nil {
-		return "", fmt.Errorf(" failed to get the folder. Project ID: %s, path: %s. %+v", projectID, buildFolderPath, err)
+		return "", fmt.Errorf(" failed to get the folder. Project ID: %s, Path: %s. %+v", projectID, buildFolderPath, err)
+	}
+
+	if buildFolders == nil || len(*buildFolders) == 0 {
+		return "", fmt.Errorf(" folder not found. Project ID: %s, Path: %s.", projectID, buildFolderPath)
 	}
 
 	Folder := (*buildFolders)[0]


### PR DESCRIPTION
## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Checks for the existence of the folder, and returns error message if the folder not found.

Issue Number: #710 

```log
=== RUN   TestAccBuildDefinitionPermissions_SetPermissions
=== PAUSE TestAccBuildDefinitionPermissions_SetPermissions
=== RUN   TestAccBuildDefinitionPermissions_UpdatePermissions
=== PAUSE TestAccBuildDefinitionPermissions_UpdatePermissions
=== CONT  TestAccBuildDefinitionPermissions_SetPermissions
=== CONT  TestAccBuildDefinitionPermissions_UpdatePermissions
--- PASS: TestAccBuildDefinitionPermissions_SetPermissions (54.82s)
--- PASS: TestAccBuildDefinitionPermissions_UpdatePermissions (74.52s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        81.129s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->