### PR TITLE
[Bug] - `azuredevops_build_folder_permissions` Fixing bug where root folder permissions for builds would not be set

### DIFF
--- a/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
@@ -121,7 +121,7 @@ func createBuildFolderToken(d *schema.ResourceData, clients *client.AggregatedCl
 
 		aclToken = fmt.Sprintf("%s/%s", projectID.(string), transformedPath)
 	} else {
-		aclToken = fmt.Sprintf("%s/%s", projectID.(string), *Folder.Path)
+		aclToken = fmt.Sprintf("%s", projectID.(string))
 	}
 
 	return aclToken, nil

--- a/azuredevops/internal/service/permissions/resource_build_folder_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_build_folder_permissions_test.go
@@ -62,7 +62,7 @@ func TestBuildFolderPermissions_CreateBuildFolderToken(t *testing.T) {
 	token, err = createBuildFolderToken(d, clients)
 	assert.NotEmpty(t, token)
 	assert.Nil(t, err)
-	assert.Equal(t, "9083e944-8e9e-405e-960a-c80180aa71e6/\\", token)
+	assert.Equal(t, "9083e944-8e9e-405e-960a-c80180aa71e6", token)
 
 	d = getBuildFolderPermissionsResource(t, "", "")
 	token, err = createBuildFolderToken(d, clients)

--- a/website/docs/r/build_folder_permissions.html.markdown
+++ b/website/docs/r/build_folder_permissions.html.markdown
@@ -12,6 +12,7 @@ Manages permissions for a Build Folder
 ~> **Note** Permissions can be assigned to group principals and not to single user principals.
 
 ## Example Usage
+### Set specific folder permissions
 
 ```hcl
 resource "azuredevops_project" "example" {
@@ -53,6 +54,31 @@ resource "azuredevops_build_folder_permissions" "example" {
     "EditBuildDefinition":        "Deny",
     "DeleteBuildDefinition":      "Deny",
     "AdministerBuildPermissions": "NotSet"
+  }
+}
+```
+### Set root folder permissions
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+data "azuredevops_group" "example-readers" {
+  project_id = azuredevops_project.example.id
+  name       = "Readers"
+}
+
+resource "azuredevops_build_folder_permissions" "example" {
+  project_id = azuredevops_project.example.id
+  path       = "\\"
+  principal  = data.azuredevops_group.example-readers.id
+
+  permissions = {
+    "RetainIndefinitely": "Allow"
   }
 }
 ```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Root folder permissions for builds are now successfully set

Issue Number:
#860

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->