### PR TITLE
`azuredevops_pipeline_authorization` - Add retry for pipeline authorization

### DIFF
--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -18,7 +18,12 @@ func ResourcePipelineAuthorization() *schema.Resource {
 		Create: resourcePipelineAuthorizationCreateUpdate,
 		Read:   resourcePipelineAuthorizationRead,
 		Delete: resourcePipelineAuthorizationDelete,
-
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Read:   schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -3,7 +3,9 @@ package build
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/pipelinepermissions"
@@ -82,6 +84,22 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	if err != nil {
 		return fmt.Errorf(" creating authorized resource: %+v", err)
 	}
+
+	// ensure authorization is complete
+	stateConf := &resource.StateChangeConf{
+		ContinuousTargetOccurence: 1,
+		Delay:                     5 * time.Second,
+		MinTimeout:                10 * time.Second,
+		Pending:                   []string{"waiting"},
+		Target:                    []string{"succeed", "failed"},
+		Refresh:                   checkPipelineAuthorization(clients, d),
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
+		return fmt.Errorf(" waiting for pipeline authorization ready. %v ", err)
+	}
+
 	d.SetId(*response.Resource.Id)
 
 	return resourcePipelineAuthorizationRead(d, m)
@@ -174,4 +192,47 @@ func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 	}
 
 	return nil
+}
+
+func checkPipelineAuthorization(clients *client.AggregatedClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		projectId := d.Get("project_id").(string)
+		resourceType := d.Get("type").(string)
+		resourceId := d.Get("resource_id").(string)
+
+		if strings.EqualFold(resourceType, "repository") {
+			resourceId = projectId + "." + resourceId
+		}
+
+		resp, err := clients.PipelinePermissionsClient.GetPipelinePermissionsForResource(clients.Ctx,
+			pipelinepermissions.GetPipelinePermissionsForResourceArgs{
+				Project:      &projectId,
+				ResourceType: &resourceType,
+				ResourceId:   &resourceId,
+			},
+		)
+		if err != nil {
+			return nil, "failed", err
+		}
+
+		// check pipeline authorization if pipeline_id exist
+		if pipeId, ok := d.GetOk("pipeline_id"); ok {
+			if resp.Pipelines != nil && len(*resp.Pipelines) > 0 {
+				for _, pipe := range *resp.Pipelines {
+					if *pipe.Id == pipeId.(int) {
+						return resp, "succeed", err
+					}
+				}
+				return nil, "waiting", err
+			}
+		} else {
+			// check all pipeline authorization
+			if resp.AllPipelines != nil && resp.AllPipelines.Authorized != nil && *resp.AllPipelines.Authorized {
+				return resp, "succeed", err
+			}
+			return nil, "waiting", err
+		}
+
+		return resp, "succeed", nil
+	}
 }


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #875 
```log
=== RUN   TestAccPipelineAuthorization_allPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipeline_queue
=== RUN   TestAccPipelineAuthorization_pipeline_queue
=== PAUSE TestAccPipelineAuthorization_pipeline_queue
=== RUN   TestAccPipelineAuthorization_multiPipeline_queue
=== PAUSE TestAccPipelineAuthorization_multiPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipeline_environment
=== PAUSE TestAccPipelineAuthorization_allPipeline_environment
=== RUN   TestAccPipelineAuthorization_pipeline_environment
=== PAUSE TestAccPipelineAuthorization_pipeline_environment
=== RUN   TestAccPipelineAuthorization_allPipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_allPipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_pipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_pipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_allPipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_allPipeline_endpoint
=== RUN   TestAccPipelineAuthorization_pipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_pipeline_endpoint
=== RUN   TestAccPipelineAuthorization_allPipeline_repository
=== PAUSE TestAccPipelineAuthorization_allPipeline_repository
=== RUN   TestAccPipelineAuthorization_pipeline_repository
=== PAUSE TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_pipeline_endpoint
=== CONT  TestAccPipelineAuthorization_pipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_allPipeline_endpoint
=== CONT  TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== CONT  TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_repository
--- PASS: TestAccPipelineAuthorization_pipeline_repository (66.39s)
=== CONT  TestAccPipelineAuthorization_pipeline_environment
--- PASS: TestAccPipelineAuthorization_allPipelineWithPipeline_queue (67.35s)
=== CONT  TestAccPipelineAuthorization_allPipeline_environment
--- PASS: TestAccPipelineAuthorization_allPipeline_repository (77.23s)
=== CONT  TestAccPipelineAuthorization_multiPipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipeline_queue (77.59s)
=== CONT  TestAccPipelineAuthorization_pipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipeline_variableGroup (82.53s)
--- PASS: TestAccPipelineAuthorization_pipeline_variableGroup (84.32s)
--- PASS: TestAccPipelineAuthorization_allPipeline_endpoint (88.07s)
--- PASS: TestAccPipelineAuthorization_pipeline_endpoint (89.57s)
--- PASS: TestAccPipelineAuthorization_allPipeline_environment (48.95s)
--- PASS: TestAccPipelineAuthorization_pipeline_environment (50.09s)
--- PASS: TestAccPipelineAuthorization_multiPipeline_queue (49.04s)
--- PASS: TestAccPipelineAuthorization_pipeline_queue (48.86s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        131.197s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->