### PR TITLE
fix: azuredevops_git_permissions branch name tokenization

### DIFF
--- a/azuredevops/internal/service/permissions/resource_git_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions.go
@@ -3,7 +3,7 @@ package permissions
 import (
 	"fmt"
 	"log"
-	"strings"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -119,7 +119,9 @@ func createGitToken(d *schema.ResourceData, clients *client.AggregatedClient) (s
 		if !repoOk {
 			return "", fmt.Errorf("Unable to create ACL token for branch %s, because no repository is specified", branchName)
 		}
-		branchPath := strings.Split(branchName.(string), "/")
+
+		re := regexp.MustCompile(`(/?refs/heads/)?(.*)+`)
+		branchPath := re.FindStringSubmatch(branchName.(string))
 		branchName, err := converter.EncodeUtf16HexString(branchPath[len(branchPath)-1])
 		if err != nil {
 			return "", err

--- a/azuredevops/internal/service/permissions/resource_git_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions_test.go
@@ -30,6 +30,8 @@ var gitTokenRepository = fmt.Sprintf("%s/%s", gitTokenProject, gitRepositoryID)
 var gitTokenBranchAll = fmt.Sprintf("%s/refs/heads", gitTokenRepository)
 var gitBranchNameValid = "master"
 var gitTokenBranch = fmt.Sprintf("%s/refs/heads/%s", gitTokenRepository, encodeBranchName(gitBranchNameValid))
+var gitSubBranchNameValid = "release/1.0.0"
+var gitTokenSubBranch = fmt.Sprintf("%s/refs/heads/%s", gitTokenRepository, encodeBranchName(gitSubBranchNameValid))
 var gitBranchNameInValid = "@@invalid@@"
 
 func TestGitPermissions_CreateGitToken(t *testing.T) {
@@ -77,6 +79,24 @@ func TestGitPermissions_CreateGitTokenWithBranch(t *testing.T) {
 	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenBranch, token)
+
+	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "/refs/heads/"+gitBranchNameValid)
+	token, err = createGitToken(d, clients)
+	assert.NotEmpty(t, token)
+	assert.Nil(t, err)
+	assert.Equal(t, gitTokenBranch, token)
+
+	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitSubBranchNameValid)
+	token, err = createGitToken(d, clients)
+	assert.NotEmpty(t, token)
+	assert.Nil(t, err)
+	assert.Equal(t, gitTokenSubBranch, token)
+
+	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "refs/heads/"+gitSubBranchNameValid)
+	token, err = createGitToken(d, clients)
+	assert.NotEmpty(t, token)
+	assert.Nil(t, err)
+	assert.Equal(t, gitTokenSubBranch, token)
 }
 
 func encodeBranchName(branchName string) string {

--- a/azuredevops/internal/service/permissions/resource_git_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions_test.go
@@ -30,8 +30,8 @@ var gitTokenRepository = fmt.Sprintf("%s/%s", gitTokenProject, gitRepositoryID)
 var gitTokenBranchAll = fmt.Sprintf("%s/refs/heads", gitTokenRepository)
 var gitBranchNameValid = "master"
 var gitTokenBranch = fmt.Sprintf("%s/refs/heads/%s", gitTokenRepository, encodeBranchName(gitBranchNameValid))
-var gitSubBranchNameValid = "release/1.0.0"
-var gitTokenSubBranch = fmt.Sprintf("%s/refs/heads/%s", gitTokenRepository, encodeBranchName(gitSubBranchNameValid))
+var gitSubBranchNameValid = "1.0.0"
+var gitTokenSubBranch = fmt.Sprintf("%s/refs/heads/%s", gitTokenRepository, encodeBranchName(gitBranchNameValid)+"/"+encodeBranchName(gitSubBranchNameValid))
 var gitBranchNameInValid = "@@invalid@@"
 
 func TestGitPermissions_CreateGitToken(t *testing.T) {
@@ -86,13 +86,13 @@ func TestGitPermissions_CreateGitTokenWithBranch(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenBranch, token)
 
-	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitSubBranchNameValid)
+	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, gitBranchNameValid+"/"+gitSubBranchNameValid)
 	token, err = createGitToken(d, clients)
 	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
 	assert.Equal(t, gitTokenSubBranch, token)
 
-	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "refs/heads/"+gitSubBranchNameValid)
+	d = getGitPermissionsResource(t, gitProjectID, gitRepositoryID, "refs/heads/"+gitBranchNameValid+"/"+gitSubBranchNameValid)
 	token, err = createGitToken(d, clients)
 	assert.NotEmpty(t, token)
 	assert.Nil(t, err)


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

fix: azuredevops_git_permissions (for branches):
Allowing '/' in branches name (without excluding intermediate branch name segment
Therefore, permissions for branch_name "release/1.0.1" are assign to the correct branch (instead of 1.0.1)

Complementing tests: 
Previous code allowed the use of branch_name format like "/refs/heads/branch_name" or "refs/heads/branch_name"
Test has been complemented to ensure these format are allowed and treated correctly

Issue Number: (#841)

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

N/A


## Other information

Documentation doesn't need update as nothing indicate it shouldn't have worked