### PR TITLE
Add `id` attribute to `azuredevops_groups` datasource

### DIFF
--- a/azuredevops/internal/service/graph/data_groups_test.go
+++ b/azuredevops/internal/service/graph/data_groups_test.go
@@ -122,12 +122,28 @@ func TestGroupsDataSource_HandlesContinuationToken(t *testing.T) {
 		ListGroups(clients.Ctx, firstListGroupCallArgs).
 		Return(firstListGroupCallResponse, nil)
 
+	firstCall = append(firstCall, graphClient.
+		EXPECT().
+		GetStorageKey(clients.Ctx, gomock.Any()).
+		Return(&graph.GraphStorageKeyResult{
+			Links: "",
+			Value: &id,
+		}, nil))
+
 	secondListGroupCallArgs := graph.ListGroupsArgs{ScopeDescriptor: projectDescriptor, ContinuationToken: &continuationToken}
 	secondListGroupCallResponse := createPaginatedResponse("", groupMeta{name: "name2", descriptor: "descriptor2", origin: "vsts", originId: uuid.New().String()})
 	secondCall := graphClient.
 		EXPECT().
 		ListGroups(clients.Ctx, secondListGroupCallArgs).
 		Return(secondListGroupCallResponse, nil)
+
+	secondCall = append(secondCall, graphClient.
+		EXPECT().
+		GetStorageKey(clients.Ctx, gomock.Any()).
+		Return(&graph.GraphStorageKeyResult{
+			Links: "",
+			Value: &id,
+		}, nil))
 
 	gomock.InOrder(firstCall, secondCall)
 

--- a/azuredevops/internal/service/graph/data_groups_test.go
+++ b/azuredevops/internal/service/graph/data_groups_test.go
@@ -139,7 +139,7 @@ func TestGroupsDataSource_HandlesContinuationToken(t *testing.T) {
 		Return(&graph.GraphStorageKeyResult{
 			Links: "",
 			Value: &id,
-		}, nil))
+		}, nil).Times(2))
 
 	gomock.InOrder(calls...)
 

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -38,6 +38,7 @@ The following attributes are exported:
 
 - `groups` - A set of existing groups in your Azure DevOps Organization or project with details about every single group which includes:
 
+  - `id` - The group ID.
   - `description` - A short phrase to help human readers disambiguate groups with similar names
   - `descriptor` - The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations.
   - `display_name` - This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Same as `azuredevops_users` datasource - expose StorageKey descriptor value as an `id` attribute of groups collection.