### PR TITLE
[New resource] - `azuredevops_pipeline_authorization`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
@@ -1,0 +1,445 @@
+//go:build (all || pipeline_authorization) && !exclude_pipeline_authorization
+// +build all pipeline_authorization
+// +build !exclude_pipeline_authorization
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccPipelineAuthorization_allPipeline_queue(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAllPipelineAuthQueue(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_pipeline_queue(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPipelineAuthQueue(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_allPipeline_environment(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAllPipelineAuthEnvironment(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_pipeline_environment(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPipelineAuthEnvironment(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_allPipeline_variableGroup(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAllPipelineAuthVariableGroup(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_pipeline_variableGroup(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPipelineAuthVariableGroup(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_allPipeline_endpoint(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAllPipelineAuthEndpoint(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPipelineAuthorization_pipeline_endpoint(t *testing.T) {
+	node := "azuredevops_pipeline_authorization.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testutils.PreCheck(t, nil)
+		},
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPipelineAuthEndpoint(testutils.GenerateResourceName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "project_id"),
+					resource.TestCheckResourceAttrSet(node, "resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func hclAllPipelineAuthQueue(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_agent_pool" "test" {
+  name           = "%[1]s"
+  auto_provision = false
+  auto_update    = false
+}
+
+resource "azuredevops_agent_queue" "test" {
+  project_id    = azuredevops_project.test.id
+  agent_pool_id = azuredevops_agent_pool.test.id
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_agent_queue.test.id
+  type        = "queue"
+}
+`, name)
+}
+
+func hclPipelineAuthQueue(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_agent_pool" "test" {
+  name           = "%[1]s"
+  auto_provision = false
+  auto_update    = false
+}
+
+resource "azuredevops_agent_queue" "test" {
+  project_id    = azuredevops_project.test.id
+  agent_pool_id = azuredevops_agent_pool.test.id
+}
+
+data "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = data.azuredevops_git_repository.test.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_agent_queue.test.id
+  pipeline_id = azuredevops_build_definition.test.id
+  type        = "queue"
+}
+`, name)
+}
+
+func hclAllPipelineAuthEnvironment(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_environment" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_environment.test.id
+  type        = "environment"
+}
+`, name)
+}
+func hclPipelineAuthEnvironment(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_environment" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+data "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = data.azuredevops_git_repository.test.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_environment.test.id
+  type        = "environment"
+  pipeline_id = azuredevops_build_definition.test.id
+}
+`, name)
+}
+
+func hclAllPipelineAuthVariableGroup(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_variable_group" "test" {
+  project_id   = azuredevops_project.test.id
+  name         = "%[1]s"
+  allow_access = true
+
+  variable {
+    name  = "key1"
+    value = "val1"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_variable_group.test.id
+  type        = "variablegroup"
+}
+`, name)
+}
+func hclPipelineAuthVariableGroup(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_variable_group" "test" {
+  project_id   = azuredevops_project.test.id
+  name         = "%[1]s"
+  allow_access = true
+
+  variable {
+    name  = "key1"
+    value = "val1"
+  }
+}
+
+data "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = data.azuredevops_git_repository.test.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_variable_group.test.id
+  type        = "variablegroup"
+  pipeline_id = azuredevops_build_definition.test.id
+}
+`, name)
+}
+func hclAllPipelineAuthEndpoint(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_serviceendpoint_github" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%[1]s"
+
+  auth_personal {
+    personal_access_token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_serviceendpoint_github.test.id
+  type        = "endpoint"
+}
+`, name)
+}
+func hclPipelineAuthEndpoint(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_serviceendpoint_github" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%[1]s"
+
+  auth_personal {
+    personal_access_token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  }
+}
+
+data "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = data.azuredevops_git_repository.test.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "test" {
+  project_id  = azuredevops_project.test.id
+  resource_id = azuredevops_serviceendpoint_github.test.id
+  type        = "endpoint"
+  pipeline_id = azuredevops_build_definition.test.id
+}
+`, name)
+}

--- a/azuredevops/internal/client/client.go
+++ b/azuredevops/internal/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/memberentitlementmanagement"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/operations"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelineschecks"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/policy"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/release"
@@ -42,6 +43,7 @@ type AggregatedClient struct {
 	GraphClient                   graph.Client
 	OperationsClient              operations.Client
 	PipelinesChecksClient         pipelineschecks.Client
+	PipelinePermissionsClient     pipelinepermissions.Client
 	PipelinesChecksClientExtras   pipelineschecksextras.Client
 	PolicyClient                  policy.Client
 	ReleaseClient                 release.Client
@@ -147,6 +149,12 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		return nil, err
 	}
 
+	pipelinepermissionsClient, err := pipelinepermissions.NewClient(ctx, connection)
+	if err != nil {
+		log.Printf("getAzdoClient(): pipelineschecks.NewClient failed.")
+		return nil, err
+	}
+
 	pipelinesChecksClientExtras, err := pipelineschecksextras.NewClient(ctx, connection)
 	if err != nil {
 		log.Printf("getAzdoClient(): pipelineschecksextras.NewClient failed.")
@@ -161,6 +169,7 @@ func GetAzdoClient(azdoPAT string, organizationURL string, tfVersion string) (*A
 		GraphClient:                   graphClient,
 		OperationsClient:              operationsClient,
 		PipelinesChecksClient:         pipelinesChecksClient,
+		PipelinePermissionsClient:     pipelinepermissionsClient,
 		PipelinesChecksClientExtras:   pipelinesChecksClientExtras,
 		PolicyClient:                  policyClient,
 		ReleaseClient:                 releaseClient,

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -1,0 +1,143 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+func ResourcePipelineAuthorization() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePipelineAuthorizationCreateUpdate,
+		Read:   resourcePipelineAuthorizationRead,
+		Delete: resourcePipelineAuthorizationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"endpoint", "queue", "variablegroup", "environment"}, false),
+			},
+			"pipeline_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+		},
+	}
+}
+
+func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	pipePermissionParams := pipelinepermissions.UpdatePipelinePermisionsForResourceArgs{
+		Project:      converter.String(d.Get("project_id").(string)),
+		ResourceType: converter.String(d.Get("type").(string)),
+		ResourceId:   converter.String(d.Get("resource_id").(string)),
+	}
+
+	if v, ok := d.GetOk("pipeline_id"); ok {
+		pipePermissionParams.ResourceAuthorization = &pipelinepermissions.ResourcePipelinePermissions{
+			Pipelines: &[]pipelinepermissions.PipelinePermission{{
+				Authorized: converter.ToPtr(true),
+				Id:         converter.ToPtr(v.(int)),
+			}}}
+	} else {
+		pipePermissionParams.ResourceAuthorization = &pipelinepermissions.ResourcePipelinePermissions{
+			AllPipelines: &pipelinepermissions.Permission{
+				Authorized: converter.ToPtr(true),
+			}}
+	}
+
+	response, err := clients.PipelinePermissionsClient.UpdatePipelinePermisionsForResource(
+		clients.Ctx,
+		pipePermissionParams,
+	)
+
+	if err != nil {
+		return fmt.Errorf(" creating authorized resource: %+v", err)
+	}
+	d.SetId(*response.Resource.Id)
+
+	return resourcePipelineAuthorizationRead(d, m)
+}
+
+func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	resp, err := clients.PipelinePermissionsClient.GetPipelinePermissionsForResource(clients.Ctx,
+		pipelinepermissions.GetPipelinePermissionsForResourceArgs{
+			Project:      converter.String(d.Get("project_id").(string)),
+			ResourceType: converter.String(d.Get("type").(string)),
+			ResourceId:   converter.String(d.Get("resource_id").(string)),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("%+v", err)
+	}
+
+	if resp == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("resource_id", resp.Resource.Id)
+	d.Set("type", resp.Resource.Type)
+	if resp.Pipelines != nil && len(*resp.Pipelines) > 0 {
+		pipeAuth := (*resp.Pipelines)[0]
+		d.Set("pipeline_id", pipeAuth.Id)
+	}
+
+	d.SetId(*resp.Resource.Id)
+	return nil
+}
+
+func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	pipePermissionParams := pipelinepermissions.UpdatePipelinePermisionsForResourceArgs{
+		Project:      converter.String(d.Get("project_id").(string)),
+		ResourceType: converter.String(d.Get("type").(string)),
+		ResourceId:   converter.String(d.Get("resource_id").(string)),
+	}
+
+	if v, ok := d.GetOk("pipeline_id"); ok {
+		pipePermissionParams.ResourceAuthorization = &pipelinepermissions.ResourcePipelinePermissions{
+			Pipelines: &[]pipelinepermissions.PipelinePermission{{
+				Authorized: converter.ToPtr(false),
+				Id:         converter.ToPtr(v.(int)),
+			}}}
+	} else {
+		pipePermissionParams.ResourceAuthorization = &pipelinepermissions.ResourcePipelinePermissions{
+			AllPipelines: &pipelinepermissions.Permission{
+				Authorized: converter.ToPtr(false),
+			}}
+	}
+
+	_, err := clients.PipelinePermissionsClient.UpdatePipelinePermisionsForResource(
+		clients.Ctx,
+		pipePermissionParams)
+
+	if err != nil {
+		return fmt.Errorf(" deleting authorized resource: %+v", err)
+	}
+
+	return nil
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -26,6 +26,7 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"azuredevops_resource_authorization":                 build.ResourceResourceAuthorization(),
+			"azuredevops_pipeline_authorization":                 build.ResourcePipelineAuthorization(),
 			"azuredevops_branch_policy_build_validation":         branch.ResourceBranchPolicyBuildValidation(),
 			"azuredevops_branch_policy_min_reviewers":            branch.ResourceBranchPolicyMinReviewers(),
 			"azuredevops_branch_policy_auto_reviewers":           branch.ResourceBranchPolicyAutoReviewers(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -10,6 +10,7 @@ import (
 func TestProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"azuredevops_resource_authorization",
+		"azuredevops_pipeline_authorization",
 		"azuredevops_build_definition",
 		"azuredevops_build_definition_permissions",
 		"azuredevops_branch_policy_build_validation",

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions/client.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions/client.go
@@ -1,0 +1,160 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package pipelinepermissions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"net/http"
+)
+
+var ResourceAreaId, _ = uuid.Parse("a81a0441-de52-4000-aa15-ff0e07bfbbaa")
+
+type Client interface {
+	// [Preview API] Given a ResourceType and ResourceId, returns authorized definitions for that resource.
+	GetPipelinePermissionsForResource(context.Context, GetPipelinePermissionsForResourceArgs) (*ResourcePipelinePermissions, error)
+	// [Preview API] Authorizes/Unauthorizes a list of definitions for a given resource.
+	UpdatePipelinePermisionsForResource(context.Context, UpdatePipelinePermisionsForResourceArgs) (*ResourcePipelinePermissions, error)
+	// [Preview API] Batch API to authorize/unauthorize a list of definitions for a multiple resources.
+	UpdatePipelinePermisionsForResources(context.Context, UpdatePipelinePermisionsForResourcesArgs) (*[]ResourcePipelinePermissions, error)
+}
+
+type ClientImpl struct {
+	Client azuredevops.Client
+}
+
+func NewClient(ctx context.Context, connection *azuredevops.Connection) (Client, error) {
+	client, err := connection.GetClientByResourceAreaId(ctx, ResourceAreaId)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientImpl{
+		Client: *client,
+	}, nil
+}
+
+// [Preview API] Given a ResourceType and ResourceId, returns authorized definitions for that resource.
+func (client *ClientImpl) GetPipelinePermissionsForResource(ctx context.Context, args GetPipelinePermissionsForResourceArgs) (*ResourcePipelinePermissions, error) {
+	routeValues := make(map[string]string)
+	if args.Project == nil || *args.Project == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.Project"}
+	}
+	routeValues["project"] = *args.Project
+	if args.ResourceType == nil || *args.ResourceType == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ResourceType"}
+	}
+	routeValues["resourceType"] = *args.ResourceType
+	if args.ResourceId == nil || *args.ResourceId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ResourceId"}
+	}
+	routeValues["resourceId"] = *args.ResourceId
+
+	locationId, _ := uuid.Parse("b5b9a4a4-e6cd-4096-853c-ab7d8b0c4eb2")
+	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "7.1-preview.1", routeValues, nil, nil, "", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue ResourcePipelinePermissions
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the GetPipelinePermissionsForResource function
+type GetPipelinePermissionsForResourceArgs struct {
+	// (required) Project ID or project name
+	Project *string
+	// (required)
+	ResourceType *string
+	// (required)
+	ResourceId *string
+}
+
+// [Preview API] Authorizes/Unauthorizes a list of definitions for a given resource.
+func (client *ClientImpl) UpdatePipelinePermisionsForResource(ctx context.Context, args UpdatePipelinePermisionsForResourceArgs) (*ResourcePipelinePermissions, error) {
+	if args.ResourceAuthorization == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.ResourceAuthorization"}
+	}
+	routeValues := make(map[string]string)
+	if args.Project == nil || *args.Project == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.Project"}
+	}
+	routeValues["project"] = *args.Project
+	if args.ResourceType == nil || *args.ResourceType == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ResourceType"}
+	}
+	routeValues["resourceType"] = *args.ResourceType
+	if args.ResourceId == nil || *args.ResourceId == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.ResourceId"}
+	}
+	routeValues["resourceId"] = *args.ResourceId
+
+	body, marshalErr := json.Marshal(*args.ResourceAuthorization)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("b5b9a4a4-e6cd-4096-853c-ab7d8b0c4eb2")
+	resp, err := client.Client.Send(ctx, http.MethodPatch, locationId, "7.1-preview.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue ResourcePipelinePermissions
+	err = client.Client.UnmarshalBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdatePipelinePermisionsForResource function
+type UpdatePipelinePermisionsForResourceArgs struct {
+	// (required)
+	ResourceAuthorization *ResourcePipelinePermissions
+	// (required) Project ID or project name
+	Project *string
+	// (required)
+	ResourceType *string
+	// (required)
+	ResourceId *string
+}
+
+// [Preview API] Batch API to authorize/unauthorize a list of definitions for a multiple resources.
+func (client *ClientImpl) UpdatePipelinePermisionsForResources(ctx context.Context, args UpdatePipelinePermisionsForResourcesArgs) (*[]ResourcePipelinePermissions, error) {
+	if args.ResourceAuthorizations == nil {
+		return nil, &azuredevops.ArgumentNilError{ArgumentName: "args.ResourceAuthorizations"}
+	}
+	routeValues := make(map[string]string)
+	if args.Project == nil || *args.Project == "" {
+		return nil, &azuredevops.ArgumentNilOrEmptyError{ArgumentName: "args.Project"}
+	}
+	routeValues["project"] = *args.Project
+
+	body, marshalErr := json.Marshal(*args.ResourceAuthorizations)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	locationId, _ := uuid.Parse("b5b9a4a4-e6cd-4096-853c-ab7d8b0c4eb2")
+	resp, err := client.Client.Send(ctx, http.MethodPatch, locationId, "7.1-preview.1", routeValues, nil, bytes.NewReader(body), "application/json", "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseValue []ResourcePipelinePermissions
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	return &responseValue, err
+}
+
+// Arguments for the UpdatePipelinePermisionsForResources function
+type UpdatePipelinePermisionsForResourcesArgs struct {
+	// (required)
+	ResourceAuthorizations *[]ResourcePipelinePermissions
+	// (required) Project ID or project name
+	Project *string
+}

--- a/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions/models.go
+++ b/vendor/github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions/models.go
@@ -1,0 +1,48 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// --------------------------------------------------------------------------------------------
+// Generated file, DO NOT EDIT
+// Changes may cause incorrect behavior and will be lost if the code is regenerated.
+// --------------------------------------------------------------------------------------------
+
+package pipelinepermissions
+
+import (
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelineschecks"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
+)
+
+type Permission struct {
+	Authorized   *bool               `json:"authorized,omitempty"`
+	AuthorizedBy *webapi.IdentityRef `json:"authorizedBy,omitempty"`
+	AuthorizedOn *azuredevops.Time   `json:"authorizedOn,omitempty"`
+}
+
+type PipelinePermission struct {
+	Authorized   *bool               `json:"authorized,omitempty"`
+	AuthorizedBy *webapi.IdentityRef `json:"authorizedBy,omitempty"`
+	AuthorizedOn *azuredevops.Time   `json:"authorizedOn,omitempty"`
+	Id           *int                `json:"id,omitempty"`
+}
+
+type PipelineProcessResources struct {
+	Resources *[]PipelineResourceReference `json:"resources,omitempty"`
+}
+
+type PipelineResourceReference struct {
+	Authorized   *bool             `json:"authorized,omitempty"`
+	AuthorizedBy *uuid.UUID        `json:"authorizedBy,omitempty"`
+	AuthorizedOn *azuredevops.Time `json:"authorizedOn,omitempty"`
+	DefinitionId *int              `json:"definitionId,omitempty"`
+	Id           *string           `json:"id,omitempty"`
+	Type         *string           `json:"type,omitempty"`
+}
+
+type ResourcePipelinePermissions struct {
+	AllPipelines *Permission               `json:"allPipelines,omitempty"`
+	Pipelines    *[]PipelinePermission     `json:"pipelines,omitempty"`
+	Resource     *pipelineschecks.Resource `json:"resource,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,6 +186,7 @@ github.com/microsoft/azure-devops-go-api/azuredevops/v7/licensing
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/licensingrule
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/memberentitlementmanagement
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/operations
+github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinesapproval
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelineschecks
 github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinestaskcheck

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -176,6 +176,9 @@
                   <a href="/docs/providers/azuredevops/r/resource_authorization.html">azuredevops_resource_authorization</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/pipeline_authorization.html">azuredevops_pipeline_authorization</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/repository_policy_author_email_pattern.html">azuredevops_repository_policy_author_email_pattern</a>
                 </li>
                 <li>

--- a/website/docs/r/pipeline_authorization.html.markdown
+++ b/website/docs/r/pipeline_authorization.html.markdown
@@ -1,0 +1,107 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_pipeline_authorization"
+description: |-
+  Manages Pipeline Authorizations within Azure DevOps Project.
+---
+
+# azuredevops_pipeline_authorization
+
+Manage pipeline access permissions to resources。
+
+## Example Usage 
+
+### Authorization for all pipelines
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_agent_pool" "example" {
+  name           = "Example Pool"
+  auto_provision = false
+  auto_update    = false
+}
+
+resource "azuredevops_agent_queue" "example" {
+  project_id    = azuredevops_project.example.id
+  agent_pool_id = azuredevops_agent_pool.example.id
+}
+
+resource "azuredevops_pipeline_authorization" "example" {
+  project_id  = azuredevops_project.example.id
+  resource_id = azuredevops_agent_queue.example.id
+  type        = "queue"
+}
+```
+
+### Authorization for specific pipeline
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_agent_pool" "example" {
+  name           = "Example Pool"
+  auto_provision = false
+  auto_update    = false
+}
+
+resource "azuredevops_agent_queue" "example" {
+  project_id    = azuredevops_project.example.id
+  agent_pool_id = azuredevops_agent_pool.example.id
+}
+
+data "azuredevops_git_repository" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Project"
+}
+
+resource "azuredevops_build_definition" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Pipeline"
+
+  repository {
+    repo_type = "TfsGit"
+    repo_id   = data.azuredevops_git_repository.example.id
+    yml_path  = "azure-pipelines.yml"
+  }
+}
+
+resource "azuredevops_pipeline_authorization" "example" {
+  project_id  = azuredevops_project.example.id
+  resource_id = azuredevops_agent_queue.example.id
+  type        = "queue"
+  pipeline_id = azuredevops_build_definition.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The  ID of the project. Changing this forces a new resource to be created 
+- `resource_id` - (Required) The ID of the resource to authorize. Changing this forces a new resource to be created
+- `type` - (Required) The type of the resource to authorize. Valid values: `endpoint`, `queue`, `variablegroup`, `environment`. Changing this forces a new resource to be created
+
+---
+- `pipeline_id` - (Optional) The ID of the pipeline. Changing this forces a new resource to be created
+
+
+## Attributes Reference
+
+No attributes are exported
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.1 - Pipeline Permissions](https://learn.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/pipeline-permissions?view=azure-devops-rest-7.1)

--- a/website/docs/r/pipeline_authorization.html.markdown
+++ b/website/docs/r/pipeline_authorization.html.markdown
@@ -9,6 +9,9 @@ description: |-
 
 Manage pipeline access permissions to resources。
 
+~> **Note** This resource is replacement for `azuredevops_resource_authorization`.  Pipeline authorizations managed by `azuredevops_resource_authorization` can also
+be managed by this resource 
+
 ## Example Usage 
 
 ### Authorization for all pipelines


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #540 
This resource is replacement for `azuredevops_resource_authorization`.  Pipeline authorizations managed by `azuredevops_resource_authorization` can also
be managed by this resource 
```log
=== RUN   TestAccPipelineAuthorization_allPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipeline_queue
=== RUN   TestAccPipelineAuthorization_pipeline_queue
=== PAUSE TestAccPipelineAuthorization_pipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipeline_environment
=== PAUSE TestAccPipelineAuthorization_allPipeline_environment
=== RUN   TestAccPipelineAuthorization_pipeline_environment
=== PAUSE TestAccPipelineAuthorization_pipeline_environment
=== RUN   TestAccPipelineAuthorization_allPipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_allPipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_pipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_pipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_allPipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_allPipeline_endpoint
=== RUN   TestAccPipelineAuthorization_pipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_pipeline_endpoint
=== CONT  TestAccPipelineAuthorization_allPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_pipeline_environment
=== CONT  TestAccPipelineAuthorization_allPipeline_endpoint
=== CONT  TestAccPipelineAuthorization_pipeline_endpoint
=== CONT  TestAccPipelineAuthorization_pipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_allPipeline_environment
=== CONT  TestAccPipelineAuthorization_pipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipeline_environment (90.57s)
--- PASS: TestAccPipelineAuthorization_allPipeline_queue (90.61s)
--- PASS: TestAccPipelineAuthorization_pipeline_environment (92.45s)
--- PASS: TestAccPipelineAuthorization_pipeline_queue (92.76s)
--- PASS: TestAccPipelineAuthorization_allPipeline_variableGroup (99.56s)
--- PASS: TestAccPipelineAuthorization_pipeline_variableGroup (103.65s)
--- PASS: TestAccPipelineAuthorization_allPipeline_endpoint (108.03s)
--- PASS: TestAccPipelineAuthorization_pipeline_endpoint (113.00s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        120.785s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->