### PR TITLE
`azuredevops_project` - Enhance project creation

### DIFF
--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -221,22 +221,32 @@ func projectRead(clients *client.AggregatedClient, projectID string, projectName
 	var project *core.TeamProject
 	var err error
 
-	//keep retrying until timeout to handle service inconsistent response
-	//lint:ignore SA1019
-	err = resource.Retry(projectRetryTimeoutDuration*time.Minute, func() *resource.RetryError { //nolint:staticcheck
-		project, err = clients.CoreClient.GetProject(clients.Ctx, core.GetProjectArgs{
-			ProjectId:           &identifier,
-			IncludeCapabilities: converter.Bool(true),
-			IncludeHistory:      converter.Bool(false),
-		})
-		if err != nil {
-			if utils.ResponseWasNotFound(err) {
-				return resource.NonRetryableError(err)
+	stateConf := &resource.StateChangeConf{
+		ContinuousTargetOccurence: 1,
+		Delay:                     5 * time.Second,
+		MinTimeout:                20 * time.Second,
+		Pending:                   []string{"pending"},
+		Target:                    []string{"success"},
+		Refresh: func() (result interface{}, state string, err error) {
+			project, err = clients.CoreClient.GetProject(clients.Ctx, core.GetProjectArgs{
+				ProjectId:           &identifier,
+				IncludeCapabilities: converter.Bool(true),
+				IncludeHistory:      converter.Bool(false),
+			})
+			if err != nil {
+				if utils.ResponseWasNotFound(err) {
+					log.Printf("[INFO] Project not found. %+v", err)
+				}
+				return project, "pending", err
 			}
-			return resource.RetryableError(err)
-		}
-		return nil
-	})
+			return project, "success", nil
+		},
+		Timeout: projectRetryTimeoutDuration * time.Minute,
+	}
+
+	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
+		return project, fmt.Errorf(" waiting for project ready. %v ", err)
+	}
 
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {

--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -235,7 +235,7 @@ func projectRead(clients *client.AggregatedClient, projectID string, projectName
 			})
 			if err != nil {
 				if utils.ResponseWasNotFound(err) {
-					log.Printf("[INFO] Project not found. %+v", err)
+					log.Printf("[INFO] Project not found. ID/Name: %s . Error: %+v", identifier, err)
 				}
 				return project, "pending", err
 			}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 
Issue Number: #790 #788 #741 #771 
Retry the get operation until the no error or timeout. 
```log
=== RUN   TestAccProject_DataSource
=== RUN   TestAccProject_DataSource/Get_project_with_id
=== PAUSE TestAccProject_DataSource/Get_project_with_id
=== RUN   TestAccProject_DataSource/Get_project_with_name
=== PAUSE TestAccProject_DataSource/Get_project_with_name
=== CONT  TestAccProject_DataSource/Get_project_with_id
=== CONT  TestAccProject_DataSource/Get_project_with_name
--- PASS: TestAccProject_DataSource (0.00s)
    --- PASS: TestAccProject_DataSource/Get_project_with_id (38.78s)
    --- PASS: TestAccProject_DataSource/Get_project_with_name (48.99s)
=== RUN   TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== PAUSE TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== RUN   TestAccProject_DataSource_ErrorWhenDescriptionSet
=== PAUSE TestAccProject_DataSource_ErrorWhenDescriptionSet
=== RUN   TestAccProject_CreateAndUpdate
=== PAUSE TestAccProject_CreateAndUpdate
=== RUN   TestAccProject_CreateAndUpdateWithFeatures
=== PAUSE TestAccProject_CreateAndUpdateWithFeatures
=== CONT  TestAccProject_DataSource_ErrorWhenBothNameAndIdSet
=== CONT  TestAccProject_CreateAndUpdate
=== CONT  TestAccProject_DataSource_ErrorWhenDescriptionSet
=== CONT  TestAccProject_CreateAndUpdateWithFeatures
--- PASS: TestAccProject_DataSource_ErrorWhenDescriptionSet (3.43s)
--- PASS: TestAccProject_DataSource_ErrorWhenBothNameAndIdSet (3.83s)
--- PASS: TestAccProject_CreateAndUpdateWithFeatures (68.07s)
--- PASS: TestAccProject_CreateAndUpdate (79.57s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        136.574s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->