### PR TITLE
Uppercase readme.md when initialize a repository

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -300,7 +300,7 @@ func initializeGitRepository(clients *client.AggregatedClient, repo *git.GitRepo
 						git.Change{
 							ChangeType: &git.VersionControlChangeTypeValues.Add,
 							Item: git.GitItem{
-								Path: converter.String("/readme.md"),
+								Path: converter.String("/README.md"),
 							},
 							NewContent: &git.ItemContent{
 								ContentType: &git.ItemContentTypeValues.RawText,

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -199,7 +199,7 @@ func TestGitRepo_Initialize_UsesTheDefaultBranch(t *testing.T) {
 						git.Change{
 							ChangeType: &git.VersionControlChangeTypeValues.Add,
 							Item: git.GitItem{
-								Path: converter.String("/readme.md"),
+								Path: converter.String("/README.md"),
 							},
 							NewContent: &git.ItemContent{
 								ContentType: &git.ItemContentTypeValues.RawText,


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The [azuredevops_git_repository](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository) resource creates a readme.md file when it's initialized. To follow the same behaviour that Azure Devops does, it needs to be uppercased (README.md)

Issue Number: #695

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Not directly, however it can impact any extra automation that relies on lowercase readme.md generated.

## Other information

The file created by [azuredevops_git_repository](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository) will be renamed from `readme.md` to `README.md`