### PR TITLE
[Bugfix] - `azuredevops_git_repository` - Set default branch for import repository

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -215,7 +215,6 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 			if err != nil {
 				return fmt.Errorf(" updating repository `default_branch`: %+v", err)
 			}
-
 		}
 	}
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #802
```log
=== RUN   TestAccGitRepo_CreateAndUpdate
=== PAUSE TestAccGitRepo_CreateAndUpdate
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
=== PAUSE TestAccGitRepo_Create_IncorrectInitialization
=== RUN   TestAccGitRepo_Create_Import
=== PAUSE TestAccGitRepo_Create_Import
=== RUN   TestAccGitRepo_RepoInitialization_Clean
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== RUN   TestAccGitRepo_PrivateImport_BranchNotEmpty
=== PAUSE TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepo_CreateAndUpdate
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_Create_Import
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (10.70s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (71.84s)
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (71.95s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (72.01s)
--- PASS: TestAccGitRepo_Create_Import (80.98s)
--- PASS: TestAccGitRepo_CreateAndUpdate (91.66s)
--- PASS: TestAccGitRepo_PrivateImport_BranchNotEmpty (94.53s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        96.336s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->