### PR TITLE
`azuredevops_branch_policy_min_reviewers` -  Fix `on_push_reset_approved_votes` cannot set to `true`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
@@ -1,0 +1,253 @@
+//go:build (all || resource_branchpolicy_min_reviewer_acceptance_test || policy) && (!exclude_resource_branchpolicy_min_reviewer_acceptance_test || !exclude_policy)
+// +build all resource_branchpolicy_min_reviewer_acceptance_test policy
+// +build !exclude_resource_branchpolicy_min_reviewer_acceptance_test !exclude_policy
+
+package acceptancetests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccBranchPolicyMinReviewers_basic(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	node := "azuredevops_branch_policy_min_reviewers.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPolicyMinReviewersBasic(1, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "id"),
+					resource.TestCheckResourceAttr(node, "blocking", "true"),
+					resource.TestCheckResourceAttr(node, "enabled", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.submitter_can_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.allow_completion_with_rejects_or_waits", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.last_pusher_cannot_approve", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_last_iteration_require_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_approved_votes", "true"),
+				),
+			}, {
+				ResourceName:      node,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(node),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBranchPolicyMinReviewers_update(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	node := "azuredevops_branch_policy_min_reviewers.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPolicyMinReviewersBasic(1, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "id"),
+					resource.TestCheckResourceAttr(node, "blocking", "true"),
+					resource.TestCheckResourceAttr(node, "enabled", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.submitter_can_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.allow_completion_with_rejects_or_waits", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.last_pusher_cannot_approve", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_last_iteration_require_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_approved_votes", "true"),
+				),
+			}, {
+				Config: hclPolicyMinReviewersUpdate(2, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "id"),
+					resource.TestCheckResourceAttr(node, "blocking", "false"),
+					resource.TestCheckResourceAttr(node, "enabled", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.submitter_can_vote", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.allow_completion_with_rejects_or_waits", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.last_pusher_cannot_approve", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_last_iteration_require_vote", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_all_votes", "false"),
+				),
+			}, {
+				ResourceName:      node,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(node),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBranchPolicyMinReviewers_resetAllVote(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	node := "azuredevops_branch_policy_min_reviewers.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPolicyMinReviewersResetAllVote(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "id"),
+					resource.TestCheckResourceAttr(node, "blocking", "true"),
+					resource.TestCheckResourceAttr(node, "enabled", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.submitter_can_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_all_votes", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_approved_votes", "true"),
+				),
+			}, {
+				ResourceName:      node,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(node),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccBranchPolicyMinReviewers_requiresImportError(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	node := "azuredevops_branch_policy_min_reviewers.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclPolicyMinReviewersResetAllVote(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "id"),
+					resource.TestCheckResourceAttr(node, "blocking", "true"),
+					resource.TestCheckResourceAttr(node, "enabled", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.submitter_can_vote", "false"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_all_votes", "true"),
+					resource.TestCheckResourceAttr(node, "settings.0.on_push_reset_approved_votes", "true"),
+				),
+			}, {
+				Config:      hclPolicyMinReviewersResetRequireImportError(name),
+				ExpectError: regexp.MustCompile(`Error creating policy in Azure DevOps: The update is rejected by policy`),
+			},
+		},
+	})
+}
+
+func hclPolicyMinReviewersTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+data "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[1]s"
+}
+`, name)
+}
+
+func hclPolicyMinReviewersBasic(reviewers int, name string) string {
+	template := hclPolicyMinReviewersTemplate(name)
+	return fmt.Sprintf(`
+
+%s
+
+resource "azuredevops_branch_policy_min_reviewers" "test" {
+  project_id = azuredevops_project.test.id
+  enabled    = true
+  blocking   = true
+  settings {
+    reviewer_count                         = %[2]d
+    submitter_can_vote                     = false
+    allow_completion_with_rejects_or_waits = false
+    on_push_reset_approved_votes           = true
+    scope {
+      repository_id  = data.azuredevops_git_repository.test.id
+      repository_ref = "refs/heads/release"
+      match_type     = "Exact"
+    }
+  }
+}
+`, template, reviewers)
+}
+
+func hclPolicyMinReviewersUpdate(reviewers int, name string) string {
+	template := hclPolicyMinReviewersTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_branch_policy_min_reviewers" "test" {
+  project_id = azuredevops_project.test.id
+  enabled    = false
+  blocking   = false
+  settings {
+    reviewer_count                         = %[2]d
+    submitter_can_vote                     = true
+    allow_completion_with_rejects_or_waits = true
+    last_pusher_cannot_approve             = true
+    on_last_iteration_require_vote         = true
+    scope {
+      repository_id  = data.azuredevops_git_repository.test.id
+      repository_ref = "refs/heads/release"
+      match_type     = "Exact"
+    }
+  }
+}
+`, template, reviewers)
+}
+
+func hclPolicyMinReviewersResetAllVote(name string) string {
+	template := hclPolicyMinReviewersTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_branch_policy_min_reviewers" "test" {
+  project_id = azuredevops_project.test.id
+  enabled    = true
+  blocking   = true
+  settings {
+    reviewer_count               = 2
+    submitter_can_vote           = false
+    on_push_reset_all_votes      = true
+    on_push_reset_approved_votes = true
+    scope {
+      repository_id  = data.azuredevops_git_repository.test.id
+      repository_ref = "refs/heads/release"
+      match_type     = "Exact"
+    }
+  }
+}
+`, template)
+}
+
+func hclPolicyMinReviewersResetRequireImportError(name string) string {
+	template := hclPolicyMinReviewersResetAllVote(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_branch_policy_min_reviewers" "import" {
+  project_id = azuredevops_branch_policy_min_reviewers.test.project_id
+  enabled    = azuredevops_branch_policy_min_reviewers.test.enabled
+  blocking   = azuredevops_branch_policy_min_reviewers.test.blocking
+  settings {
+    reviewer_count               = azuredevops_branch_policy_min_reviewers.test.settings.0.reviewer_count
+    submitter_can_vote           = azuredevops_branch_policy_min_reviewers.test.settings.0.submitter_can_vote
+    on_push_reset_all_votes      = azuredevops_branch_policy_min_reviewers.test.settings.0.on_push_reset_all_votes
+    on_push_reset_approved_votes = azuredevops_branch_policy_min_reviewers.test.settings.0.on_push_reset_approved_votes
+    scope {
+      repository_id  = azuredevops_branch_policy_min_reviewers.test.settings.0.scope.0.repository_id
+      repository_ref = azuredevops_branch_policy_min_reviewers.test.settings.0.scope.0.repository_ref
+      match_type     = azuredevops_branch_policy_min_reviewers.test.settings.0.scope.0.match_type
+    }
+  }
+}
+`, template)
+}

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_test.go
@@ -14,68 +14,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-// TestAccBranchPolicyMinReviewers_CreateAndUpdate - acceptance test for min reviewers branch policy attributes
-func TestAccBranchPolicyMinReviewers_CreateAndUpdate(t *testing.T) {
-	minReviewerTfNode := "azuredevops_branch_policy_min_reviewers.p"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testutils.PreCheck(t, nil) },
-		Providers: testutils.GetProviders(),
-		Steps: []resource.TestStep{
-			{
-				Config: getMinReviewersHcl(true, true, 1, false, "\"refs/heads/release\"", "Exact"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.submitter_can_vote", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.allow_completion_with_rejects_or_waits", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.last_pusher_cannot_approve", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_last_iteration_require_vote", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_last_iteration_require_vote", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_push_reset_approved_votes", "true"),
-				),
-			}, {
-				Config: getMinReviewersHcl(false, false, 2, true, "\"refs/heads/release\"", "Exact"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(minReviewerTfNode, "id"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "blocking", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "enabled", "false"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.submitter_can_vote", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.allow_completion_with_rejects_or_waits", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.last_pusher_cannot_approve", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_last_iteration_require_vote", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_last_iteration_require_vote", "true"),
-					resource.TestCheckResourceAttr(minReviewerTfNode, "settings.0.on_push_reset_all_votes", "true"),
-				),
-			}, {
-				ResourceName:      minReviewerTfNode,
-				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(minReviewerTfNode),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func getMinReviewersHcl(enabled bool, blocking bool, reviewers int, flag bool, repositoryRef string, matchType string) string {
-	votes := "all"
-	if !flag {
-		votes = "approved"
-	}
-	settings := fmt.Sprintf(
-		`
-		reviewer_count     = %[1]d
-		submitter_can_vote = %[2]t
-		allow_completion_with_rejects_or_waits =%[2]t
-		last_pusher_cannot_approve = %[2]t
-		on_last_iteration_require_vote = %[2]t
-		on_push_reset_%[3]s_votes = true
-		`, reviewers, flag, votes)
-
-	return getBranchPolicyHcl("azuredevops_branch_policy_min_reviewers", enabled, blocking, settings, "azuredevops_git_repository.repository.id", repositoryRef, matchType)
-}
-
 func TestAccBranchPolicyAutoReviewers_CreateAndUpdate(t *testing.T) {
 	autoReviewerTfNode := "azuredevops_branch_policy_auto_reviewers.p"
 

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_min_reviewers.go
@@ -1,26 +1,11 @@
 package branch
 
 import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/policy"
 )
-
-type minReviewerPolicySettings struct {
-	ApprovalCount                     int  `json:"minimumApproverCount" tf:"reviewer_count"`
-	SubmitterCanVote                  bool `json:"creatorVoteCounts" tf:"submitter_can_vote"`
-	AllowCompletionWithRejectsOrWaits bool `json:"allowDownvotes" tf:"allow_completion_with_rejects_or_waits"`
-	OnPushResetApprovedVotes          bool `json:"resetOnSourcePush" tf:"on_push_reset_approved_votes" ConflictsWith:"on_push_reset_all_votes"`
-	OnLastIterationRequireVote        bool `json:"requireVoteOnLastIteration" tf:"on_last_iteration_require_vote"`
-	OnPushResetAllVotes               bool `json:"resetRejectionsOnSourcePush" tf:"on_push_reset_all_votes" ConflictsWith:"on_push_reset_approved_votes"`
-	LastPusherCannotVote              bool `json:"blockLastPusherVote" tf:"last_pusher_cannot_approve"`
-}
 
 // ResourceBranchPolicyMinReviewers schema and implementation for min reviewer policy resource
 func ResourceBranchPolicyMinReviewers() *schema.Resource {
@@ -32,34 +17,49 @@ func ResourceBranchPolicyMinReviewers() *schema.Resource {
 
 	settingsSchema := resource.Schema[SchemaSettings].Elem.(*schema.Resource).Schema
 
-	// Dynamically create the schema based on the minReviewerPolicySettings tags
-	metaField := reflect.TypeOf(minReviewerPolicySettings{})
-	// Loop through the fields, adding schema for each one.
-	for i := 0; i < metaField.NumField(); i++ {
-		tfName := metaField.Field(i).Tag.Get("tf")
-		if _, ok := settingsSchema[tfName]; ok {
-			continue // skip those which are already set
-		}
-		if metaField.Field(i).Type == reflect.TypeOf(true) {
-			settingsSchema[tfName] = &schema.Schema{
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			}
-		}
-		if metaField.Field(i).Type == reflect.TypeOf(0) {
-			settingsSchema[tfName] = &schema.Schema{
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			}
-		}
-		if conflicts, ok := metaField.Field(i).Tag.Lookup("ConflictsWith"); ok {
-			if _, ok := settingsSchema[conflicts]; ok {
-				settingsSchema[conflicts].ConflictsWith = []string{SchemaSettings + ".0." + tfName}
-				settingsSchema[tfName].ConflictsWith = []string{SchemaSettings + ".0." + conflicts}
-			}
-		}
+	settingsSchema["reviewer_count"] = &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ValidateFunc: validation.IntAtLeast(1),
+	}
+
+	settingsSchema["submitter_can_vote"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+
+	settingsSchema["allow_completion_with_rejects_or_waits"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+
+	settingsSchema["on_last_iteration_require_vote"] = &schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		Default:       false,
+		ConflictsWith: []string{"settings.0.on_push_reset_approved_votes", "settings.0.on_push_reset_all_votes"},
+	}
+
+	settingsSchema["on_push_reset_approved_votes"] = &schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		Default:       false,
+		ConflictsWith: []string{"settings.0.on_last_iteration_require_vote"},
+	}
+
+	settingsSchema["on_push_reset_all_votes"] = &schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		Default:       false,
+		ConflictsWith: []string{"settings.0.on_last_iteration_require_vote"},
+	}
+
+	settingsSchema["last_pusher_cannot_approve"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
 	}
 	return resource
 }
@@ -70,31 +70,19 @@ func minReviewersFlattenFunc(d *schema.ResourceData, policyConfig *policy.Policy
 	if err != nil {
 		return err
 	}
-	policyAsJSON, err := json.Marshal(policyConfig.Settings)
-	if err != nil {
-		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
-	}
 
-	policySettings := minReviewerPolicySettings{}
-	err = json.Unmarshal(policyAsJSON, &policySettings)
-	if err != nil {
-		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
-	}
+	policySettings := policyConfig.Settings.(map[string]interface{})
 
 	settingsList := d.Get(SchemaSettings).([]interface{})
 	settings := settingsList[0].(map[string]interface{})
 
-	tipe := reflect.TypeOf(policySettings)
-	for i := 0; i < tipe.NumField(); i++ {
-		tfName := tipe.Field(i).Tag.Get("tf")
-		ps := reflect.ValueOf(policySettings)
-		if tipe.Field(i).Type == reflect.TypeOf(true) {
-			settings[tfName] = ps.Field(i).Bool()
-		}
-		if tipe.Field(i).Type == reflect.TypeOf(0) {
-			settings[tfName] = ps.Field(i).Int()
-		}
-	}
+	settings["reviewer_count"] = policySettings["minimumApproverCount"]
+	settings["submitter_can_vote"] = policySettings["creatorVoteCounts"]
+	settings["allow_completion_with_rejects_or_waits"] = policySettings["allowDownvotes"]
+	settings["on_push_reset_approved_votes"] = policySettings["resetOnSourcePush"]
+	settings["on_last_iteration_require_vote"] = policySettings["requireVoteOnLastIteration"]
+	settings["on_push_reset_all_votes"] = policySettings["resetRejectionsOnSourcePush"]
+	settings["last_pusher_cannot_approve"] = policySettings["blockLastPusherVote"]
 
 	d.Set(SchemaSettings, settingsList)
 	return nil
@@ -111,21 +99,17 @@ func minReviewersExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.P
 	settings := settingsList[0].(map[string]interface{})
 
 	policySettings := policyConfig.Settings.(map[string]interface{})
+	policySettings["minimumApproverCount"] = settings["reviewer_count"]
+	policySettings["creatorVoteCounts"] = settings["submitter_can_vote"]
+	policySettings["allowDownvotes"] = settings["allow_completion_with_rejects_or_waits"]
+	policySettings["requireVoteOnLastIteration"] = settings["on_last_iteration_require_vote"]
+	policySettings["resetOnSourcePush"] = settings["on_push_reset_approved_votes"]
+	policySettings["blockLastPusherVote"] = settings["last_pusher_cannot_approve"]
 
-	tipe := reflect.TypeOf(minReviewerPolicySettings{})
-	for i := 0; i < tipe.NumField(); i++ {
-		tags := tipe.Field(i).Tag
-		apiName := tags.Get("json")
-		tfName := tags.Get("tf")
-		if _, ok := policySettings[apiName]; ok {
-			continue
-		}
-		if tipe.Field(i).Type == reflect.TypeOf(true) {
-			policySettings[apiName] = settings[tfName].(bool)
-		}
-		if tipe.Field(i).Type == reflect.TypeOf(0) {
-			policySettings[apiName] = settings[tfName].(int)
-		}
+	resetRejectionsOnSourcePush := settings["on_push_reset_all_votes"].(bool)
+	policySettings["resetRejectionsOnSourcePush"] = resetRejectionsOnSourcePush
+	if resetRejectionsOnSourcePush {
+		policySettings["resetOnSourcePush"] = true
 	}
 
 	return policyConfig, projectID, nil

--- a/website/docs/r/branch_policy_min_reviewers.html.markdown
+++ b/website/docs/r/branch_policy_min_reviewers.html.markdown
@@ -62,28 +62,43 @@ resource "azuredevops_branch_policy_min_reviewers" "example" {
 The following arguments are supported:
 
 - `project_id` - (Required) The ID of the project in which the policy will be created.
-- `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
-- `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
-- `settings` - (Required) Configuration for the policy. This block must be defined exactly once.
 
+- `settings` - (Required) A `settings` block as defined below.. This block must be defined exactly once. 
+
+---
+- `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
+
+- `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
+
+---
 A `settings` block supports the following:
 
 - `reviewer_count` - (Required) The number of reviewers needed to approve.
+
+- `scope` (Required) A `scope` block as defined below. Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
+
 - `submitter_can_vote` - (Optional) Allow requesters to approve their own changes. Defaults to `false`.
+
 - `last_pusher_cannot_approve`(Optional) Prohibit the most recent pusher from approving their own changes. Defaults to `false`.
+
 - `allow_completion_with_rejects_or_waits` (Optional) Allow completion even if some reviewers vote to wait or reject. Defaults to `false`.
+
 - `on_push_reset_approved_votes` (Optional) When new changes are pushed reset all approval votes (does not reset votes to reject or wait). Defaults to `false`.
+
 - `on_push_reset_all_votes` (Optional) When new changes are pushed reset all code reviewer votes. Defaults to `false`.
+
+~> **Note:** If `on_push_reset_all_votes` is `true` then `on_push_reset_approved_votes` will be set to `true`. To enable `on_push_reset_approved_votes`, you need explicitly set `on_push_reset_all_votes` `false` or not configure.
+
 - `on_last_iteration_require_vote` (Optional) On last iteration require vote. Defaults to `false`.
 
-Only one of `on_push_reset_all_votes` or `on_push_reset_approved_votes` may be specified. 
 
-- `scope` (Required) Controls which repositories and branches the policy will be enabled for. This block must be defined at least once.
-
+---
 A `settings` `scope` block supports the following:
 
 - `repository_id` - (Optional) The repository ID. Needed only if the scope of the policy will be limited to a single repository. If `match_type` is `DefaultBranch`, this should not be defined.
+
 - `repository_ref` - (Optional) The ref pattern to use for the match when `match_type` other than `DefaultBranch`. If `match_type` is `Exact`, this should be a qualified ref such as `refs/heads/master`. If `match_type` is `Prefix`, this should be a ref path such as `refs/heads/releases`.
+
 - `match_type` (Optional) The match type to use when applying the policy. Supported values are `Exact` (default), `Prefix` or `DefaultBranch`.
 
 ## Attributes Reference


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #783 
Fix `on_push_reset_approved_votes` cannot set to `true` when `on_push_reset_all_votes` is `true`

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->