### PR TITLE
feat: add attribute queue_status to resource azuredevops_build_definition

### DIFF
--- a/azuredevops/internal/service/build/data_build_definition.go
+++ b/azuredevops/internal/service/build/data_build_definition.go
@@ -272,6 +272,15 @@ func DataBuildDefinition() *schema.Resource {
 					},
 				},
 			},
+			"queue_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(build.DefinitionQueueStatusValues.Enabled),
+					string(build.DefinitionQueueStatusValues.Paused),
+					string(build.DefinitionQueueStatusValues.Disabled),
+				}, false),
+			},
 		},
 	}
 }

--- a/azuredevops/internal/service/build/data_build_definition.go
+++ b/azuredevops/internal/service/build/data_build_definition.go
@@ -275,11 +275,6 @@ func DataBuildDefinition() *schema.Resource {
 			"queue_status": {
 				Type:     schema.TypeString,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(build.DefinitionQueueStatusValues.Enabled),
-					string(build.DefinitionQueueStatusValues.Paused),
-					string(build.DefinitionQueueStatusValues.Disabled),
-				}, false),
 			},
 		},
 	}

--- a/website/docs/d/build_definition.html.markdown
+++ b/website/docs/d/build_definition.html.markdown
@@ -60,6 +60,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `variable_groups` - A list of variable group IDs.
 
+* `queue_status` - The queue status of the build definition.
+
 ---
 
 A `branch_filter` block exports the following:

--- a/website/docs/r/build_definition.html.markdown
+++ b/website/docs/r/build_definition.html.markdown
@@ -153,6 +153,7 @@ The following arguments are supported:
 - `variable_groups` - (Optional) A list of variable group IDs (integers) to link to the build definition.
 - `variable` - (Optional) A list of `variable` blocks, as documented below.
 - `features`- (Optional) A `features` blocks as documented below.
+- `queue_status`- (Optional) The queue status of the build definition. Valid values: `enabled` or `paused` or `disabled`. Defaults to `enabled`.
 
 ---
 `features` block supports the following:


### PR DESCRIPTION

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

added `queue_status` as new attribute in resource `azuredevops_build_definition` to enable the use to configure the setting of the pipeline. Prior the pipeline was always `enabled`. With this PR `enabled` is the default and additional `paused` and `disabled` are allowed to be set too.

Issue Number: #915

closes #915

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->