### PR TITLE
fix: add missing version property on check resources

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_check_approval_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_approval_test.go
@@ -89,6 +89,7 @@ func TestAccCheckApproval_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
 					resource.TestCheckResourceAttr(tfCheckNode, "approvers.#", "2"),
+					resource.TestCheckResourceAttr(tfCheckNode, "version", "2"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
@@ -97,6 +97,7 @@ func TestAccCheckBranchControl_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
 					resource.TestCheckResourceAttr(tfCheckNode, "allowed_branches", branchesSecond),
 					resource.TestCheckResourceAttr(tfCheckNode, "display_name", checkNameSecond),
+					resource.TestCheckResourceAttr(tfCheckNode, "version", "2"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
@@ -150,6 +150,7 @@ func TestAccCheckBusinessHours_update(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "friday", friday_second),
 					resource.TestCheckResourceAttr(tfCheckNode, "saturday", saturday_second),
 					resource.TestCheckResourceAttr(tfCheckNode, "sunday", sunday_second),
+					resource.TestCheckResourceAttr(tfCheckNode, "version", "2"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
@@ -101,6 +101,7 @@ func TestAccCheckRequiredTemplate_update(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.repository_name", repositoryNameSecond),
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.repository_ref", repositoryRefSecond),
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.template_path", templatePathSecond),
+					resource.TestCheckResourceAttr(tfCheckNode, "version", "2"),
 				),
 			},
 		},

--- a/azuredevops/internal/service/approvalsandchecks/common_check.go
+++ b/azuredevops/internal/service/approvalsandchecks/common_check.go
@@ -86,6 +86,10 @@ func genBaseCheckResource(f flatFunc, e expandFunc) *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(targetResourceTypes, false),
 			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -101,6 +105,7 @@ func doBaseExpansion(d *schema.ResourceData, checkType *pipelineschecksextras.Ch
 			Id:   converter.String(d.Get("target_resource_id").(string)),
 			Type: converter.String(d.Get("target_resource_type").(string)),
 		},
+		Version: converter.Int(d.Get("version").(int)),
 	}
 
 	if timeout != nil {
@@ -130,6 +135,7 @@ func doBaseFlattening(d *schema.ResourceData, check *pipelineschecksextras.Check
 
 	d.Set("target_resource_id", check.Resource.Id)
 	d.Set("target_resource_type", check.Resource.Type)
+	d.Set("version", check.Version)
 
 	return nil
 }

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
@@ -48,6 +48,7 @@ var ApprovalCheckTest = pipelineschecksextras.CheckConfiguration{
 	Settings: ApprovalCheckSettings,
 	Timeout:  converter.ToPtr(20000),
 	Resource: &endpointResourceApproval,
+	Version:  converter.Int(0),
 }
 
 // verifies that the flatten/expand round trip yields the same branch control

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control_test.go
@@ -49,6 +49,7 @@ var branchControlCheckTest = pipelineschecksextras.CheckConfiguration{
 	Settings: branchControlCheckSettings,
 	Timeout:  converter.ToPtr(50000),
 	Resource: &endpointResource,
+	Version:  converter.Int(0),
 }
 
 // verifies that the flatten/expand round trip yields the same branch control

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_business_hours_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_business_hours_test.go
@@ -42,6 +42,7 @@ var CheckBusinessHoursTest = pipelineschecksextras.CheckConfiguration{
 	Settings: CheckBusinessHoursSettings,
 	Timeout:  converter.ToPtr(50000),
 	Resource: &endpointResource,
+	Version:  converter.Int(0),
 }
 
 // verifies that the flatten/expand round trip yields the same business hours check

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_exclusive_lock_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_exclusive_lock_test.go
@@ -33,6 +33,7 @@ var CheckExclusiveLockTest = pipelineschecksextras.CheckConfiguration{
 	Settings: CheckExclusiveLockSettings,
 	Timeout:  converter.ToPtr(20000),
 	Resource: &endpointResource,
+	Version:  converter.Int(0),
 }
 
 // verifies that the flatten/expand round trip yields the same exclusive lock check

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_required_template_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_required_template_test.go
@@ -45,6 +45,7 @@ var requiredTemplateCheckTest = pipelineschecksextras.CheckConfiguration{
 	Type:     approvalAndCheckType.ExtendsCheck,
 	Settings: requiredTemplateCheckSettings,
 	Resource: &requiredTemplateTestEndpointResource,
+	Version:  converter.Int(0),
 }
 
 // verifies that the flatten/expand round trip yields the same required template

--- a/azuredevops/utils/pipelineschecksextras/models.go
+++ b/azuredevops/utils/pipelineschecksextras/models.go
@@ -36,6 +36,8 @@ type CheckConfiguration struct {
 	Settings interface{} `json:"settings,omitempty"`
 	// Timeout in minutes for the check.
 	Timeout *int `json:"timeout,omitempty"`
+	// Version of check configuration
+	Version *int `json:"version,omitempty"`
 }
 
 type CheckConfigurationRef struct {

--- a/website/docs/r/check_approval.html.markdown
+++ b/website/docs/r/check_approval.html.markdown
@@ -2,7 +2,7 @@
 layout: "azuredevops"
 page_title: "AzureDevops: azuredevops_check_approval"
 description: |-
-  Manages a Approval Check.
+  Manages an Approval Check.
 ---
 
 # azuredevops_check_approval
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `target_resource_type` - (Required) The type of resource being protected by the check. Valid values: `endpoint`, `environment`, `queue`, `repository`, `securefile`, `variablegroup`. Changing this forces a new Approval Check to be created.
 
 * `approvers` - (Required) Specifies a list of approver IDs.
- 
+
 ---
 
 * `instructions` - (Optional) The instructions for the approvers.
@@ -93,13 +93,14 @@ The following arguments are supported:
 
 * `requester_can_approve` - (Optional) Can the requestor approve? Defaults to `false`.
 
-* `timeout` - (Optional) The timeout in minutes for the approval.  Defaults to `43200`. 
+* `timeout` - (Optional) The timeout in minutes for the approval.  Defaults to `43200`.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Approval Check.
+* `id` - The ID of the check.
+* `version` - The version of the check.
 
 ## Timeouts
 

--- a/website/docs/r/check_branch_control.html.markdown
+++ b/website/docs/r/check_branch_control.html.markdown
@@ -162,7 +162,8 @@ The following arguments are supported:
 
 In addition to all arguments above the following attributes are exported:
 
-- `id` - The ID of the check.
+* `id` - The ID of the check.
+* `version` - The version of the check.
 
 ## Relevant Links
 

--- a/website/docs/r/check_business_hours.html.markdown
+++ b/website/docs/r/check_business_hours.html.markdown
@@ -189,7 +189,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the check.
+* `id` - The ID of the check.
+* `version` - The version of the check.
 
 ## Relevant Links
 

--- a/website/docs/r/check_exclusive_lock.html.markdown
+++ b/website/docs/r/check_exclusive_lock.html.markdown
@@ -2,7 +2,7 @@
 layout: "azuredevops"
 page_title: "AzureDevops: azuredevops_check_exclusive_lock"
 description: |-
-  Manages a Exclusive Lock Check.
+  Manages an Exclusive Lock Check.
 ---
 
 # azuredevops_check_exclusive_lock
@@ -68,7 +68,7 @@ The following arguments are supported:
 * `target_resource_id` - (Required) The ID of the resource being protected by the check. Changing this forces a new Exclusive Lock to be created.
 
 * `target_resource_type` - (Required) The type of resource being protected by the check. Valid values: `endpoint`, `environment`, `queue`, `repository`, `securefile`, `variablegroup`. Changing this forces a new Exclusive Lock to be created.
- 
+
 ---
 
 * `timeout` - (Optional) The timeout in minutes for the exclusive lock. Defaults to `43200`.
@@ -77,7 +77,8 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Exclusive Lock.
+* `id` - The ID of the check.
+* `version` - The version of the check.
 
 ## Timeouts
 

--- a/website/docs/r/check_required_template.html.markdown
+++ b/website/docs/r/check_required_template.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 * `target_resource_type` - (Required) The type of resource being protected by the check. Valid values: `endpoint`, `environment`, `queue`, `repository`, `securefile`, `variablegroup`. Changing this forces a new Required Template Check to be created.
 
 * `required_template` - (Required) One or more `required_template` blocks documented below.
- 
+
 A `required_template` block supports the following:
 
 - `repository_type` - (Optional) The type of the repository storing the template. Valid values: `azuregit`, `github`, `bitbucket`. Defaults to `azuregit`.
@@ -95,7 +95,8 @@ A `required_template` block supports the following:
 
 In addition to the Arguments listed above - the following attribute are exported:
 
-* `id` - The ID of the Required Template Check.
+* `id` - The ID of the check.
+* `version` - The version of the check.
 
 ## Import
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

From my testing, the rest API in AzureDevOps has introduced a new required fields `version`, although the API documentation doesn't mention it.

https://learn.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/check-configurations/update?view=azure-devops-rest-7.1&tabs=HTTP

I've added a new computed property to read and send it from/to AZDO.

Issue Number: #976 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

You can see the existing bug by running tests on `^TestAccCheck\\w+_update$` on the current version of the provider.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->