### PR TITLE
[Bug Fix] - `azuredevops_build_folder` - fix `path` cannot update

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_build_folder_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_test.go
@@ -5,24 +5,25 @@
 package acceptancetests
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-func TestAccBuildFolder(t *testing.T) {
+func TestAccBuildFolder_basic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
-	config := testutils.HclBuildFolder(projectName, "\\test-folder", "Acceptance Test Folder")
 
-	tfNode := "azuredevops_build_folder.test_folder"
+	tfNode := "azuredevops_build_folder.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.GetProviders(),
 		CheckDestroy: testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: buildFolderBasic(projectName, "\\\\test folder", "Acceptance Test Folder"),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckProjectExists(projectName),
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
@@ -32,4 +33,97 @@ func TestAccBuildFolder(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccBuildFolder_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+
+	tfNode := "azuredevops_build_folder.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: buildFolderBasic(projectName, "\\\\test folder", "Acceptance Test Folder"),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttr(tfNode, "path", `\test folder`),
+				),
+			},
+			{
+				Config: buildFolderBasic(projectName, "\\\\test folderupdate", "Acceptance Test Folder"),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttr(tfNode, "path", `\test folderupdate`),
+				),
+			},
+			{
+				Config: buildFolderBasic(projectName, "\\\\test folder", "Acceptance Test Folder"),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttr(tfNode, "path", `\test folder`),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBuildFolder_requiresImportErrorStep(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: buildFolderBasic(projectName, "\\\\test folder", "Acceptance Test Folder"),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+				),
+			},
+			{
+				Config:      buildFolderRequiresImport(projectName, "\\\\test folder", "Acceptance Test Folder"),
+				ExpectError: buildFolderRequiresImportError(`\\test folder\\`, projectName),
+			},
+		},
+	})
+}
+
+func buildFolderRequiresImportError(resourceName, projectName string) *regexp.Regexp {
+	message := `failed creating resource Build Folder, Folder %[1]s already exists for project %[2]s.`
+	return regexp.MustCompile(fmt.Sprintf(message, resourceName, projectName))
+}
+
+func buildFolderBasic(projectName, path, description string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "project" {
+	name       = "%[1]s"
+	description        = "%[1]s-description"
+	visibility         = "private"
+	version_control    = "Git"
+	work_item_template = "Agile"
+}
+
+resource "azuredevops_build_folder" "test" {
+	project_id  = azuredevops_project.project.id
+	path        = "%[2]s"
+	description = "%[3]s"
+}
+`, projectName, path, description)
+}
+
+func buildFolderRequiresImport(projectName, path, description string) string {
+	basicConfig := buildFolderBasic(projectName, path, description)
+	return fmt.Sprintf(`
+
+%s
+
+resource "azuredevops_build_folder" "import" {
+	project_id  = azuredevops_build_folder.test.project_id
+	path        = azuredevops_build_folder.test.path
+	description = azuredevops_build_folder.test.description
+}
+`, basicConfig)
 }

--- a/azuredevops/internal/acceptancetests/resource_build_folder_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_test.go
@@ -99,17 +99,17 @@ func buildFolderRequiresImportError(resourceName, projectName string) *regexp.Re
 func buildFolderBasic(projectName, path, description string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "project" {
-	name       = "%[1]s"
-	description        = "%[1]s-description"
-	visibility         = "private"
-	version_control    = "Git"
-	work_item_template = "Agile"
+  name               = "%[1]s"
+  description        = "%[1]s-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
 }
 
 resource "azuredevops_build_folder" "test" {
-	project_id  = azuredevops_project.project.id
-	path        = "%[2]s"
-	description = "%[3]s"
+  project_id  = azuredevops_project.project.id
+  path        = "%[2]s"
+  description = "%[3]s"
 }
 `, projectName, path, description)
 }
@@ -118,12 +118,13 @@ func buildFolderRequiresImport(projectName, path, description string) string {
 	basicConfig := buildFolderBasic(projectName, path, description)
 	return fmt.Sprintf(`
 
+
 %s
 
 resource "azuredevops_build_folder" "import" {
-	project_id  = azuredevops_build_folder.test.project_id
-	path        = azuredevops_build_folder.test.path
-	description = azuredevops_build_folder.test.description
+  project_id  = azuredevops_build_folder.test.project_id
+  path        = azuredevops_build_folder.test.path
+  description = azuredevops_build_folder.test.description
 }
 `, basicConfig)
 }

--- a/azuredevops/internal/acceptancetests/resource_workitem_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitem_test.go
@@ -23,7 +23,7 @@ func TestAccWorkItem_basic(t *testing.T) {
 		CheckDestroy:      testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: basic(projectName, workItemTitle),
+				Config: workItemBasic(projectName, workItemTitle),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckProjectExists(projectName),
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitle),
@@ -48,14 +48,14 @@ func TestAccWorkItem_titleUpdate(t *testing.T) {
 		CheckDestroy:      testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: basic(projectName, workItemTitle),
+				Config: workItemBasic(projectName, workItemTitle),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckProjectExists(projectName),
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitle),
 				),
 			},
 			{
-				Config: basic(projectName, workItemTitleUpdated),
+				Config: workItemBasic(projectName, workItemTitleUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitleUpdated),
 				),
