### PR TITLE
Don't use `is_secret` attribute for secrets in variable groups

### DIFF
--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -646,7 +646,6 @@ resource "azuredevops_variable_group" "vg" {
 	variable {
 		name      = "key1"
 		secret_value  = "value1"
-		is_secret = true
 	}
 
 	variable {

--- a/examples/azdo-based-cicd/main.tf
+++ b/examples/azdo-based-cicd/main.tf
@@ -65,7 +65,6 @@ resource "azuredevops_variable_group" "vg" {
   variable {
     name      = "key1"
     value     = "value1"
-    is_secret = true
   }
 
   variable {

--- a/website/docs/r/check_branch_control.html.markdown
+++ b/website/docs/r/check_branch_control.html.markdown
@@ -129,7 +129,6 @@ resource "azuredevops_variable_group" "example" {
   variable {
     name         = "key2"
     secret_value = "val2"
-    is_secret    = true
   }
 }
 

--- a/website/docs/r/check_business_hours.html.markdown
+++ b/website/docs/r/check_business_hours.html.markdown
@@ -145,7 +145,6 @@ resource "azuredevops_variable_group" "example" {
   variable {
     name         = "key2"
     secret_value = "val2"
-    is_secret    = true
   }
 }
 

--- a/website/docs/r/variable_group.html.markdown
+++ b/website/docs/r/variable_group.html.markdown
@@ -38,7 +38,6 @@ resource "azuredevops_variable_group" "example" {
   variable {
     name         = "key2"
     secret_value = "val2"
-    is_secret    = true
   }
 }
 ```
@@ -103,8 +102,10 @@ A `variable` block supports the following:
 
 - `name` - (Required) The key value used for the variable. Must be unique within the Variable Group.
 - `value` - (Optional) The value of the variable. If omitted, it will default to empty string.
-- `secret_value` - (Optional) The secret value of the variable. If omitted, it will default to empty string. Used when `is_secret` set to `true`.
+- `secret_value` - (Optional) The secret value of the variable. If omitted, it will default to empty string.
 - `is_secret` - (Optional) A boolean flag describing if the variable value is sensitive. Defaults to `false`.
+
+-> **Note:** This property has been deprecated and specifying `secret_value` is enough to designate the variable as secret.
 
 A `key_vault` block supports the following:
 


### PR DESCRIPTION
Because specifying the `secret_value` attribute is enough to designate the variable as secret.

## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->