### PR TITLE
[Bug - Fix] `azuredevops_build_definition` - `skip_first_run` to work for all repo types

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -387,7 +387,7 @@ func resourceBuildDefinitionCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating resource Build Definition: %+v", err)
 	}
 
-	var diags diag.Diagnostics
+	var diags diag.Diagnostics = nil
 	features := buildDefinitionFeatures(d)
 	if features != nil && len(features) != 0 {
 		if v, ok := features["skip_first_run"]; ok {
@@ -418,7 +418,7 @@ func resourceBuildDefinitionCreate(ctx context.Context, d *schema.ResourceData, 
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Warning,
 						Summary:  "First run of build definition failed, nothing to trigger",
-						Detail:   fmt.Sprintf("Recieved error: %s\n Try initializing the repository with a valid build definition file", err),
+						Detail:   fmt.Sprintf("Received error: %s\n Try initializing the repository with a valid build definition file", err),
 					})
 				}
 			}
@@ -431,7 +431,7 @@ func resourceBuildDefinitionCreate(ctx context.Context, d *schema.ResourceData, 
 	if readDiag != nil {
 		return readDiag
 	} else {
-		return append(diags, readDiag...)
+		return diags
 	}
 }
 

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -413,7 +413,6 @@ func resourceBuildDefinitionCreate(d *schema.ResourceData, m interface{}) error 
 				if err != nil {
 					return fmt.Errorf(" queue pipeline first run failed: %+v", err)
 				}
-
 			}
 		}
 	}

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -418,7 +418,7 @@ func resourceBuildDefinitionCreate(ctx context.Context, d *schema.ResourceData, 
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Warning,
 						Summary:  "First run of build definition failed, nothing to trigger",
-						Detail:   "Try initializing the repository with a valid build definition file",
+						Detail:   fmt.Sprintf("Recieved error: %s\n Try initializing the repository with a valid build definition file", err),
 					})
 				}
 			}

--- a/azuredevops/internal/service/build/resource_build_definition_test.go
+++ b/azuredevops/internal/service/build/resource_build_definition_test.go
@@ -348,13 +348,13 @@ func TestBuildDefinition_ValidatesServiceConnection_Bitbucket(t *testing.T) {
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
 	clients := &client.AggregatedClient{BuildClient: buildClient, Ctx: context.Background()}
 
-	err := resourceBuildDefinitionCreate(resourceData, clients)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "bitbucket repositories need a referenced service connection ID")
+	diags := resourceBuildDefinitionCreate(context.Background(), resourceData, clients)
+	require.NotNil(t, diags)
+	require.Contains(t, diags[len(diags)-1].Summary, "bitbucket repositories need a referenced service connection ID")
 
-	err = resourceBuildDefinitionUpdate(resourceData, clients)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "bitbucket repositories need a referenced service connection ID")
+	diags = resourceBuildDefinitionUpdate(context.Background(), resourceData, clients)
+	require.NotNil(t, diags)
+	require.Contains(t, diags[len(diags)-1].Summary, "bitbucket repositories need a referenced service connection ID")
 }
 
 // verifies that a service connection is required for GitHub Enterprise repos
@@ -369,13 +369,13 @@ func TestBuildDefinition_ValidatesServiceConnection_GitHubEnterprise(t *testing.
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
 	clients := &client.AggregatedClient{BuildClient: buildClient, Ctx: context.Background()}
 
-	err := resourceBuildDefinitionCreate(resourceData, clients)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "GitHub Enterprise repositories need a referenced service connection ID")
+	diags := resourceBuildDefinitionCreate(context.Background(), resourceData, clients)
+	require.NotNil(t, diags)
+	require.Contains(t, diags[len(diags)-1].Summary, "GitHub Enterprise repositories need a referenced service connection ID")
 
-	err = resourceBuildDefinitionUpdate(resourceData, clients)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "GitHub Enterprise repositories need a referenced service connection ID")
+	diags = resourceBuildDefinitionUpdate(context.Background(), resourceData, clients)
+	require.NotNil(t, diags)
+	require.Contains(t, diags[len(diags)-1].Summary, "GitHub Enterprise repositories need a referenced service connection ID")
 }
 
 // verifies that create a build definition with Bitbucket and CI triggers
@@ -396,8 +396,8 @@ func TestAzureDevOpsBuildDefinition_CITriggers_Bitbucket(t *testing.T) {
 		CreateDefinition(clients.Ctx, expectedArgs).
 		Return(nil, errors.New("CreateDefinition() Failed")).
 		Times(1)
-	err := resourceBuildDefinitionCreate(resourceData, clients)
-	require.Contains(t, err.Error(), "CreateDefinition() Failed")
+	diags := resourceBuildDefinitionCreate(context.Background(), resourceData, clients)
+	require.Contains(t, diags[len(diags)-1].Summary, "CreateDefinition() Failed")
 }
 
 // verifies that create a build definition with GitHub Enterprise and CI triggers
