### PR TITLE
[Bug fix] - Service connection - Get description from root not project referrence

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -94,9 +94,10 @@ func doBaseExpansion(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, 
 	projectID := uuid.MustParse(d.Get("project_id").(string))
 	name := converter.String(d.Get("service_endpoint_name").(string))
 	serviceEndpoint := &serviceendpoint.ServiceEndpoint{
-		Id:    serviceEndpointID,
-		Name:  name,
-		Owner: converter.String("library"),
+		Id:          serviceEndpointID,
+		Name:        name,
+		Owner:       converter.String("library"),
+		Description: converter.String(d.Get("description").(string)),
 		ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 			{
 				ProjectReference: &serviceendpoint.ProjectReference{
@@ -116,7 +117,7 @@ func doBaseFlattening(d *schema.ResourceData, serviceEndpoint *serviceendpoint.S
 	d.SetId(serviceEndpoint.Id.String())
 	d.Set("service_endpoint_name", serviceEndpoint.Name)
 	d.Set("project_id", projectID.String())
-	d.Set("description", (*serviceEndpoint.ServiceEndpointProjectReferences)[0].Description)
+	d.Set("description", serviceEndpoint.Description)
 
 	if serviceEndpoint.Authorization != nil && serviceEndpoint.Authorization.Scheme != nil {
 		d.Set("authorization", &map[string]interface{}{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
@@ -59,11 +59,12 @@ var argocdTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &argocdTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("argocd"),
-	Url:   converter.String("https://www.argocd.com"),
+	Id:          &argocdTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("argocd"),
+	Url:         converter.String("https://www.argocd.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
@@ -31,11 +31,12 @@ var argocdTestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &argocdTestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("argocd"),
-	Url:   converter.String("https://www.argocd.com"),
+	Id:          &argocdTestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("argocd"),
+	Url:         converter.String("https://www.argocd.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
@@ -59,11 +59,12 @@ var artifactoryTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &artifactoryTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("artifactoryService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &artifactoryTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("artifactoryService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
@@ -31,11 +31,12 @@ var artifactoryTestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &artifactoryTestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("artifactoryService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &artifactoryTestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("artifactoryService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
@@ -35,11 +35,12 @@ var awsTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &awsTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("aws"),
-	Url:   converter.String("https://aws.amazon.com/"),
+	Id:          &awsTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("aws"),
+	Url:         converter.String("https://aws.amazon.com/"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
@@ -50,11 +50,12 @@ var azureCRTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		"azureSpnPermissions":      "[{\\\"roleAssignmentId\\\":\\\"00000000 - 0000-0000-0000-000000000000\\\",\\\"resourceProvider\\\":\\\"Microsoft.RoleAssignment\\\",\\\"provisioned\\\":true}]",
 		"azureSpnRoleAssignmentId": "00000000-0000-0000-0000-000000000000",
 	},
-	Id:    &azureCRTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("dockerregistry"),
-	Url:   converter.String("https://testacr.azurecr.io"),
+	Id:          &azureCRTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("dockerregistry"),
+	Url:         converter.String("https://testacr.azurecr.io"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -41,11 +41,12 @@ func getManualAuthServiceEndpoint() serviceendpoint.ServiceEndpoint {
 			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
 			"subscriptionName": "SUBSCRIPTION_TEST",
 		},
-		Id:    &azurermTestServiceEndpointAzureRMID,
-		Name:  converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
-		Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-		Type:  converter.String("azurerm"),
-		Url:   converter.String("https://management.azure.com/"),
+		Id:          &azurermTestServiceEndpointAzureRMID,
+		Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
+		Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+		Type:        converter.String("azurerm"),
+		Url:         converter.String("https://management.azure.com/"),
+		Description: converter.String("_AZURERM_UNIT_TEST_CONN_DESCRIPTION"),
 		ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 			{
 				ProjectReference: &serviceendpoint.ProjectReference{
@@ -77,11 +78,12 @@ var azurermTestServiceEndpointsAzureRM = []serviceendpoint.ServiceEndpoint{
 			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
 			"subscriptionName": "SUBSCRIPTION_TEST",
 		},
-		Id:    &azurermTestServiceEndpointAzureRMID,
-		Name:  converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
-		Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-		Type:  converter.String("azurerm"),
-		Url:   converter.String("https://management.azure.com/"),
+		Id:          &azurermTestServiceEndpointAzureRMID,
+		Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
+		Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+		Type:        converter.String("azurerm"),
+		Url:         converter.String("https://management.azure.com/"),
+		Description: converter.String("_AZURERM_UNIT_TEST_CONN_DESCRIPTION"),
 		ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 			{
 				ProjectReference: &serviceendpoint.ProjectReference{
@@ -110,11 +112,12 @@ var azurermTestServiceEndpointsAzureRM = []serviceendpoint.ServiceEndpoint{
 			"subscriptionId":   "42125daf-72fd-417c-9ea7-080690625ad3", //fake value
 			"subscriptionName": "SUBSCRIPTION_TEST",
 		},
-		Id:    &azurermTestServiceEndpointAzureRMID,
-		Name:  converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
-		Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-		Type:  converter.String("azurerm"),
-		Url:   converter.String("https://management.azure.com/"),
+		Id:          &azurermTestServiceEndpointAzureRMID,
+		Name:        converter.String("_AZURERM_UNIT_TEST_CONN_NAME"),
+		Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+		Type:        converter.String("azurerm"),
+		Url:         converter.String("https://management.azure.com/"),
+		Description: converter.String("_AZURERM_UNIT_TEST_CONN_DESCRIPTION"),
 		ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 			{
 				ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry_test.go
@@ -36,11 +36,12 @@ var dockerRegistryTestServiceEndpoint = serviceendpoint.ServiceEndpoint{ //todo 
 	Data: &map[string]string{
 		"registrytype": "Others",
 	},
-	Id:    &dockerRegistryTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("dockerregistry"),
-	Url:   converter.String("https://hub.docker.com/"),
+	Id:          &dockerRegistryTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("dockerregistry"),
+	Url:         converter.String("https://hub.docker.com/"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
@@ -32,11 +32,12 @@ var externalTfsTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &externalTfsTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("externaltfs"),
-	Url:   converter.String("https://dev.azure.com/myorganization"),
+	Id:          &externalTfsTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("externaltfs"),
+	Url:         converter.String("https://dev.azure.com/myorganization"),
+	Description: converter.String("UNIT_TEST_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform_test.go
@@ -36,11 +36,12 @@ var gcpForTerraformTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 	Data: &map[string]string{
 		"project": "GCP_TEST_project_id",
 	},
-	Id:    &gcpForTerraformTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("GoogleCloudServiceEndpoint"),
-	Url:   converter.String("https://www.googleapis.com/"),
+	Id:          &gcpForTerraformTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("GoogleCloudServiceEndpoint"),
+	Url:         converter.String("https://www.googleapis.com/"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise_test.go
@@ -30,11 +30,12 @@ var ghesTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &ghesTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("githubenterprise"),
-	Url:   converter.String("https://github.contoso.com"),
+	Id:          &ghesTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("githubenterprise"),
+	Url:         converter.String("https://github.contoso.com"),
+	Description: converter.String("UNIT_TEST_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
@@ -30,11 +30,12 @@ var ghTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &ghTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("github"),
-	Url:   converter.String("https://github.com"),
+	Id:          &ghTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("github"),
+	Url:         converter.String("https://github.com"),
+	Description: converter.String("UNIT_TEST_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook_test.go
@@ -32,11 +32,12 @@ var incomingWebhookTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("None"),
 	},
-	Id:    &incomingWebhookTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("incomingwebhook"),
-	Url:   converter.String("https://dev.azure.com"),
+	Id:          &incomingWebhookTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("incomingwebhook"),
+	Url:         converter.String("https://dev.azure.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2_test.go
@@ -31,11 +31,12 @@ var artifactoryV2TestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &artifactoryV2TestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogArtifactoryService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &artifactoryV2TestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogArtifactoryService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{
@@ -58,11 +59,12 @@ var artifactoryV2TestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &artifactoryV2TestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogArtifactoryService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &artifactoryV2TestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogArtifactoryService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2_test.go
@@ -31,11 +31,12 @@ var distributionV2TestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &distributionV2TestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogDistributionService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &distributionV2TestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogDistributionService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{
@@ -58,11 +59,12 @@ var distributionV2TestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &distributionV2TestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogDistributionService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &distributionV2TestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogDistributionService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2_test.go
@@ -31,11 +31,12 @@ var platformV2TestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &platformV2TestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogPlatformService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &platformV2TestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogPlatformService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{
@@ -58,11 +59,12 @@ var platformV2TestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &platformV2TestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogPlatformService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &platformV2TestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogPlatformService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2_test.go
@@ -31,11 +31,12 @@ var xrayV2TestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &xrayV2TestServiceEndpointIDpassword,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogXrayService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &xrayV2TestServiceEndpointIDpassword,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogXrayService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{
@@ -58,11 +59,12 @@ var xrayV2TestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &xrayV2TestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("jfrogXrayService"),
-	Url:   converter.String("https://www.artifactory.com"),
+	Id:          &xrayV2TestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("jfrogXrayService"),
+	Url:         converter.String("https://www.artifactory.com"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
@@ -37,6 +37,7 @@ var kubernetesTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 	Owner:         converter.String("library"), // Supported values are "library", "agentcloud"
 	Type:          converter.String("kubernetes"),
 	Url:           converter.String("https://kubernetes.apiserver.com/"),
+	Description:   converter.String("description"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm_test.go
@@ -30,11 +30,12 @@ var npmTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Token"),
 	},
-	Id:    &npmTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("externalnpmregistry"),
-	Url:   converter.String("https://registry.npmjs.org"),
+	Id:          &npmTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("externalnpmregistry"),
+	Url:         converter.String("https://registry.npmjs.org"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline_test.go
@@ -34,11 +34,12 @@ var rpTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 	Data: &map[string]string{
 		"releaseUrl": "https://vsrm.dev.azure.com/example",
 	},
-	Id:    &rpTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("azdoapi"),
-	Url:   converter.String("https://dev.azure.com/example"),
+	Id:          &rpTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("azdoapi"),
+	Url:         converter.String("https://dev.azure.com/example"),
+	Description: converter.String("UNIT_TEST_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric_test.go
@@ -33,11 +33,12 @@ var serviceFabricTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("Certificate"),
 	},
-	Id:    &serviceFabricTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_NAME"),
-	Owner: converter.String("library"),
-	Type:  converter.String("servicefabric"),
-	Url:   converter.String("tcp://servicefabric.com"),
+	Id:          &serviceFabricTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_NAME"),
+	Owner:       converter.String("library"),
+	Type:        converter.String("servicefabric"),
+	Url:         converter.String("tcp://servicefabric.com"),
+	Description: converter.String("UNIT_TEST_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube_test.go
@@ -30,11 +30,12 @@ var sonarQubeTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},
-	Id:    &sonarQubeTestServiceEndpointID,
-	Name:  converter.String("UNIT_TEST_CONN_NAME"),
-	Owner: converter.String("library"), // Supported values are "library", "agentcloud"
-	Type:  converter.String("sonarqube"),
-	Url:   converter.String("https://www.sonarqube.com/"),
+	Id:          &sonarQubeTestServiceEndpointID,
+	Name:        converter.String("UNIT_TEST_CONN_NAME"),
+	Owner:       converter.String("library"), // Supported values are "library", "agentcloud"
+	Type:        converter.String("sonarqube"),
+	Url:         converter.String("https://www.sonarqube.com/"),
+	Description: converter.String("UNIT_TEST_CONN_DESCRIPTION"),
 	ServiceEndpointProjectReferences: &[]serviceendpoint.ServiceEndpointProjectReference{
 		{
 			ProjectReference: &serviceendpoint.ProjectReference{


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #823
Due to permission issues, the project reference may not returned if the PAT does not have the permission. Use the description from `response.description` instead of `response response.projectReference.0.description`

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->