### PR TITLE
Add Data_sources for on-premise User and Group(s)

### DIFF
--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -22,7 +22,7 @@ func testIdentityGroupDataSource(t *testing.T, groupName string) {
 				Config: createIdentityGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
-					resource.TestCheckResourceAttr(tfNode, "name", groupName),
+					resource.TestCheckResourceAttr(tfNode, "name", "[default]\\Contributors"),
 				),
 			},
 		},
@@ -37,12 +37,12 @@ data "azuredevops_project" "project" {
 }
 
 data "azuredevops_identity_group" "test" {
-	name       = "%[1]s"
+	name       = "[default]\\%[1]s"
 	project_id = data.azuredevops_project.project.id
 }`, groupName)
 }
 
 func TestAccIdentityGroupDataSource(t *testing.T) {
-	groupName := "[default]\\\\Contributors"
+	groupName := "Contributors"
 	testIdentityGroupDataSource(t, groupName)
 }

--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -32,13 +32,17 @@ func testIdentityGroupDataSource(t *testing.T, groupName string) {
 func createIdentityGroupConfig(groupName string) string {
 	return fmt.Sprintf(
 		`
-data "azuredevops_project" "project" {
-	name = "default"
+resource "azuredevops_project" "test" {
+	name               = "%[1]s"
+	work_item_template = "Agile"
+	version_control    = "Git"
+	visibility         = "private"
+	description        = "Managed by Terraform"
 }
 
 data "azuredevops_identity_group" "test" {
 	name       = "[default]\\%[1]s"
-	project_id = data.azuredevops_project.project.id
+	project_id = azuredevops_project.test.id
 }`, groupName)
 }
 

--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -1,0 +1,48 @@
+//go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
+// +build all core data_sources data_group
+// +build !exclude_data_sources !exclude_data_group
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func testIdentityGroupDataSource(t *testing.T, groupName string) {
+	tfNode := "data.azuredevops_identity_group.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: createIdentityGroupConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "name", groupName),
+				),
+			},
+		},
+	})
+}
+
+func createIdentityGroupConfig(groupName string) string {
+	return fmt.Sprintf(
+		`
+data "azuredevops_project" "project" {
+	name = "default"
+}
+
+data "azuredevops_identity_group" "test" {
+	name       = "%[1]s"
+	project_id = data.azuredevops_project.project.id
+}`, groupName)
+}
+
+func TestAccIdentityGroupDataSource(t *testing.T) {
+	groupName := "[default]\\\\Contributors"
+	testIdentityGroupDataSource(t, groupName)
+}

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -1,0 +1,46 @@
+//go:build (all || core || data_sources || data_groups) && (!exclude_data_sources || !exclude_data_groups)
+// +build all core data_sources data_groups
+// +build !exclude_data_sources !exclude_data_groups
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func generateIdentityGroupsDataSourceConfig(projectName string) string {
+	return fmt.Sprintf(`
+data "azuredevops_project" "project" {
+	name = "%[1]s"
+}
+
+data "azuredevops_identity_groups" "groups" {
+	project_id = data.azuredevops_project.project.id
+}
+`, projectName)
+}
+
+func testIdentityGroupsDataSource(t *testing.T, projectName string) {
+	tfNode := "data.azuredevops_identity_groups.groups"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: generateIdentityGroupsDataSourceConfig(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityGroupsDataSource(t *testing.T) {
+	projectName := "default"
+	testIdentityGroupsDataSource(t, projectName)
+}

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -29,7 +29,7 @@ data "azuredevops_identity_groups" "test" {
 }
 
 func testIdentityGroupsDataSource(t *testing.T, projectName string) {
-	tfNode := "data.azuredevops_identity_groups.groups"
+	tfNode := "data.azuredevops_identity_groups.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testutils.PreCheck(t, nil) },
 		Providers: testutils.GetProviders(),
@@ -46,6 +46,6 @@ func testIdentityGroupsDataSource(t *testing.T, projectName string) {
 }
 
 func TestAccIdentityGroupsDataSource(t *testing.T) {
-	projectName := "default"
+	projectName := testutils.GenerateResourceName()
 	testIdentityGroupsDataSource(t, projectName)
 }

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -34,6 +34,7 @@ func testIdentityGroupsDataSource(t *testing.T, projectName string) {
 				Config: generateIdentityGroupsDataSourceConfig(projectName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "groups.#"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -14,12 +14,16 @@ import (
 
 func generateIdentityGroupsDataSourceConfig(projectName string) string {
 	return fmt.Sprintf(`
-data "azuredevops_project" "project" {
-	name = "%[1]s"
+resource "azuredevops_project" "test" {
+	name               = "%[1]s"
+	work_item_template = "Agile"
+	version_control    = "Git"
+	visibility         = "private"
+	description        = "Managed by Terraform"
 }
 
-data "azuredevops_identity_groups" "groups" {
-	project_id = data.azuredevops_project.project.id
+data "azuredevops_identity_groups" "test" {
+	project_id = azuredevops_project.test.id
 }
 `, projectName)
 }

--- a/azuredevops/internal/acceptancetests/data_identity_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_users_test.go
@@ -1,0 +1,39 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func createIdentityUsersDataSourceConfig(userName string) string {
+	return fmt.Sprintf(
+		`
+data "azuredevops_identity_user" "test" {
+	name       = "%[1]s"
+}`, userName)
+}
+
+func testIdentityUsersDataSource(t *testing.T, userName string) {
+	tfNode := "data.azuredevops_identity_user.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: createIdentityUsersDataSourceConfig(userName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "name", userName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityUsersDataSource(t *testing.T) {
+	userName := "dummy user"
+	testIdentityUsersDataSource(t, userName)
+}

--- a/azuredevops/internal/acceptancetests/data_identity_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_users_test.go
@@ -34,6 +34,6 @@ func testIdentityUsersDataSource(t *testing.T, userName string) {
 }
 
 func TestAccIdentityUsersDataSource(t *testing.T) {
-	userName := "dummy user"
+	userName := "tfsdev install"
 	testIdentityUsersDataSource(t, userName)
 }

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -13,7 +13,7 @@ import (
 // DataGroup schema and implementation for group data source
 func DataIdentityGroup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataIdentitySourceGroupRead,
+		Read: dataSourceIdentityGroupRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -33,7 +33,7 @@ func DataIdentityGroup() *schema.Resource {
 	}
 }
 
-func dataIdentitySourceGroupRead(d *schema.ResourceData, m interface{}) error {
+func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	groupName, projectID := d.Get("name").(string), d.Get("project_id").(string)
 

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -53,7 +53,7 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	// Set ID and descriptor for group data resource based on targetGroup output.
 	targetGroupID := targetGroup.Id.String()
 	d.SetId(targetGroupID)
-	d.Set("descriptor", targetGroup.Id)
+	d.Set("descriptor", targetGroupID)
 	return nil
 }
 

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 )
 
-// DataGroup schema and implementation for group data source
+// DataIdentityGroup returns the schema and implementation for the group data source
 func DataIdentityGroup() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceIdentityGroupRead,
@@ -35,10 +35,11 @@ func DataIdentityGroup() *schema.Resource {
 
 func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
-	groupName, projectID := d.Get("name").(string), d.Get("project_id").(string)
+	groupName := d.Get("name").(string)
+	projectID := d.Get("project_id").(string)
 
-	// Get groups in specified project id
-	projectGroups, err := getIdentityGroupsWithprojectID(clients, projectID)
+	// Get groups in specified project ID
+	projectGroups, err := getIdentityGroupsWithProjectID(clients, projectID)
 	if err != nil {
 		errMsg := "Error finding groups"
 		if projectID != "" {
@@ -47,9 +48,8 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("%s. Error: %v", errMsg, err)
 	}
 
-	// select specific group by name/provider name.
-	// Use projectGroups (groups listed in project) and groupName (name provided by data source invoke).
-	targetGroup := selectIdentityGroup(projectGroups, groupName)
+	// Select specific group by name/provider name.
+	targetGroup := selectIdentityGroup(&projectGroups, groupName)
 	if targetGroup == nil {
 		errMsg := fmt.Sprintf("Could not find group with name %s", groupName)
 		if projectID != "" {
@@ -58,9 +58,9 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf(errMsg)
 	}
 
-	// Set id and descriptor for group data resource based on targetGroup output.
-	targetGroupstring := targetGroup.Id.String()
-	d.SetId(targetGroupstring)
+	// Set ID and descriptor for group data resource based on targetGroup output.
+	targetGroupID := targetGroup.Id.String()
+	d.SetId(targetGroupID)
 	d.Set("descriptor", targetGroup.Id)
 	return nil
 }

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -1,0 +1,81 @@
+package identity
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// DataGroup schema and implementation for group data source
+func DataIdentityGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataIdentitySourceGroupRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"project_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"descriptor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataIdentitySourceGroupRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	groupName, projectID := d.Get("name").(string), d.Get("project_id").(string)
+
+	projectGroups, err := getIdentityGroupsWithProjectDescriptor(clients, projectID)
+	if err != nil {
+		errMsg := "Error finding groups"
+		if projectID != "" {
+			errMsg = fmt.Sprintf("%s for project with ID %s", errMsg, projectID)
+		}
+		return fmt.Errorf("%s. Error: %v", errMsg, err)
+	}
+
+	targetGroup := selectIdentityGroup(projectGroups, groupName)
+	if targetGroup == nil {
+		errMsg := fmt.Sprintf("Could not find group with name %s", groupName)
+		if projectID != "" {
+			errMsg = fmt.Sprintf("%s in project with ID %s", errMsg, projectID)
+		}
+		return fmt.Errorf(errMsg)
+	}
+
+	d.SetId(*targetGroup.Descriptor)
+	d.Set("descriptor", targetGroup.Descriptor)
+	return nil
+}
+
+func getIdentityGroupsWithProjectDescriptor(clients *client.AggregatedClient, projectDescriptor string) (*[]identity.Identity, error) {
+	response, err := clients.IdentityClient.ListGroups(clients.Ctx, identity.ListGroupsArgs{
+		ScopeIds: &projectDescriptor,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func selectIdentityGroup(groups *[]identity.Identity, groupName string) *identity.Identity {
+	for _, group := range *groups {
+		if strings.EqualFold(*group.ProviderDisplayName, groupName) {
+			return &group
+		}
+	}
+	return nil
+}

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -17,15 +17,15 @@ func DataIdentityGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"project_id": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
-			"id": {
+			"descriptor": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -41,21 +41,13 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	// Get groups in specified project ID
 	projectGroups, err := getIdentityGroupsWithProjectID(clients, projectID)
 	if err != nil {
-		errMsg := "Error finding groups"
-		if projectID != "" {
-			errMsg = fmt.Sprintf("%s for project with ID %s", errMsg, projectID)
-		}
-		return fmt.Errorf("%s. Error: %v", errMsg, err)
+		return fmt.Errorf(" failed to get groups for project with ID: %s. Error: %v", projectID, err)
 	}
 
 	// Select specific group by name/provider name.
 	targetGroup := selectIdentityGroup(&projectGroups, groupName)
 	if targetGroup == nil {
-		errMsg := fmt.Sprintf("Could not find group with name %s", groupName)
-		if projectID != "" {
-			errMsg = fmt.Sprintf("%s in project with ID %s", errMsg, projectID)
-		}
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf(" can not find group with name %s in project with ID %s", groupName, projectID)
 	}
 
 	// Set ID and descriptor for group data resource based on targetGroup output.

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -23,7 +23,7 @@ func DataIdentityGroup() *schema.Resource {
 			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotWhiteSpace,
+				ValidateFunc: validation.IsUUID,
 			},
 			"descriptor": {
 				Type:     schema.TypeString,
@@ -53,7 +53,7 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	// Set ID and descriptor for group data resource based on targetGroup output.
 	targetGroupID := targetGroup.Id.String()
 	d.SetId(targetGroupID)
-	d.Set("descriptor", targetGroupID)
+	d.Set("descriptor", targetGroup.Descriptor)
 	return nil
 }
 

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -1,0 +1,128 @@
+//go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
+// +build all core data_sources data_group
+// +build !exclude_data_sources !exclude_data_group
+
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+)
+
+// A helper type that is used in some of these tests to make initializing
+// identity entities easier
+type groupMeta struct {
+	name       string
+	descriptor string
+	domain     string
+	origin     string
+	originId   string
+}
+
+// verifies that the translation for project_id to project_descriptor has proper error handling
+func TestIdentityGroupDataSource_DoesNotSwallowProjectDescriptorLookupError_Generic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createResourceData(t, projectID.String(), "group-name")
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("ListGroups() Failed"))
+
+	err := dataSourceIdentityGroupRead(resourceData, clients)
+	require.Contains(t, err.Error(), "ListGroups() Failed")
+}
+
+// verifies that the translation for project_id to project_descriptor has proper error handling
+func TestIdentityGroupDataSource_DoesNotSwallowProjectDescriptorLookupError_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createResourceData(t, projectID.String(), "group-name")
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedArgs).
+		Return(nil, azuredevops.WrappedError{
+			StatusCode: converter.Int(404),
+		})
+
+	err := dataSourceIdentityGroupRead(resourceData, clients)
+	require.Contains(t, err.Error(), "was not found")
+}
+
+// verifies that the group lookup functionality has proper error handling
+func TestIdentityGroupDataSource_DoesNotSwallowListGroupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createResourceData(t, projectID.String(), "group-name")
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedProjectDescriptorLookupArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	projectDescriptor := converter.String("descriptor")
+	projectDescriptorResponse := identity.Identity{Descriptor: projectDescriptor}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedProjectDescriptorLookupArgs).
+		Return(&projectDescriptorResponse, nil)
+
+	expectedListGroupArgs := identity.ListGroupsArgs{ScopeIds: projectDescriptor}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedListGroupArgs).
+		Return(nil, errors.New("ListGroups() Failed"))
+
+	err := dataSourceIdentityGroupRead(resourceData, clients)
+	require.Contains(t, err.Error(), "ListGroups() Failed")
+}
+
+func createGroupsWithDescriptors(groups ...groupMeta) *[]identity.Identity {
+	var identitys []identity.Identity
+	for _, group := range groups {
+		identitys = append(identitys, identity.Identity{
+			Descriptor:          converter.String(group.descriptor),
+			ProviderDisplayName: converter.String(group.name),
+		})
+	}
+
+	return &identitys
+}
+
+func createResourceData(t *testing.T, projectID string, groupName string) *schema.ResourceData {
+	resourceData := schema.TestResourceDataRaw(t, DataIdentityGroup().Schema, nil)
+	resourceData.Set("name", groupName)
+	if projectID != "" {
+		resourceData.Set("project_id", projectID)
+	}
+	return resourceData
+}

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -66,18 +66,6 @@ func TestIdentityGroupDataSource_ProjectDescriptorLookupErrorNotFound(t *testing
 	require.Contains(t, err.Error(), "Error finding groups")
 }
 
-func createIdentityGroups(groups ...groupMeta) *[]identity.Identity {
-	var identities []identity.Identity
-	for _, group := range groups {
-		identities = append(identities, identity.Identity{
-			Descriptor:          converter.String(group.descriptor),
-			ProviderDisplayName: converter.String(group.name),
-		})
-	}
-
-	return &identities
-}
-
 func createIdentityGroupDataSource(t *testing.T, projectID string, groupName string) *schema.ResourceData {
 	resourceData := schema.TestResourceDataRaw(t, DataIdentityGroup().Schema, nil)
 	resourceData.Set("name", groupName)

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -16,14 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type groupMeta struct {
-	name       string
-	descriptor string
-	domain     string
-	origin     string
-	originId   string
-}
-
 func TestIdentityGroupDataSource_ProjectDescriptorLookupError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -73,7 +73,7 @@ func TestIdentityGroupDataSource_DoesNotSwallowProjectDescriptorLookupError_NotF
 		})
 
 	err := dataSourceIdentityGroupRead(resourceData, clients)
-	require.Contains(t, err.Error(), "was not found")
+	require.Contains(t, err.Error(), "Error finding groups")
 }
 
 // verifies that the group lookup functionality has proper error handling
@@ -90,7 +90,7 @@ func TestIdentityGroupDataSource_DoesNotSwallowListGroupError(t *testing.T) {
 
 	expectedProjectDescriptorLookupArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
 	projectDescriptor := converter.String("descriptor")
-	projectDescriptorResponse := identity.Identity{Descriptor: projectDescriptor}
+	projectDescriptorResponse := []identity.Identity{{Descriptor: projectDescriptor}}
 	identityClient.
 		EXPECT().
 		ListGroups(clients.Ctx, expectedProjectDescriptorLookupArgs).
@@ -106,16 +106,16 @@ func TestIdentityGroupDataSource_DoesNotSwallowListGroupError(t *testing.T) {
 	require.Contains(t, err.Error(), "ListGroups() Failed")
 }
 
-func createGroupsWithDescriptors(groups ...groupMeta) *[]identity.Identity {
-	var identitys []identity.Identity
+func createIdentityGroupsWithDescriptors(groups ...groupMeta) *[]identity.Identity {
+	var Identity []identity.Identity
 	for _, group := range groups {
-		identitys = append(identitys, identity.Identity{
+		Identity = append(Identity, identity.Identity{
 			Descriptor:          converter.String(group.descriptor),
 			ProviderDisplayName: converter.String(group.name),
 		})
 	}
 
-	return &identitys
+	return &Identity
 }
 
 func createResourceData(t *testing.T, projectID string, groupName string) *schema.ResourceData {

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -63,7 +63,7 @@ func TestIdentityGroupDataSource_ProjectDescriptorLookupErrorNotFound(t *testing
 		})
 
 	err := dataSourceIdentityGroupRead(resourceData, clients)
-	require.Contains(t, err.Error(), "Error finding groups")
+	require.Contains(t, err.Error(), "Error getting groups")
 }
 
 func createIdentityGroups(groups ...groupMeta) *[]identity.Identity {

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -103,6 +103,7 @@ func TestIdentityGroupDataSource_DoesNotSwallowListGroupError(t *testing.T) {
 		Return(nil, errors.New("ListGroups() Failed"))
 
 	err := dataSourceIdentityGroupRead(resourceData, clients)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "ListGroups() Failed")
 }
 

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -65,7 +65,6 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 }
 
 // Get Groups with Scope of Project ID
-// Get Groups with Scope of Project ID
 func getIdentityGroupsWithProjectID(clients *client.AggregatedClient, projectID string) ([]identity.Identity, error) {
 	response, err := clients.IdentityClient.ListGroups(clients.Ctx, identity.ListGroupsArgs{
 		ScopeIds: &projectID,

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -1,0 +1,93 @@
+package identity
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// DataIdentityGroups schema and implementation for group data source
+func DataIdentityGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"groups": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Set:      getIdentityGroupHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"descriptor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"display_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	projectID := d.Get("project_id").(string)
+
+	groups, err := getIdentityGroupsWithProjectDescriptor(clients, projectID)
+	if err != nil {
+		errMsg := "Error finding groups"
+		if projectID != "" {
+			errMsg = fmt.Sprintf("%s for project with ID %s", errMsg, projectID)
+		}
+		return fmt.Errorf("%s. Error: %v", errMsg, err)
+	}
+
+	fgroups, err := flattenIdentityGroups(groups)
+	if err != nil {
+		return fmt.Errorf("Error flatten groups. Error: %w", err)
+	}
+
+	d.SetId("groups-" + uuid.New().String())
+	d.Set("groups", fgroups)
+	return nil
+}
+
+func getIdentityGroupHash(v interface{}) int {
+	return tfhelper.HashString(v.(map[string]interface{})["descriptor"].(string))
+}
+
+func flattenIdentityGroups(groups *[]identity.Identity) ([]interface{}, error) {
+	if groups == nil {
+		return []interface{}{}, nil
+	}
+
+	results := make([]interface{}, len(*groups))
+	for i, group := range *groups {
+		s := make(map[string]interface{})
+
+		if group.Descriptor != nil {
+			s["descriptor"] = *group.Descriptor
+		} else {
+			return nil, fmt.Errorf("Group Object does not contain a descriptor")
+		}
+		if group.ProviderDisplayName != nil {
+			s["display_name"] = *group.ProviderDisplayName
+		}
+		results[i] = s
+	}
+	return results, nil
+}

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -56,15 +56,15 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("%s. Error: %v", errMsg, err)
 	}
 
-	// With project groups flatten results
-	// fgroups, err := flattenIdentityGroups(groups)
-	// if err != nil {
-	// 	return fmt.Errorf("Error flatten groups. Error: %w", err)
-	// }
+	//With project groups flatten results
+	fgroups, err := flattenIdentityGroups(groups)
+	if err != nil {
+		return fmt.Errorf("Error flatten groups. Error: %w", err)
+	}
 
 	// Set id and group list for groups data resource
 	d.SetId("groups-" + uuid.New().String())
-	d.Set("groups", groups)
+	d.Set("groups", fgroups)
 	return nil
 }
 

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -59,7 +59,7 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 	//With project groups flatten results
 	fgroups, err := flattenIdentityGroups(groups)
 	if err != nil {
-		return fmt.Errorf("Error flatten groups. Error: %w", err)
+		return fmt.Errorf("Error flatten groups. Error: %v", err)
 	}
 
 	// Set id and group list for groups data resource
@@ -82,7 +82,7 @@ func getIdentityGroupsWithprojectID(clients *client.AggregatedClient, projectID 
 // flatten function
 func flattenIdentityGroups(groups *[]identity.Identity) ([]interface{}, error) {
 	if groups == nil {
-		return []interface{}{}, nil
+		return nil, fmt.Errorf("Input Groups Paramater is nil")
 	}
 
 	results := make([]interface{}, len(*groups))

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -86,7 +86,8 @@ func flattenIdentityGroups(groups *[]identity.Identity) ([]interface{}, error) {
 		groupMap := make(map[string]interface{})
 
 		if group.Id != nil {
-			groupMap["id"] = *group.Id
+			groupID := *group.Id
+			groupMap["id"] = groupID.String()
 		} else {
 			return nil, fmt.Errorf("Group Object does not contain an id")
 		}
@@ -99,7 +100,5 @@ func flattenIdentityGroups(groups *[]identity.Identity) ([]interface{}, error) {
 }
 
 func getIdentityGroupHash(v interface{}) int {
-	group := v.(map[string]interface{})
-	groupID := group["id"].(string)
-	return tfhelper.HashString(groupID)
+	return tfhelper.HashString(v.(map[string]interface{})["id"].(string))
 }

--- a/azuredevops/internal/service/identity/data_identity_groups_test.go
+++ b/azuredevops/internal/service/identity/data_identity_groups_test.go
@@ -1,0 +1,100 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityGroupsDataSource_DoesNotSwallowProjectDescriptorLookupError_Generic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createIdentityGroupsDataSource(t, projectID.String())
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("GetDescriptor() Failed"))
+
+	err := dataSourceIdentityGroupsRead(resourceData, clients)
+	require.Contains(t, err.Error(), "GetDescriptor() Failed")
+}
+
+// verifies that the translation for project_id to project_descriptor has proper error handling
+func TestIdentityGroupsDataSource_DoesNotSwallowProjectDescriptorLookupError_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createIdentityGroupsDataSource(t, projectID.String())
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedArgs).
+		Return(nil, azuredevops.WrappedError{
+			StatusCode: converter.Int(404),
+		})
+
+	err := dataSourceIdentityGroupsRead(resourceData, clients)
+	require.Contains(t, err.Error(), "was not found")
+}
+
+// verifies that the group lookup functionality has proper error handling
+func TestIdentityGroupsDataSource_DoesNotSwallowListGroupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	resourceData := createIdentityGroupsDataSource(t, projectID.String())
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+
+	expectedProjectDescriptorLookupArgs := identity.ListGroupsArgs{ScopeIds: &projectIDstring}
+	projectDescriptor := converter.String("descriptor")
+	projectDescriptorResponse := identity.Identity{Descriptor: projectDescriptor}
+	identityClient.
+		EXPECT().
+		GetDescriptorById(clients.Ctx, expectedProjectDescriptorLookupArgs).
+		Return(&projectDescriptorResponse, nil)
+
+	expectedListGroupArgs := identity.ListGroupsArgs{ScopeIds: projectDescriptor}
+	identityClient.
+		EXPECT().
+		ListGroups(clients.Ctx, expectedListGroupArgs).
+		Return(nil, errors.New("ListGroups() Failed"))
+
+	err := dataSourceIdentityGroupsRead(resourceData, clients)
+	require.Contains(t, err.Error(), "ListGroups() Failed")
+}
+
+func createIdentityGroupsDataSource(t *testing.T, projectID string) *schema.ResourceData {
+	resourceData := schema.TestResourceDataRaw(t, DataIdentityGroups().Schema, nil)
+	if projectID != "" {
+		resourceData.Set("project_id", projectID)
+	}
+	return resourceData
+}

--- a/azuredevops/internal/service/identity/data_identity_groups_test.go
+++ b/azuredevops/internal/service/identity/data_identity_groups_test.go
@@ -55,7 +55,7 @@ func TestIdentityGroupsDataSource_DoesNotSwallowProjectDescriptorLookupError_Not
 		})
 
 	err := dataSourceIdentityGroupsRead(resourceData, clients)
-	require.Contains(t, err.Error(), "Error finding groups")
+	require.Contains(t, err.Error(), "Error getting group")
 }
 
 func createIdentityGroupsDataSource(t *testing.T, projectID string) *schema.ResourceData {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -65,7 +65,8 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Set id and user list for users data resource
-	d.SetId(*targetUser.Descriptor)
+	targetUserID := targetUser.Id.String()
+	d.SetId(targetUserID)
 	d.Set("descriptor", targetUser.Descriptor)
 	return nil
 }
@@ -89,14 +90,16 @@ func FlattenIdentityUsers(users *[]identity.Identity) (*[]identity.Identity, err
 	}
 	results := make([]identity.Identity, len(*users))
 	for i, user := range *users {
-		if user.Id != nil {
-			results[i].Id = user.Id
-		} else {
-			return nil, fmt.Errorf("User Object does not contain an Id")
+		if user.Descriptor == nil {
+			return nil, fmt.Errorf("User Object does not contain an id")
 		}
-		if user.ProviderDisplayName != nil {
-			results[i].ProviderDisplayName = user.ProviderDisplayName
+		newUser := identity.Identity{
+			Descriptor:          user.Descriptor,
+			Id:                  user.Id,
+			ProviderDisplayName: user.ProviderDisplayName,
+			// Add other fields here if needed
 		}
+		results[i] = newUser
 	}
 	return &results, nil
 }

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -68,9 +68,25 @@ func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchfil
 		SearchFilter: &searchfilter, // Filter to get users
 		FilterValue:  &filtervalue,  // Search String for user
 	})
+	results := make([]interface{}, len(*response))
+
+	for i, user := range *response {
+		s := make(map[string]interface{})
+
+		if user.Id != nil {
+			s["descriptor"] = *user.Id
+		} else {
+			return nil, fmt.Errorf("users Object does not contain a descriptor")
+		}
+		if user.ProviderDisplayName != nil {
+			s["display_name"] = *user.ProviderDisplayName
+		}
+		results[i] = s
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	return response, nil
 }
 

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -39,7 +39,7 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	userName, searchFilter := d.Get("name").(string), d.Get("search_filter").(string)
 
 	//https://ado.url.com/_apis/identities?searchFilter=General&filterValue=my_user&api-version=7.0
-
+	// Query ADO for list of identity users with filter
 	FilterUsers, err := getIdentityUsersWithFilterValue(clients, searchFilter, userName)
 	if err != nil {
 		errMsg := "Error finding user"
@@ -49,6 +49,7 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("%s. Error: %v", errMsg, err)
 	}
 
+	// with FilterUsers resultes match and filter for the desired user.
 	targetUser := selectIdentityUser(FilterUsers, userName)
 	if targetUser == nil {
 		errMsg := fmt.Sprintf("Could not find user with name %s", userName)
@@ -58,18 +59,21 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf(errMsg)
 	}
 
+	// Set id and group list for groups data resource
 	d.SetId(*targetUser.Descriptor)
 	d.Set("descriptor", targetUser.Descriptor)
 	return nil
 }
 
 func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchfilter string, filtervalue string) (*[]identity.Identity, error) {
+	// get list of users with search_filter and filter value provided at data source invokation.
 	response, err := clients.IdentityClient.ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
 		SearchFilter: &searchfilter, // Filter to get users
 		FilterValue:  &filtervalue,  // Search String for user
 	})
 	results := make([]interface{}, len(*response))
 
+	// for each user that has been provided by response, flatten to only displayName and Descriptor/id.
 	for i, user := range *response {
 		s := make(map[string]interface{})
 
@@ -90,6 +94,7 @@ func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchfil
 	return response, nil
 }
 
+// for list of users filter and return user based on ProviderDisplayName
 func selectIdentityUser(users *[]identity.Identity, userName string) *identity.Identity {
 	for _, user := range *users {
 		if strings.EqualFold(*user.ProviderDisplayName, userName) {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -17,7 +17,7 @@ func DataIdentityUser() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"descriptor": {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -98,7 +98,7 @@ func flattenIdentityUsers(users *[]identity.Identity) (*[]identity.Identity, err
 	return &results, nil
 }
 
-// Filter results to validate user is correct. Occurs post-flatten due to missing properties based on search-filter. 
+// Filter results to validate user is correct. Occurs post-flatten due to missing properties based on search-filter.
 func validateIdentityUser(users *[]identity.Identity, userName string, searchFilter string) *identity.Identity {
 	for _, user := range *users {
 		if strings.Contains(strings.ToLower(*user.ProviderDisplayName), strings.ToLower(userName)) {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -27,8 +27,8 @@ func DataIdentityUser() *schema.Resource {
 			"search_filter": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotWhiteSpace,
 				Default:      "General",
+				ValidateFunc: validation.StringInSlice([]string{"AccountName", "DisplayName", "MailAddress", "General"}, false),
 			},
 		},
 	}

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -42,11 +42,7 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	// Query ADO for list of identity users with filter
 	filterUsers, err := getIdentityUsersWithFilterValue(clients, searchFilter, userName)
 	if err != nil {
-		errMsg := "Error finding user"
-		if searchFilter != "" {
-			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
-		}
-		return fmt.Errorf("%s. Error: %v", errMsg, err)
+		return fmt.Errorf(" finding user with filter %s. Error: %v", searchFilter, err)
 	}
 
 	flattenUsers, err := FlattenIdentityUsers(filterUsers)
@@ -57,11 +53,7 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	// Filter for the desired user in the FilterUsers results
 	targetUser := selectIdentityUser(flattenUsers, userName)
 	if targetUser == nil {
-		errMsg := fmt.Sprintf("Could not find user with name %s", userName)
-		if searchFilter != "" {
-			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
-		}
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf(" Could not find user with name %s with filter %s", userName, searchFilter)
 	}
 
 	// Set id and user list for users data resource

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 )
 
-// DataUser schema and implementation for user data source
+// DataIdentityUserResource returns the user data source resource
 func DataIdentityUser() *schema.Resource {
 	return &schema.Resource{
 		Read: dataIdentitySourceUserRead,
@@ -36,67 +36,83 @@ func DataIdentityUser() *schema.Resource {
 
 func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
-	userName, search_filter := d.Get("name").(string), d.Get("search_filter").(string)
+	userName := d.Get("name").(string)
+	searchFilter := d.Get("search_filter").(string)
 
-	//https://ado.url.com/_apis/identities?search_filter=General&filterValue=my_user&api-version=7.0
 	// Query ADO for list of identity users with filter
-	FilterUsers, err := getIdentityUsersWithFilterValue(clients, search_filter, userName)
+	filterUsers, err := getIdentityUsersWithFilterValue(clients, searchFilter, userName)
 	if err != nil {
 		errMsg := "Error finding user"
-		if search_filter != "" {
-			errMsg = fmt.Sprintf("%s with filter %s", errMsg, search_filter)
+		if searchFilter != "" {
+			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
 		}
 		return fmt.Errorf("%s. Error: %v", errMsg, err)
 	}
-	// with FilterUsers resultes match and filter for the desired user.
-	targetUser := selectIdentityUser(FilterUsers, userName)
+
+	flattenUsers, err := flattenIdentityGroups(filterUsers)
+	if err != nil {
+		return fmt.Errorf("Error flatten users. Error: %v", err)
+	}
+
+	identityUsers := make([]identity.Identity, len(flattenUsers))
+	for i, user := range flattenUsers {
+		identityUser, ok := user.(identity.Identity)
+		if !ok {
+			return fmt.Errorf("Failed to convert user to identity.Identity")
+		}
+		identityUsers[i] = identityUser
+	}
+
+	// Filter for the desired user in the FilterUsers results
+	targetUser := selectIdentityUser(&identityUsers, userName)
 	if targetUser == nil {
 		errMsg := fmt.Sprintf("Could not find user with name %s", userName)
-		if search_filter != "" {
-			errMsg = fmt.Sprintf("%s with filter %s", errMsg, search_filter)
+		if searchFilter != "" {
+			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
 		}
 		return fmt.Errorf(errMsg)
 	}
 
-	// Set id and group list for groups data resource
+	// Set id and user list for users data resource
 	d.SetId(*targetUser.Descriptor)
 	d.Set("descriptor", targetUser.Descriptor)
 	return nil
 }
 
-func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchfilter string, filtervalue string) (*[]identity.Identity, error) {
-	// get list of users with search_filter and filter value provided at data source invokation.
+func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchFilter string, filterValue string) (*[]identity.Identity, error) {
+	// Get list of users with search filter and filter value provided at data source invocation.
 	response, err := clients.IdentityClient.ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
-		SearchFilter: &searchfilter, // Filter to get users
-		FilterValue:  &filtervalue,  // Search String for user
+		SearchFilter: &searchFilter, // Filter to get users
+		FilterValue:  &filterValue,  // Search String for user
 	})
-	results := make([]interface{}, len(*response))
 
-	// for each user that has been provided by response, flatten to only displayName, Descriptor/id and search_filter
-	for i, user := range *response {
-		s := make(map[string]interface{})
-
-		if user.Id != nil {
-			s["descriptor"] = *user.Id
-		} else {
-			return nil, fmt.Errorf("users Object does not contain a descriptor")
-		}
-		if user.ProviderDisplayName != nil {
-			s["name"] = *user.ProviderDisplayName
-		}
-		if &filtervalue != nil {
-			s["search_filter"] = filtervalue
-		}
-		results[i] = s
-	}
 	if err != nil {
 		return nil, err
 	}
-
 	return response, nil
 }
 
-// for list of users filter and return user based on ProviderDisplayName
+func FlattenIdentityUsers(users *[]identity.Identity) ([]interface{}, error) {
+	if users == nil {
+		return nil, fmt.Errorf("Input Users Paramater is nil")
+	}
+	results := make([]interface{}, len(*users))
+	for i, user := range *users {
+		userMap := make(map[string]interface{})
+
+		if user.Id != nil {
+			userMap["descriptor"] = *user.Id
+		} else {
+			return nil, fmt.Errorf("User Object does not contain a id")
+		}
+		if user.ProviderDisplayName != nil {
+			userMap["name"] = *user.ProviderDisplayName
+		}
+		results[i] = userMap
+	}
+	return results, nil
+}
+
 func selectIdentityUser(users *[]identity.Identity, userName string) *identity.Identity {
 	for _, user := range *users {
 		if strings.EqualFold(*user.ProviderDisplayName, userName) {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -1,0 +1,84 @@
+package identity
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// DataUser schema and implementation for user data source
+func DataIdentityUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataIdentitySourceUserRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"descriptor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"search_filter": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Default:      "General",
+			},
+		},
+	}
+}
+
+func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	userName, searchFilter := d.Get("name").(string), d.Get("search_filter").(string)
+
+	//https://ado.url.com/_apis/identities?searchFilter=General&filterValue=my_user&api-version=7.0
+
+	FilterUsers, err := getIdentityUsersWithFilterValue(clients, searchFilter, userName)
+	if err != nil {
+		errMsg := "Error finding user"
+		if searchFilter != "" {
+			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
+		}
+		return fmt.Errorf("%s. Error: %v", errMsg, err)
+	}
+
+	targetUser := selectIdentityUser(FilterUsers, userName)
+	if targetUser == nil {
+		errMsg := fmt.Sprintf("Could not find user with name %s", userName)
+		if searchFilter != "" {
+			errMsg = fmt.Sprintf("%s with filter %s", errMsg, searchFilter)
+		}
+		return fmt.Errorf(errMsg)
+	}
+
+	d.SetId(*targetUser.Descriptor)
+	d.Set("descriptor", targetUser.Descriptor)
+	return nil
+}
+
+func getIdentityUsersWithFilterValue(clients *client.AggregatedClient, searchfilter string, filtervalue string) (*[]identity.Identity, error) {
+	response, err := clients.IdentityClient.ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
+		SearchFilter: &searchfilter, // Filter to get users
+		FilterValue:  &filtervalue,  // Search String for user
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func selectIdentityUser(users *[]identity.Identity, userName string) *identity.Identity {
+	for _, user := range *users {
+		if strings.EqualFold(*user.ProviderDisplayName, userName) {
+			return &user
+		}
+	}
+	return nil
+}

--- a/azuredevops/internal/service/identity/data_identity_user_test.go
+++ b/azuredevops/internal/service/identity/data_identity_user_test.go
@@ -10,7 +10,6 @@ package identity
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -26,23 +25,28 @@ func TestDataSourceIdentityUser_UserNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	userName := "SomeUser"
 	searchFilter := "General"
-	userName := "NonExistentUser"
 
 	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
-	clients := &client.AggregatedClient{IdentityClient: identityClient, Ctx: context.Background()}
+	clients := &client.AggregatedClient{
+		IdentityClient: identityClient,
+		Ctx:            context.Background(),
+	}
 	// Set up the mock expectations for ReadIdentities
 	expectedArgs := identity.ReadIdentitiesArgs{FilterValue: &userName, SearchFilter: &searchFilter}
 	identityClient.
 		EXPECT().
 		ReadIdentities(clients.Ctx, expectedArgs).
 		Return(nil, errors.New("User not found"))
-
 	// Set up the resource data with input values
-	resourceData := createUserResourceData(t, "group-name")
+	t.Log("after executing")
+	resourceData := schema.TestResourceDataRaw(t, DataIdentityUser().Schema, nil)
+	resourceData.Set("name", "SomeUser")
+	resourceData.Set("search_filter", "General")
+	t.Log("after executing")
 	// Execute the function and check for the expected error
 	err := dataIdentitySourceUserRead(resourceData, clients)
-	require.Error(t, err)
 	require.Contains(t, err.Error(), "Could not find user with name "+userName)
 }
 
@@ -59,17 +63,18 @@ func TestDataSourceIdentityUser_ErrorNotSwallowed(t *testing.T) {
 		IdentityClient: identityClient,
 		Ctx:            context.Background(),
 	}
+	// Set up the resource data with input values
+	resourceData := schema.TestResourceDataRaw(t, DataIdentityUser().Schema, nil)
+	resourceData.Set("name", userName)
 
 	// Set up the mock expectations for ReadIdentities
-	expectedArgs := []identity.ReadIdentitiesArgs{{FilterValue: &userName, SearchFilter: &searchFilter}}
+	expectedArgs := identity.ReadIdentitiesArgs{FilterValue: &userName, SearchFilter: &searchFilter}
 	// Set up the mock expectations for ReadIdentities
 	identityClient.
 		EXPECT().
 		ReadIdentities(clients.Ctx, expectedArgs).
 		Return(nil, errors.New("Some other error"))
 
-	// Set up the resource data with input values
-	resourceData := createUserResourceData(t, "group-name")
 	// Execute the function and check for the expected error
 	err := dataIdentitySourceUserRead(resourceData, clients)
 	require.Error(t, err)
@@ -77,26 +82,4 @@ func TestDataSourceIdentityUser_ErrorNotSwallowed(t *testing.T) {
 	require.Contains(t, err.Error(), "with filter "+searchFilter)
 }
 
-// Helper function to simulate the behavior of Read method
-func testReadFunction(d *schema.ResourceData, m interface{}) error {
-	// Convert interface{} to *client.AggregatedClient
-	clients := m.(*client.AggregatedClient)
-
-	// Call the actual dataIdentitySourceUserRead function
-	//return dataIdentitySourceUserRead(d, clients)
-	if err := dataIdentitySourceUserRead(d, clients); err != nil {
-		return nil
-	}
-	id, idExists := d.GetOk("descriptor")
-	if !idExists {
-		return fmt.Errorf("id field not set in ResourceData")
-	}
-	d.SetId(id.(string))
-	return nil
-}
-
-func createUserResourceData(t *testing.T, groupName string) *schema.ResourceData {
-	resourceData := schema.TestResourceDataRaw(t, DataIdentityUser().Schema, nil)
-	resourceData.Set("name", groupName)
-	return resourceData
-}
+//

--- a/azuredevops/internal/service/identity/data_identity_user_test.go
+++ b/azuredevops/internal/service/identity/data_identity_user_test.go
@@ -10,56 +10,37 @@ package identity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
 	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/stretchr/testify/require"
 )
 
-var id, _ = uuid.Parse("00000000-0000-0000-0000-000000000000")
+// Helper function to simulate the behavior of Read method
+func testReadFunction(d *schema.ResourceData, m interface{}) error {
+	// Convert interface{} to *client.AggregatedClient
+	clients := m.(*client.AggregatedClient)
 
-var usrList1 = []identity.Identity{
-	{
-		Descriptor:          converter.String("aad.YWU4YzJkMTktOThmYS03ZDhmLWJhNTAtOWI4MWQzYTUxZjcy"),
-		ProviderDisplayName: converter.String("DesireeMCollins@jourrapide.com"),
-	},
-	{
-		Descriptor:          converter.String("svc.Nzc3NGFjMDMtOGEyOS00NGFjLTg2ZjEtZmE0YmRlZDc4ZGUyOkdpdEh1YiBBcHA6MjE3OGVhMGItMmNlMi00ZDA4LTg4YTMtODdiYWRjYjkzNjE1"),
-		ProviderDisplayName: converter.String("GitHub"),
-	},
-	{
-		Descriptor:          converter.String("aad.NTJmM2YzZmMtZmE4NS00ZGNhLTkwYjUtMDNiY2U0NjBlMmIy"),
-		ProviderDisplayName: converter.String("WalterMBrooks@rhyta.com"),
-	},
-	{
-		Descriptor:          converter.String("msa.MmRkMWZkMWMtNWE0Mi00NDM1LThhM2ItMWQ1NWUwOTA2NzUx"),
-		ProviderDisplayName: converter.String("KerryMRaymond@teleworm.us"),
-	},
+	// Call the actual dataIdentitySourceUserRead function
+	//return dataIdentitySourceUserRead(d, clients)
+	if err := dataIdentitySourceUserRead(d, clients); err != nil {
+		return nil
+	}
+	id, idExists := d.GetOk("descriptor")
+	if !idExists {
+		return fmt.Errorf("id field not set in ResourceData")
+	}
+	d.SetId(id.(string))
+	return nil
 }
 
-var usrList2 = []identity.Identity{
-	{
-		Descriptor:          converter.String("svc.Nzc3NGFjMDMtOGEyOS00NGFjLTg2ZjEtZmE0YmRlZDc4ZGUyOkJ1aWxkOmYwNzg2ZGZkLTA4OGYtNDYxOS1hY2NjLTJlYzc1ZTEyNmRjZQ"),
-		ProviderDisplayName: converter.String("Project Collection Build Service (unittest)"),
-	},
-	{
-		Descriptor:          converter.String("bnd.dXBuOmIwYjg0Yzc1LTI4NjctNGQ0Mi1iNWFhLTg1YjE5Nzc1ZDdlN1xBbGxlbkJNY0tpbm5vbkBkYXlyZXAuY29t"),
-		ProviderDisplayName: converter.String("AllenBMcKinnon@dayrep.com"),
-	},
-	{
-		Descriptor:          converter.String("win.Uy0xLTUtMjEtMjA4NTA0NzkxOS0yODAyODgxNjk5LTE5MDg1MTA1MTctNTAw"),
-		ProviderDisplayName: converter.String("Local Admin"),
-	},
-}
-
-// verfies that the data source propagates an error from the API correctly
-func TestDataSourceIdentityUser_Read_TestDoesNotSwallowError(t *testing.T) {
+// Test when user is not found
+func TestDataSourceIdentityUser_UserNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -68,18 +49,61 @@ func TestDataSourceIdentityUser_Read_TestDoesNotSwallowError(t *testing.T) {
 		IdentityClient: identityClient,
 		Ctx:            context.Background(),
 	}
-	projectID := uuid.New()
-	projectIDstring := projectID.String()
-	expectedArgs := identity.ReadIdentitiesArgs{
-		IdentityIds: &projectIDstring,
-	}
-	identityClient.
-		EXPECT().
-		ReadIdentities(clients.Ctx, expectedArgs).
-		Return(nil, errors.New("ReadIdentities() Failed"))
 
-	resourceData := schema.TestResourceDataRaw(t, DataIdentityUser().Schema, nil)
-	err := dataIdentitySourceUserRead(resourceData, clients)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "ReadIdentities() Failed")
+	userName := "NonExistentUser"
+	searchFilter := "General"
+
+	// Set up the mock expectations for ReadIdentities
+	identityClient.EXPECT().
+		ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
+			SearchFilter: &searchFilter,
+			FilterValue:  &userName,
+		}).
+		Return(nil, errors.New("User not found"))
+
+	// Set up the resource data with input values
+	resourceData := map[string]interface{}{
+		"name":          userName,
+		"search_filter": searchFilter,
+	}
+
+	// Execute the function and check for the expected error
+	err := testReadFunction(schema.TestResourceDataRaw(t, DataIdentityUser().Schema, resourceData), clients)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Could not find user with name "+userName)
+}
+
+// Test to validate that the error is not swallowed
+func TestDataSourceIdentityUser_ErrorNotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{
+		IdentityClient: identityClient,
+		Ctx:            context.Background(),
+	}
+
+	userName := "SomeUser"
+	searchFilter := "General"
+
+	// Set up the mock expectations for ReadIdentities
+	identityClient.EXPECT().
+		ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
+			SearchFilter: &searchFilter,
+			FilterValue:  &userName,
+		}).
+		Return(nil, errors.New("Some other error"))
+
+	// Set up the resource data with input values
+	resourceData := map[string]interface{}{
+		"name":          userName,
+		"search_filter": searchFilter,
+	}
+
+	// Execute the function and check for the expected error
+	err := testReadFunction(schema.TestResourceDataRaw(t, DataIdentityUser().Schema, resourceData), clients)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Error finding user")
+	require.Contains(t, err.Error(), "with filter "+searchFilter)
 }

--- a/azuredevops/internal/service/identity/data_identity_user_test.go
+++ b/azuredevops/internal/service/identity/data_identity_user_test.go
@@ -43,7 +43,7 @@ func TestUserNotFound(t *testing.T) {
 
 	// Execute the function and check for the expected error
 	err := dataIdentitySourceUserRead(resourceData, clients)
-	require.Contains(t, err.Error(), "Error finding user")
+	require.Contains(t, err.Error(), "finding user with filter")
 }
 
 func TestErrorNotSwallowed(t *testing.T) {
@@ -69,7 +69,7 @@ func TestErrorNotSwallowed(t *testing.T) {
 	// Execute the function and check for the expected error
 	err := dataIdentitySourceUserRead(resourceData, clients)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Error finding user")
+	require.Contains(t, err.Error(), "finding user with filter")
 	require.Contains(t, err.Error(), "with filter "+searchFilter)
 }
 

--- a/azuredevops/internal/service/identity/data_identity_user_test.go
+++ b/azuredevops/internal/service/identity/data_identity_user_test.go
@@ -1,0 +1,85 @@
+//go:build (all || core || data_sources || data_users) && (!exclude_data_sources || !exclude_data_users)
+// +build all core data_sources data_users
+// +build !exclude_data_sources !exclude_data_users
+
+package identity
+
+// The tests in this file use the mock clients in mock_client.go to mock out
+// the Azure DevOps client operations.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+)
+
+var id, _ = uuid.Parse("00000000-0000-0000-0000-000000000000")
+
+var usrList1 = []identity.Identity{
+	{
+		Descriptor:          converter.String("aad.YWU4YzJkMTktOThmYS03ZDhmLWJhNTAtOWI4MWQzYTUxZjcy"),
+		ProviderDisplayName: converter.String("DesireeMCollins@jourrapide.com"),
+	},
+	{
+		Descriptor:          converter.String("svc.Nzc3NGFjMDMtOGEyOS00NGFjLTg2ZjEtZmE0YmRlZDc4ZGUyOkdpdEh1YiBBcHA6MjE3OGVhMGItMmNlMi00ZDA4LTg4YTMtODdiYWRjYjkzNjE1"),
+		ProviderDisplayName: converter.String("GitHub"),
+	},
+	{
+		Descriptor:          converter.String("aad.NTJmM2YzZmMtZmE4NS00ZGNhLTkwYjUtMDNiY2U0NjBlMmIy"),
+		ProviderDisplayName: converter.String("WalterMBrooks@rhyta.com"),
+	},
+	{
+		Descriptor:          converter.String("msa.MmRkMWZkMWMtNWE0Mi00NDM1LThhM2ItMWQ1NWUwOTA2NzUx"),
+		ProviderDisplayName: converter.String("KerryMRaymond@teleworm.us"),
+	},
+}
+
+var usrList2 = []identity.Identity{
+	{
+		Descriptor:          converter.String("svc.Nzc3NGFjMDMtOGEyOS00NGFjLTg2ZjEtZmE0YmRlZDc4ZGUyOkJ1aWxkOmYwNzg2ZGZkLTA4OGYtNDYxOS1hY2NjLTJlYzc1ZTEyNmRjZQ"),
+		ProviderDisplayName: converter.String("Project Collection Build Service (unittest)"),
+	},
+	{
+		Descriptor:          converter.String("bnd.dXBuOmIwYjg0Yzc1LTI4NjctNGQ0Mi1iNWFhLTg1YjE5Nzc1ZDdlN1xBbGxlbkJNY0tpbm5vbkBkYXlyZXAuY29t"),
+		ProviderDisplayName: converter.String("AllenBMcKinnon@dayrep.com"),
+	},
+	{
+		Descriptor:          converter.String("win.Uy0xLTUtMjEtMjA4NTA0NzkxOS0yODAyODgxNjk5LTE5MDg1MTA1MTctNTAw"),
+		ProviderDisplayName: converter.String("Local Admin"),
+	},
+}
+
+// verfies that the data source propagates an error from the API correctly
+func TestDataSourceIdentityUser_Read_TestDoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{
+		IdentityClient: identityClient,
+		Ctx:            context.Background(),
+	}
+	projectID := uuid.New()
+	projectIDstring := projectID.String()
+	expectedArgs := identity.ReadIdentitiesArgs{
+		IdentityIds: &projectIDstring,
+	}
+	identityClient.
+		EXPECT().
+		ReadIdentities(clients.Ctx, expectedArgs).
+		Return(nil, errors.New("ReadIdentities() Failed"))
+
+	resourceData := schema.TestResourceDataRaw(t, DataIdentityUser().Schema, nil)
+	err := dataIdentitySourceUserRead(resourceData, clients)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "ReadIdentities() Failed")
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/core"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/git"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/graph"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/identity"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/memberentitlementmanagement"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
@@ -130,6 +131,9 @@ func Provider() *schema.Provider {
 			"azuredevops_team":                       core.DataTeam(),
 			"azuredevops_teams":                      core.DataTeams(),
 			"azuredevops_groups":                     graph.DataGroups(),
+			"azuredevops_identity_groups":            identity.DataIdentityGroups(),
+			"azuredevops_identity_group":             identity.DataIdentityGroup(),
+			"azuredevops_identity_user":              identity.DataIdentityUser(),
 			"azuredevops_variable_group":             taskagent.DataVariableGroup(),
 			"azuredevops_serviceendpoint_azurerm":    serviceendpoint.DataServiceEndpointAzureRM(),
 			"azuredevops_serviceendpoint_github":     serviceendpoint.DataServiceEndpointGithub(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -124,6 +124,7 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		"azuredevops_team",
 		"azuredevops_teams",
 		"azuredevops_groups",
+		"azuredevops_identity_user",
 		"azuredevops_identity_group",
 		"azuredevops_identity_groups",
 		"azuredevops_variable_group",

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -124,6 +124,7 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		"azuredevops_team",
 		"azuredevops_teams",
 		"azuredevops_groups",
+		"azuredevops_identity_group",
 		"azuredevops_identity_groups",
 		"azuredevops_variable_group",
 		"azuredevops_serviceendpoint_azurerm",

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -124,6 +124,7 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		"azuredevops_team",
 		"azuredevops_teams",
 		"azuredevops_groups",
+		"azuredevops_identity_groups",
 		"azuredevops_variable_group",
 		"azuredevops_serviceendpoint_azurerm",
 		"azuredevops_serviceendpoint_github",

--- a/website/docs/d/identity_group.html.markdown
+++ b/website/docs/d/identity_group.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_identity_group"
+description: |-
+  Use this data source to access information about existing Groups within Azure DevOps
+---
+
+# Data Source: azuredevops_identity_group
+
+Use this data source to access information about existing Groups within Azure DevOps On-Premise(Azure DevOps Server).
+
+## Example Usage
+
+```hcl
+data "azuredevops_project" "example" {
+  name = "Example Project"
+}
+
+# load all existing groups inside an organization
+data "azuredevops_identity_group" "example-all-group" {
+  name = "Group-Name"
+}
+
+# load all existing groups inside a specific project
+data "azuredevops_identity_group" "example-project-group" {
+  project_id = data.azuredevops_project.example.id
+  name = "[Project-Name]\\Group-Name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the group.
+- `project_id` - (Optional) The Project ID. If no project ID is specified all groups of an organization will be returned
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  - `id` - The ID is the primary way to reference the identity subject. This field will uniquely identify the same identity subject across both Accounts and Organizations.
+  - `name` - This is the non-unique display name of the identity subject. To change this field, you must alter its value in the source provider.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Identities](https://docs.microsoft.com/en-us/rest/api/azure/devops/ims/?view=azure-devops-rest-7.2)

--- a/website/docs/d/identity_group.html.markdown
+++ b/website/docs/d/identity_group.html.markdown
@@ -12,7 +12,7 @@ Use this data source to access information about an existing Group within Azure 
 ## Example Usage
 
 ```hcl
-# load all existing groups inside a specific project
+# load existing group with specific name
 data "azuredevops_identity_group" "example-project-group" {
   project_id = data.azuredevops_project.example.id
   name = "[Project-Name]\\Group-Name"

--- a/website/docs/d/identity_group.html.markdown
+++ b/website/docs/d/identity_group.html.markdown
@@ -7,20 +7,11 @@ description: |-
 
 # Data Source: azuredevops_identity_group
 
-Use this data source to access information about existing Groups within Azure DevOps On-Premise(Azure DevOps Server).
+Use this data source to access information about an existing Group within Azure DevOps On-Premise(Azure DevOps Server).
 
 ## Example Usage
 
 ```hcl
-data "azuredevops_project" "example" {
-  name = "Example Project"
-}
-
-# load all existing groups inside an organization
-data "azuredevops_identity_group" "example-all-group" {
-  name = "Group-Name"
-}
-
 # load all existing groups inside a specific project
 data "azuredevops_identity_group" "example-project-group" {
   project_id = data.azuredevops_project.example.id
@@ -33,7 +24,7 @@ data "azuredevops_identity_group" "example-project-group" {
 The following arguments are supported:
 
 - `name` - (Required) The name of the group.
-- `project_id` - (Optional) The Project ID. If no project ID is specified all groups of an organization will be returned
+- `project_id` - (Required) The Project ID.
 
 ## Attributes Reference
 

--- a/website/docs/d/identity_groups.html.markdown
+++ b/website/docs/d/identity_groups.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_identity_groups"
+description: |-
+  Use this data source to access information about existing Groups within Azure DevOps
+---
+
+# Data Source: azuredevops_identity_groups
+
+Use this data source to access information about existing Groups within Azure DevOps On-Premise(Azure DevOps Server).
+
+## Example Usage
+
+```hcl
+data "azuredevops_project" "example" {
+  name = "Example Project"
+}
+
+# load all existing groups inside an organization
+data "azuredevops_identity_groups" "example-all-groups" {
+}
+
+# load all existing groups inside a specific project
+data "azuredevops_identity_groups" "example-project-groups" {
+  project_id = data.azuredevops_project.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Optional) The Project ID. If no project ID is specified all groups of an organization will be returned
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `groups` - A set of existing groups in your Azure DevOps Organization or project with details about every single group which includes:
+
+  - `descriptor` - The descriptor is the primary way to reference the identity subject while the system is running. This field will uniquely identify the same identity subject across both Accounts and Organizations.
+  - `name` - This is the non-unique display name of the identity subject. To change this field, you must alter its value in the source provider.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Identities](https://docs.microsoft.com/en-us/rest/api/azure/devops/ims/?view=azure-devops-rest-7.2)

--- a/website/docs/d/identity_users.html.markdown
+++ b/website/docs/d/identity_users.html.markdown
@@ -43,14 +43,14 @@ data "azuredevops_user" "contoso-user-upn" {
 The following arguments are supported:
 
 - `name` - (required) The PrincipalName of this identity member from the source provider.
-- `search_filter` - (Optional) Default is General, but other options are AccountName, DisplayName, and MailAddress.
+- `search_filter` - (Optional) The type of search to perform. Default is `General`. Possible values are `AccountName`, `DisplayName`, and `MailAddress`.
 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-- `users` - A set of existing users in your Azure DevOps Organization with details about every single user which includes:
+  - `user` - A set of existing users in your Azure DevOps Organization with details about every single user which includes:
 
   - `id` - The ID is the primary way to reference the identity subject while the system is running. This field will uniquely identify the same identity subject across both Accounts and Organizations.
   - `name` - This is the PrincipalName of this identity member from the source provider. The source provider may change this field over time and it is not guaranteed to be immutable for the life of the identity member.

--- a/website/docs/d/identity_users.html.markdown
+++ b/website/docs/d/identity_users.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_identity_user"
+description: |-
+  Use this data source to access information about an existing users within Azure DevOps.
+---
+
+# Data Source: azuredevops_identity_user
+
+Use this data source to access information about an existing users within Azure DevOps On-Premise(Azure DevOps Server).
+
+## Example Usage
+
+```hcl
+# Load single user by using it's principal name
+data "azuredevops_identity_user" "contoso-user" {
+  name = "contoso-user"
+}
+
+# Use userPrincipalName instead of principal name.
+data "azuredevops_user" "contoso-user-upn" {
+  name = "contoso-user@contoso.onmicrosoft.com"
+}
+
+# Load all users know inside an organization
+data "azuredevops_user" "example-all-users" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Optional) The PrincipalName of this identity member from the source provider.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `users` - A set of existing users in your Azure DevOps Organization with details about every single user which includes:
+
+  - `id` - The ID is the primary way to reference the identity subject while the system is running. This field will uniquely identify the same identity subject across both Accounts and Organizations.
+  - `name` - This is the PrincipalName of this identity member from the source provider. The source provider may change this field over time and it is not guaranteed to be immutable for the life of the identity member.
+
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Identities](https://docs.microsoft.com/en-us/rest/api/azure/devops/ims/?view=azure-devops-rest-7.2)

--- a/website/docs/d/identity_users.html.markdown
+++ b/website/docs/d/identity_users.html.markdown
@@ -17,21 +17,34 @@ data "azuredevops_identity_user" "contoso-user" {
   name = "contoso-user"
 }
 
-# Use userPrincipalName instead of principal name.
+# Use MailAddress instead of principal name.
 data "azuredevops_user" "contoso-user-upn" {
   name = "contoso-user@contoso.onmicrosoft.com"
+  search_filter = "MailAddress"
 }
 
-# Load all users know inside an organization
-data "azuredevops_user" "example-all-users" {
+
+# Use MailAddress instead of principal name.
+data "azuredevops_user" "contoso-user-upn" {
+  name = "contoso-user@contoso.onmicrosoft.com"
+  search_filter = "MailAddress"
 }
+
+# Use DisplayName instead of principal name.
+data "azuredevops_user" "contoso-user-upn" {
+  name = "Contoso User"
+  search_filter = "DisplayName"
+}
+
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-- `name` - (Optional) The PrincipalName of this identity member from the source provider.
+- `name` - (required) The PrincipalName of this identity member from the source provider.
+- `search_filter` - (Optional) Default is General, but other options are AccountName, DisplayName, and MailAddress.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:
This addition creates the data_sources for azuredevops_identity_groups, azuredevops_identity_group, and azuredevops_identity_user allowing the tf provided to use the identity api for on-premise/non-cloud since graph is not provided for on-premises installs. 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
Nothing for cloud/AzureDevOps changed but customers who are using on-premise Azure DevOps can now use this TF module to manage their Azure DevOps Instances since graph API is not applicable to them. 


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently this TF module is almost useless for on-prem deployments as you can not query and assign users/groups to git repositories, branch policies, and etc. 

Issue Number: NA

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
Open to input :D happy to contribute! 

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->