### PR TITLE
`azuredevops_pipeline_authorization` - Allow pipeline authorization across projects

### DIFF
--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -23,6 +23,11 @@ func ResourcePipelineAuthorization() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"pipeline_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -48,6 +53,11 @@ func ResourcePipelineAuthorization() *schema.Resource {
 func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	projectId := d.Get("project_id").(string)
+	pipelineProjectId := projectId
+	if d.Get("pipeline_project_id").(string) != "" {
+		pipelineProjectId = d.Get("pipeline_project_id").(string)
+	}
+
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
@@ -56,7 +66,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	}
 
 	pipePermissionParams := pipelinepermissions.UpdatePipelinePermisionsForResourceArgs{
-		Project:      &projectId,
+		Project:      &pipelineProjectId,
 		ResourceType: &resType,
 		ResourceId:   &resId,
 	}
@@ -90,6 +100,11 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	projectId := d.Get("project_id").(string)
+	pipelineProjectId := projectId
+	if d.Get("pipeline_project_id").(string) != "" {
+		pipelineProjectId = d.Get("pipeline_project_id").(string)
+	}
+
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
@@ -99,7 +114,7 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 
 	resp, err := clients.PipelinePermissionsClient.GetPipelinePermissionsForResource(clients.Ctx,
 		pipelinepermissions.GetPipelinePermissionsForResourceArgs{
-			Project:      &projectId,
+			Project:      &pipelineProjectId,
 			ResourceType: &resType,
 			ResourceId:   &resId,
 		},
@@ -139,6 +154,11 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	projectId := d.Get("project_id").(string)
+	pipelineProjectId := projectId
+	if d.Get("pipeline_project_id").(string) != "" {
+		pipelineProjectId = d.Get("pipeline_project_id").(string)
+	}
+
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
@@ -147,7 +167,7 @@ func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 	}
 
 	pipePermissionParams := pipelinepermissions.UpdatePipelinePermisionsForResourceArgs{
-		Project:      &projectId,
+		Project:      &pipelineProjectId,
 		ResourceType: &resType,
 		ResourceId:   &resId,
 	}

--- a/website/docs/r/pipeline_authorization.html.markdown
+++ b/website/docs/r/pipeline_authorization.html.markdown
@@ -14,7 +14,7 @@ Manage pipeline access permissions to resources.
 ~> **Note** If both "All Pipeline Authorization" and "Custom Pipeline Authorization" are configured, "All Pipeline Authorization" has higher priority.
 
 
-## Example Usage 
+## Example Usage
 
 ### Authorization for all pipelines
 
@@ -95,13 +95,14 @@ resource "azuredevops_pipeline_authorization" "example" {
 
 The following arguments are supported:
 
-- `project_id` - (Required) The  ID of the project. Changing this forces a new resource to be created 
+- `project_id` - (Required) The  ID of the project. Changing this forces a new resource to be created
 - `resource_id` - (Required) The ID of the resource to authorize. Changing this forces a new resource to be created
 - `type` - (Required) The type of the resource to authorize. Valid values: `endpoint`, `queue`, `variablegroup`, `environment`, `repository`. Changing this forces a new resource to be created
 
 ---
-- `pipeline_id` - (Optional) The ID of the pipeline. If not configured, all pipelines will be authorized. Changing this forces a new resource to be created.
 
+- `pipeline_id` - (Optional) The ID of the pipeline. If not configured, all pipelines will be authorized. Changing this forces a new resource to be created.
+- `pipeline_project_id` - (Optional) The ID of the project where the pipeline exists. Defaults to `project_id` if not specified. Changing this forces a new resource to be created
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Currently, we cannot authorize pipelines cross project repository.

This PR adds a new optional property to specify the pipeline's project id.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [ ] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->