### PR TITLE
[Bug fix ] -`azuredevops_pipeline_authorization` - Fix resource recreate with `pipeline_id` not configured

### DIFF
--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -100,9 +100,17 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 
 	d.Set("resource_id", resp.Resource.Id)
 	d.Set("type", resp.Resource.Type)
+
 	if resp.Pipelines != nil && len(*resp.Pipelines) > 0 {
-		pipeAuth := (*resp.Pipelines)[0]
-		d.Set("pipeline_id", pipeAuth.Id)
+		var exist = false
+		for _, pipe := range *resp.Pipelines {
+			if *pipe.Id == d.Get("pipeline_id").(int) {
+				exist = true
+			}
+		}
+		if !exist {
+			d.Set("pipeline_id", nil)
+		}
 	}
 
 	d.SetId(*resp.Resource.Id)

--- a/website/docs/r/pipeline_authorization.html.markdown
+++ b/website/docs/r/pipeline_authorization.html.markdown
@@ -9,8 +9,10 @@ description: |-
 
 Manage pipeline access permissions to resources.
 
-~> **Note** This resource is a replacement for `azuredevops_resource_authorization`.  Pipeline authorizations managed by `azuredevops_resource_authorization` can also
-be managed by this resource 
+~> **Note** This resource is a replacement for `azuredevops_resource_authorization`.  Pipeline authorizations managed by `azuredevops_resource_authorization` can also be managed by this resource.
+
+~> **Note** If both "All Pipeline Authorization" and "Custom Pipeline Authorization" are configured, "All Pipeline Authorization" has higher priority.
+
 
 ## Example Usage 
 
@@ -98,7 +100,7 @@ The following arguments are supported:
 - `type` - (Required) The type of the resource to authorize. Valid values: `endpoint`, `queue`, `variablegroup`, `environment`. Changing this forces a new resource to be created
 
 ---
-- `pipeline_id` - (Optional) The ID of the pipeline. Changing this forces a new resource to be created
+- `pipeline_id` - (Optional) The ID of the pipeline. If not configured, all pipelines will be authorized. Changing this forces a new resource to be created.
 
 
 ## Attributes Reference


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #808 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->