### PR TITLE
`azuredevops_pipeline_authorization` - Support `repository `authorization

### DIFF
--- a/website/docs/r/pipeline_authorization.html.markdown
+++ b/website/docs/r/pipeline_authorization.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 - `project_id` - (Required) The  ID of the project. Changing this forces a new resource to be created 
 - `resource_id` - (Required) The ID of the resource to authorize. Changing this forces a new resource to be created
-- `type` - (Required) The type of the resource to authorize. Valid values: `endpoint`, `queue`, `variablegroup`, `environment`. Changing this forces a new resource to be created
+- `type` - (Required) The type of the resource to authorize. Valid values: `endpoint`, `queue`, `variablegroup`, `environment`, `repository`. Changing this forces a new resource to be created
 
 ---
 - `pipeline_id` - (Optional) The ID of the pipeline. If not configured, all pipelines will be authorized. Changing this forces a new resource to be created.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #876 
```log
=== RUN   TestAccPipelineAuthorization_allPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipeline_queue
=== RUN   TestAccPipelineAuthorization_pipeline_queue
=== PAUSE TestAccPipelineAuthorization_pipeline_queue
=== RUN   TestAccPipelineAuthorization_multiPipeline_queue
=== PAUSE TestAccPipelineAuthorization_multiPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipeline_environment
=== PAUSE TestAccPipelineAuthorization_allPipeline_environment
=== RUN   TestAccPipelineAuthorization_pipeline_environment
=== PAUSE TestAccPipelineAuthorization_pipeline_environment
=== RUN   TestAccPipelineAuthorization_allPipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_allPipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_pipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_pipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_allPipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_allPipeline_endpoint
=== RUN   TestAccPipelineAuthorization_pipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_pipeline_endpoint
=== RUN   TestAccPipelineAuthorization_allPipeline_repository
=== PAUSE TestAccPipelineAuthorization_allPipeline_repository
=== RUN   TestAccPipelineAuthorization_pipeline_repository
=== PAUSE TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_pipeline_endpoint
=== CONT  TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_endpoint
=== CONT  TestAccPipelineAuthorization_allPipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== CONT  TestAccPipelineAuthorization_pipeline_environment
--- PASS: TestAccPipelineAuthorization_allPipeline_queue (61.73s)
=== CONT  TestAccPipelineAuthorization_allPipeline_environment
--- PASS: TestAccPipelineAuthorization_allPipeline_repository (62.83s)
=== CONT  TestAccPipelineAuthorization_pipeline_variableGroup
--- PASS: TestAccPipelineAuthorization_pipeline_repository (63.16s)
=== CONT  TestAccPipelineAuthorization_multiPipeline_queue
--- PASS: TestAccPipelineAuthorization_pipeline_environment (63.38s)
=== CONT  TestAccPipelineAuthorization_pipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipelineWithPipeline_queue (63.81s)
--- PASS: TestAccPipelineAuthorization_allPipeline_variableGroup (75.21s)
--- PASS: TestAccPipelineAuthorization_pipeline_endpoint (82.59s)
--- PASS: TestAccPipelineAuthorization_allPipeline_endpoint (82.68s)
--- PASS: TestAccPipelineAuthorization_allPipeline_environment (41.15s)
--- PASS: TestAccPipelineAuthorization_multiPipeline_queue (42.21s)
--- PASS: TestAccPipelineAuthorization_pipeline_queue (42.10s)
--- PASS: TestAccPipelineAuthorization_pipeline_variableGroup (67.81s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        135.971s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->