@@ -418,8 +418,8 @@ func TestAzureDevOpsBuildDefinition_CITriggers_GitHubEnterprise(t *testing.T) {
 		CreateDefinition(clients.Ctx, expectedArgs).
 		Return(nil, errors.New("CreateDefinition() Failed")).
 		Times(1)
-	err := resourceBuildDefinitionCreate(resourceData, clients)
-	require.Contains(t, err.Error(), "CreateDefinition() Failed")
+	diags := resourceBuildDefinitionCreate(context.Background(), resourceData, clients)
+	require.Contains(t, diags[len(diags)-1].Summary, "CreateDefinition() Failed")
 }
 
 // verifies that the flatten/expand round trip yields the same build definition
@@ -462,8 +462,8 @@ func TestBuildDefinition_Create_DoesNotSwallowError(t *testing.T) {
 		Return(nil, errors.New("CreateDefinition() Failed")).
 		Times(1)
 
-	err := resourceBuildDefinitionCreate(resourceData, clients)
-	require.Contains(t, err.Error(), "CreateDefinition() Failed")
+	diags := resourceBuildDefinitionCreate(context.Background(), resourceData, clients)
+	require.Contains(t, diags[len(diags)-1].Summary, "CreateDefinition() Failed")
 }
 
 // verifies that if an error is produced on a read, it is not swallowed
@@ -484,8 +484,8 @@ func TestBuildDefinition_Read_DoesNotSwallowError(t *testing.T) {
 		Return(nil, errors.New("GetDefinition() Failed")).
 		Times(1)
 
-	err := resourceBuildDefinitionRead(resourceData, clients)
-	require.Equal(t, "GetDefinition() Failed", err.Error())
+	diags := resourceBuildDefinitionRead(context.Background(), resourceData, clients)
+	require.Equal(t, "GetDefinition() Failed", diags[len(diags)-1].Summary)
 }
 
 // verifies that if an error is produced on a delete, it is not swallowed
@@ -506,8 +506,8 @@ func TestBuildDefinition_Delete_DoesNotSwallowError(t *testing.T) {
 		Return(errors.New("DeleteDefinition() Failed")).
 		Times(1)
 
-	err := resourceBuildDefinitionDelete(resourceData, clients)
-	require.Equal(t, "DeleteDefinition() Failed", err.Error())
+	diags := resourceBuildDefinitionDelete(context.Background(), resourceData, clients)
+	require.Equal(t, "DeleteDefinition() Failed", diags[len(diags)-1].Summary)
 }
 
 // verifies that if an error is produced on an update, it is not swallowed
@@ -533,8 +533,8 @@ func TestBuildDefinition_Update_DoesNotSwallowError(t *testing.T) {
 		Return(nil, errors.New("UpdateDefinition() Failed")).
 		Times(1)
 
-	err := resourceBuildDefinitionUpdate(resourceData, clients)
-	require.Equal(t, "UpdateDefinition() Failed", err.Error())
+	diags := resourceBuildDefinitionUpdate(context.Background(), resourceData, clients)
+	require.Equal(t, "UpdateDefinition() Failed", diags[len(diags)-1].Summary)
 }
 
 func TestExpandVariables_CatchesDuplicateVariables(t *testing.T) {

--- a/website/docs/r/build_definition.html.markdown
+++ b/website/docs/r/build_definition.html.markdown
@@ -160,7 +160,7 @@ The following arguments are supported:
 
   - `skip_first_run` (Optional) Trigger the pipeline to run after the creation. Defaults to `true`.
   
-  ~> **Note** The first run(`skip_first_run = false`) will only be triggered on create.
+  ~> **Note** The first run(`skip_first_run = false`) will only be triggered on create. If the first run fails, the build definition will still be marked as successfully created. A warning message indicating the inability to run pipeline will be displayed.
 
 ---
 `variable` block supports the following:


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #862

The code is using `clients.GitReposClient` which I bealive is working only with DevOps Git Repos.
When I pass repoId in GitHub format (gitOrg/repoName), it's throwing error "Page not found".

As far as I can see from the code, we need the branch information for passing `commitId` to `version` property in RunPipeline request. After few tests in DevOps UI and with Rest API directly, it looks like `version` is not required. So we can ommit that which will allow to remove the code with `GitReposClient` which was causing the code to work with only Azure DevOps Repos.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->