### PR TITLE
`azuredevops_team` - Fixing the team admin flags

### DIFF
--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -494,11 +494,10 @@ func readTeamAdministrators(d *schema.ResourceData, clients *client.AggregatedCl
 
 	adminDescriptorList := []string{}
 	if acl != nil && acl.AcesDictionary != nil {
-		// For backwards compatibility, we check only the ManageMembership bit, but a proper admin actually requires all bits filled (ace.Allow=31). When creating a new admin,
-		// all bits are set, so this is not a problem.
-		bit := *(*actionDefinitions)["ManageMembership"].Bit
+		bit := *(*actionDefinitions)["Read"].Bit | *(*actionDefinitions)["Write"].Bit | *(*actionDefinitions)["Delete"].Bit | *(*actionDefinitions)["ManageMembership"].Bit | *(*actionDefinitions)["CreateScope"].Bit
 		for _, ace := range *acl.AcesDictionary {
-			if *ace.Allow&bit > 0 {
+
+			if *ace.Allow&bit == bit {
 				adminDescriptorList = append(adminDescriptorList, *ace.Descriptor)
 			}
 		}

--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -494,6 +494,8 @@ func readTeamAdministrators(d *schema.ResourceData, clients *client.AggregatedCl
 
 	adminDescriptorList := []string{}
 	if acl != nil && acl.AcesDictionary != nil {
+		// For backwards compatibility, we check only the ManageMembership bit, but a proper admin actually requires all bits filled (ace.Allow=31). When creating a new admin,
+		// all bits are set, so this is not a problem.
 		bit := *(*actionDefinitions)["ManageMembership"].Bit
 		for _, ace := range *acl.AcesDictionary {
 			if *ace.Allow&bit > 0 {
@@ -563,7 +565,11 @@ func setTeamAdministratorsPermissions(d *schema.ResourceData, clients *client.Ag
 				PrincipalPermission: securityhelper.PrincipalPermission{
 					SubjectDescriptor: item.(string),
 					Permissions: map[securityhelper.ActionName]securityhelper.PermissionType{
+						"Read":             permission,
+						"Write":            permission,
+						"Delete":           permission,
 						"ManageMembership": permission,
+						"CreateScope":      permission,
 					},
 				},
 			}

--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -496,7 +496,6 @@ func readTeamAdministrators(d *schema.ResourceData, clients *client.AggregatedCl
 	if acl != nil && acl.AcesDictionary != nil {
 		bit := *(*actionDefinitions)["Read"].Bit | *(*actionDefinitions)["Write"].Bit | *(*actionDefinitions)["Delete"].Bit | *(*actionDefinitions)["ManageMembership"].Bit | *(*actionDefinitions)["CreateScope"].Bit
 		for _, ace := range *acl.AcesDictionary {
-
 			if *ace.Allow&bit == bit {
 				adminDescriptorList = append(adminDescriptorList, *ace.Descriptor)
 			}

--- a/azuredevops/internal/service/core/resource_team_test.go
+++ b/azuredevops/internal/service/core/resource_team_test.go
@@ -151,13 +151,7 @@ func TestTeam_Create_EnsureTeamDeletedOnAddAdministratorsError(t *testing.T) {
 		}).
 		Return(&[]security.AccessControlList{}, nil).
 		Times(1)
-
-	securityClient.
-		EXPECT().
-		SetAccessControlEntries(clients.Ctx, gomock.Any()).
-		Return(nil, fmt.Errorf("@@SetAccessControlEntries@@failed@@")).
-		Times(1)
-
+	
 	coreClient.
 		EXPECT().
 		DeleteTeam(clients.Ctx, core.DeleteTeamArgs{

--- a/azuredevops/internal/service/core/resource_team_test.go
+++ b/azuredevops/internal/service/core/resource_team_test.go
@@ -151,7 +151,7 @@ func TestTeam_Create_EnsureTeamDeletedOnAddAdministratorsError(t *testing.T) {
 		}).
 		Return(&[]security.AccessControlList{}, nil).
 		Times(1)
-	
+
 	coreClient.
 		EXPECT().
 		DeleteTeam(clients.Ctx, core.DeleteTeamArgs{


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Before: Team administrator was created with flags ManageMembership
After: Team administrator is created with flags Read, Write, Delete, ManageMembership, CreateScope

The behavior before is not consistent with the UI. When you create a team administrator via UI, it is consistent with the behavior after.

Issue Number: #979 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->