### PR TITLE
Update documentation: WORK_ITEM_SAVE_COMMENT

### DIFF
--- a/website/docs/r/area_permissions.html.markdown
+++ b/website/docs/r/area_permissions.html.markdown
@@ -55,16 +55,17 @@ The following arguments are supported:
 * `path` - (Optional) The name of the branch to assign the permissions. 
 * `replace` - (Optional) Replace (`true`) or merge (`false`) the permissions. Default: `true`.
 
-| Permission         | Description                    |
-|--------------------|--------------------------------|
-| GENERIC_READ       | View permissions for this node |
-| GENERIC_WRITE      | Edit this node                 |
-| CREATE_CHILDREN    | Create child nodes             |
-| DELETE             | Delete this node               |
-| WORK_ITEM_READ     | View work items in this node   |
-| WORK_ITEM_WRITE    | Edit work items in this node   |
-| MANAGE_TEST_PLANS  | Manage test plans              |
-| MANAGE_TEST_SUITES | Manage test suites             |
+| Permission             | Description                          |
+|------------------------|--------------------------------------|
+| GENERIC_READ           | View permissions for this node       |
+| GENERIC_WRITE          | Edit this node                       |
+| CREATE_CHILDREN        | Create child nodes                   |
+| DELETE                 | Delete this node                     |
+| WORK_ITEM_READ         | View work items in this node         |
+| WORK_ITEM_WRITE        | Edit work items in this node         |
+| MANAGE_TEST_PLANS      | Manage test plans                    |
+| MANAGE_TEST_SUITES     | Manage test suites                   |
+| WORK_ITEM_SAVE_COMMENT | Edit work item comments in this node |
 
 ## Relevant Links
 


### PR DESCRIPTION
## All Submissions:
The WORK_ITEM_SAVE_COMMENT permission wasn't documented yet. Adding this permission through the area_permissions resource already works.

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
Nothing. The WORK_ITEM_SAVE_COMMENT permission wasn't documented yet.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
