### PR TITLE
[Bug Fix] - `azuredevops_git_repository_file`- apply for non-project resources fails

### DIFF
--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -219,8 +219,6 @@ func projectRead(clients *client.AggregatedClient, projectID string, projectName
 	}
 
 	var project *core.TeamProject
-	var err error
-
 	stateConf := &resource.StateChangeConf{
 		ContinuousTargetOccurence: 1,
 		Delay:                     5 * time.Second,
@@ -245,15 +243,12 @@ func projectRead(clients *client.AggregatedClient, projectID string, projectName
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return project, fmt.Errorf(" waiting for project ready. %v ", err)
-	}
-
-	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			return nil, err
 		}
 		return nil, fmt.Errorf(" Project not found. (ID: %s or name: %s), Error: %+v", projectID, projectName, err)
 	}
+
 	return project, nil
 }
 

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -167,6 +167,17 @@ func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error 
 	repoId, file := splitRepoFilePath(d.Id())
 	branch := d.Get("branch").(string)
 
+	_, err := clients.GitReposClient.GetRepository(ctx, git.GetRepositoryArgs{
+		RepositoryId: &repoId,
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf(" Repository not found, repositoryID: %s. Error:  %+v", repoId, err)
+	}
+
 	if err := checkRepositoryBranchExists(clients, repoId, branch); err != nil {
 		return err
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->