@@ -75,20 +75,20 @@ func TestAccWorkItem_tagUpdate(t *testing.T) {
 		CheckDestroy:      testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: basic(projectName, workItemTitle),
+				Config: workItemBasic(projectName, workItemTitle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitle),
 				),
 			},
 			{
-				Config: tagUpdate(projectName, workItemTitle),
+				Config: workItemTagUpdate(projectName, workItemTitle),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckProjectExists(projectName),
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitle),
 				),
 			},
 			{
-				Config: basic(projectName, workItemTitle),
+				Config: workItemBasic(projectName, workItemTitle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "title", workItemTitle),
 				),
@@ -96,8 +96,8 @@ func TestAccWorkItem_tagUpdate(t *testing.T) {
 		},
 	})
 }
-func basic(projectNane string, title string) string {
-	template := template(projectNane)
+func workItemBasic(projectNane string, title string) string {
+	template := workItemTemplate(projectNane)
 	return fmt.Sprintf(`
 %s
 
@@ -109,8 +109,8 @@ resource "azuredevops_workitem" "test" {
 `, template, title)
 }
 
-func tagUpdate(projectNane string, title string) string {
-	template := template(projectNane)
+func workItemTagUpdate(projectNane string, title string) string {
+	template := workItemTemplate(projectNane)
 	return fmt.Sprintf(`
 %s
 
@@ -124,7 +124,7 @@ resource "azuredevops_workitem" "test" {
 `, template, title)
 }
 
-func template(name string) string {
+func workItemTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "project" {
   name               = "%[1]s"

--- a/azuredevops/internal/service/build/resource_build_folder.go
+++ b/azuredevops/internal/service/build/resource_build_folder.go
@@ -53,7 +53,7 @@ func resourceBuildFolderCreate(d *schema.ResourceData, m interface{}) error {
 
 	createdBuildFolder, err := createBuildFolder(clients, path, projectID, description)
 	if err != nil {
-		return fmt.Errorf(" failed creating resource Build Folder, project ID: %s. Error: %+v", projectID, err)
+		return fmt.Errorf(" failed creating resource Build Folder, %+v", err)
 	}
 
 	flattenBuildFolder(d, createdBuildFolder, projectID)
@@ -94,7 +94,7 @@ func resourceBuildFolderRead(d *schema.ResourceData, m interface{}) error {
 func resourceBuildFolderUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	path := d.Get("path").(string)
+	oldPath, _ := d.GetChange("path")
 	buildFolder, projectID, err := expandBuildFolder(d)
 	if err != nil {
 		return fmt.Errorf(" failed to expand build folder configurations. Project ID: %s , Error: %+v", projectID, err)
@@ -102,7 +102,7 @@ func resourceBuildFolderUpdate(d *schema.ResourceData, m interface{}) error {
 
 	updatedBuildFolder, err := clients.BuildClient.UpdateFolder(m.(*client.AggregatedClient).Ctx, build.UpdateFolderArgs{
 		Project: &projectID,
-		Path:    &path,
+		Path:    converter.String(oldPath.(string)),
 		Folder:  buildFolder,
 	})
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #720 
1. Fix `azuredevops_build_folder` path cannot update
2. Update `azuredevops_build_folder` test cases
3. Update `azuredevops_workitem` test case

```log
=== RUN   TestAccBuildFolder_basic
=== PAUSE TestAccBuildFolder_basic
=== RUN   TestAccBuildFolder_update
=== PAUSE TestAccBuildFolder_update
=== RUN   TestAccBuildFolder_requiresImportErrorStep
=== PAUSE TestAccBuildFolder_requiresImportErrorStep
=== CONT  TestAccBuildFolder_basic
=== CONT  TestAccBuildFolder_requiresImportErrorStep
=== CONT  TestAccBuildFolder_update
--- PASS: TestAccBuildFolder_requiresImportErrorStep (32.06s)
--- PASS: TestAccBuildFolder_basic (39.06s)
--- PASS: TestAccBuildFolder_update (45.73s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        52.365s

=== RUN   TestAccWorkItem_basic
=== PAUSE TestAccWorkItem_basic
=== RUN   TestAccWorkItem_titleUpdate
=== PAUSE TestAccWorkItem_titleUpdate
=== RUN   TestAccWorkItem_tagUpdate
=== PAUSE TestAccWorkItem_tagUpdate
=== CONT  TestAccWorkItem_basic
=== CONT  TestAccWorkItem_tagUpdate
=== CONT  TestAccWorkItem_titleUpdate
--- PASS: TestAccWorkItem_basic (27.78s)
--- PASS: TestAccWorkItem_titleUpdate (35.61s)
--- PASS: TestAccWorkItem_tagUpdate (43.80s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        44.386s

```


## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->