### PR TITLE
`azuredevops_check_required_template` support githubenterprise repository type

### DIFF
--- a/azuredevops/internal/service/approvalsandchecks/resource_check_required_template.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_required_template.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/pipelineschecksextras"
 )
 
-var validRepositoryTypes = []string{"azuregit", "github", "bitbucket"}
+var validRepositoryTypes = []string{"azuregit", "github", "githubenterprise", "bitbucket"}
 
 // ResourceCheckRequiredTemplate schema and implementation for required template check resources
 func ResourceCheckRequiredTemplate() *schema.Resource {

--- a/website/docs/r/check_required_template.html.markdown
+++ b/website/docs/r/check_required_template.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
  
 A `required_template` block supports the following:
 
-- `repository_type` - (Optional) The type of the repository storing the template. Valid values: `azuregit`, `github`, `bitbucket`. Defaults to `azuregit`.
+- `repository_type` - (Optional) The type of the repository storing the template. Valid values: `azuregit`, `github`, `githubenterprise`, `bitbucket`. Defaults to `azuregit`.
 - `repository_name` - (Required) The name of the repository storing the template.
 - `repository_ref` - (Required) The branch in which the template will be referenced.
 - `template_path` - (Required) The path to the template yaml.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Azure DevOps release (11/16/23) added support for [GitHub Enterprise for required template checks](https://learn.microsoft.com/en-us/azure/devops/release-notes/2023/sprint-230-update#support-for-github-enterprise-server-in-required-template-check).

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Tested terraform apply with local build, `githubenterprise` looks ok:

```Terraform will perform the following actions:

  # azuredevops_check_required_template.required_template["dri_test-githubenterprise-Microservices/Microservices-refs/heads/main-test.yml"] will be created
  + resource "azuredevops_check_required_template" "required_template" {
      + id                   = (known after apply)
      + project_id           = "fadc4d72-3c4a-431e-8510-1ed875db83f2"
      + target_resource_id   = "44c67df1-f2ef-4b6b-b9b5-d132cac74474"
      + target_resource_type = "endpoint"

      + required_template {
          + repository_name = "Microservices/Microservices"
          + repository_ref  = "refs/heads/main"
          + repository_type = "githubenterprise"
          + template_path   = "test.yml"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

azuredevops_check_required_template.required_template["dri_test-githubenterprise-Microservices/Microservices-refs/heads/main-test.yml"]: Creating...
azuredevops_check_required_template.required_template["dri_test-githubenterprise-Microservices/Microservices-refs/heads/main-test.yml"]: Creation complete after 0s [id=2948]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
````
<img width="1448" alt="image" src="https://github.com/microsoft/terraform-provider-azuredevops/assets/12406674/00ea6e48-7837-4aa3-a854-7ae7ce7b49be">
