### PR TITLE
Make `agent_pool_id` optional in resource `azuredevops_agent_queue`

### DIFF
--- a/azuredevops/internal/service/taskagent/resource_agent_queue.go
+++ b/azuredevops/internal/service/taskagent/resource_agent_queue.go
@@ -93,10 +93,9 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 func expandAgentQueue(d *schema.ResourceData) (*taskagent.TaskAgentQueue, string, error) {
 	queue := &taskagent.TaskAgentQueue{}
 
-	poolId := converter.Int(d.Get(agentPoolID).(int))
-	if *poolId != 0 {
+	if v, exist := d.GetOk(agentPoolID); exist {
 		queue.Pool = &taskagent.TaskAgentPoolReference{
-			Id: poolId,
+			Id: converter.Int(v.(int)),
 		}
 	}
 

--- a/azuredevops/internal/service/taskagent/resource_agent_queue.go
+++ b/azuredevops/internal/service/taskagent/resource_agent_queue.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	agentQueueName                   = "name"
 	agentPoolID                      = "agent_pool_id"
 	projectID                        = "project_id"
 	invalidQueueIDErrorMessageFormat = "Queue ID was unexpectedly not a valid integer: %+v"
@@ -29,10 +30,21 @@ func ResourceAgentQueue() *schema.Resource {
 		Delete:   resourceAgentQueueDelete,
 		Importer: tfhelper.ImportProjectQualifiedResourceInteger(),
 		Schema: map[string]*schema.Schema{
+			agentQueueName: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				AtLeastOneOf:  []string{agentPoolID, agentQueueName},
+				ConflictsWith: []string{agentPoolID},
+			},
 			agentPoolID: {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				AtLeastOneOf:  []string{agentPoolID, agentQueueName},
+				ConflictsWith: []string{agentQueueName},
 			},
 			projectID: {
 				Type:             schema.TypeString,
@@ -52,14 +64,18 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error expanding the agent queue resource from state: %+v", err)
 	}
 
-	referencedPool, err := clients.TaskAgentClient.GetAgentPool(clients.Ctx, taskagent.GetAgentPoolArgs{
-		PoolId: queue.Pool.Id,
-	})
-	if err != nil {
-		return fmt.Errorf("Error looking up referenced agent pool: %+v", err)
+	if queue.Pool != nil {
+		referencedPool, err := clients.TaskAgentClient.GetAgentPool(clients.Ctx, taskagent.GetAgentPoolArgs{
+			PoolId: queue.Pool.Id,
+		})
+		if err != nil {
+			return fmt.Errorf("Error looking up referenced agent pool: %+v", err)
+		}
+		queue.Name = referencedPool.Name
+	} else {
+		queue.Name = converter.String(d.Get(agentQueueName).(string))
 	}
 
-	queue.Name = referencedPool.Name
 	createdQueue, err := clients.TaskAgentClient.AddAgentQueue(clients.Ctx, taskagent.AddAgentQueueArgs{
 		Queue:              queue,
 		Project:            &projectID,
@@ -75,10 +91,13 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func expandAgentQueue(d *schema.ResourceData) (*taskagent.TaskAgentQueue, string, error) {
-	queue := &taskagent.TaskAgentQueue{
-		Pool: &taskagent.TaskAgentPoolReference{
-			Id: converter.Int(d.Get(agentPoolID).(int)),
-		},
+	queue := &taskagent.TaskAgentQueue{}
+
+	poolId := converter.Int(d.Get(agentPoolID).(int))
+	if *poolId != 0 {
+		queue.Pool = &taskagent.TaskAgentPoolReference{
+			Id: poolId,
+		}
 	}
 
 	if d.Id() != "" {

--- a/website/docs/r/agent_queue.html.markdown
+++ b/website/docs/r/agent_queue.html.markdown
@@ -61,9 +61,9 @@ The following arguments are supported:
 - `project_id` - (Required) The ID of the project in which to create the resource.
 - `agent_pool_id` - (Optional) The ID of the organization agent pool. Conflicts with `name`.
 
-> **NOTE:**
-> One of `name` or `agent_pool_id` must be specified, but not both.
-> When `agent_pool_id` is specified, the agent queue name will be derived from the agent pool name.
+~> **NOTE:**
+    One of `name` or `agent_pool_id` must be specified, but not both.
+    When `agent_pool_id` is specified, the agent queue name will be derived from the agent pool name.
 
 ## Attributes Reference
 

--- a/website/docs/r/agent_queue.html.markdown
+++ b/website/docs/r/agent_queue.html.markdown
@@ -15,6 +15,8 @@ the `azuredevops_resource_authorization` resource can be used to grant authoriza
 
 ## Example Usage
 
+### Creating a Queue from an organization-level pool
+
 ```hcl
 resource "azuredevops_project" "example" {
   name = "Example Project"
@@ -38,12 +40,30 @@ resource "azuredevops_resource_authorization" "example" {
 }
 ```
 
+### Creating a Queue at the project level (Organization-level permissions not required)
+
+```hcl
+data "azuredevops_project" "example" {
+  name = "Example Project"
+}
+
+resource "azuredevops_agent_queue" "example" {
+  name          = "example-queue"
+  project_id    = data.azuredevops_project.example.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
+- `name` - (Optional) The name of the agent queue. Defaults to the ID of the agent pool. Conflicts with `agent_pool_id`.
 - `project_id` - (Required) The ID of the project in which to create the resource.
-- `agent_pool_id` - (Required) The ID of the organization agent pool.
+- `agent_pool_id` - (Optional) The ID of the organization agent pool. Conflicts with `name`.
+
+> **NOTE:**
+> One of `name` or `agent_pool_id` must be specified, but not both.
+> When `agent_pool_id` is specified, the agent queue name will be derived from the agent pool name.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Adds the attribute `name` to `azuredevops_agent_queue`, and make it mutually exclusive with the `agent_pool_id` attribute.

The API does not require a Pool ID to be specified when creating an Agent Queue, alternatively only a name needs to be specified.
In this scenario, the pool gets automatically created without explicitly requesting it. This is useful for creating agent pools at the project-level without needing org-level permissions to create pools.

Issue Number: #456 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is my first attempt at a PR for a terraform module and I'm pretty new at Go, so please let me know if I should have done anything differently!