### PR TITLE
`azuredevops_pipeline_authorization` - Fix pipeline authorization not authorized

### DIFF
--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -131,7 +131,7 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 		return fmt.Errorf("%+v", err)
 	}
 
-	if resp == nil {
+	if resp == nil || (resp.AllPipelines == nil && len(*resp.Pipelines) == 0) {
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #847 
```log
=== RUN   TestAccPipelineAuthorization_allPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipeline_queue
=== RUN   TestAccPipelineAuthorization_pipeline_queue
=== PAUSE TestAccPipelineAuthorization_pipeline_queue
=== RUN   TestAccPipelineAuthorization_multiPipeline_queue
=== PAUSE TestAccPipelineAuthorization_multiPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipeline_environment
=== PAUSE TestAccPipelineAuthorization_allPipeline_environment
=== RUN   TestAccPipelineAuthorization_pipeline_environment
=== PAUSE TestAccPipelineAuthorization_pipeline_environment
=== RUN   TestAccPipelineAuthorization_allPipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_allPipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_pipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_pipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_allPipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_allPipeline_endpoint
=== RUN   TestAccPipelineAuthorization_pipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_pipeline_endpoint
=== RUN   TestAccPipelineAuthorization_allPipeline_repository
=== PAUSE TestAccPipelineAuthorization_allPipeline_repository
=== RUN   TestAccPipelineAuthorization_pipeline_repository
=== PAUSE TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_pipeline_endpoint
=== CONT  TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_pipeline_environment
=== CONT  TestAccPipelineAuthorization_allPipeline_endpoint
=== CONT  TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_repository
--- PASS: TestAccPipelineAuthorization_allPipeline_repository (111.96s)
=== CONT  TestAccPipelineAuthorization_allPipeline_environment
--- PASS: TestAccPipelineAuthorization_pipeline_repository (112.44s)
=== CONT  TestAccPipelineAuthorization_pipeline_variableGroup
--- PASS: TestAccPipelineAuthorization_pipeline_environment (112.74s)
=== CONT  TestAccPipelineAuthorization_multiPipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipeline_queue (113.23s)
=== CONT  TestAccPipelineAuthorization_pipeline_queue
--- PASS: TestAccPipelineAuthorization_allPipelineWithPipeline_queue (114.09s)
--- PASS: TestAccPipelineAuthorization_allPipeline_variableGroup (123.03s)
--- PASS: TestAccPipelineAuthorization_allPipeline_endpoint (130.87s)
--- PASS: TestAccPipelineAuthorization_pipeline_endpoint (132.55s)
--- PASS: TestAccPipelineAuthorization_allPipeline_environment (46.46s)
--- PASS: TestAccPipelineAuthorization_pipeline_queue (60.16s)
--- PASS: TestAccPipelineAuthorization_multiPipeline_queue (61.78s)
--- PASS: TestAccPipelineAuthorization_pipeline_variableGroup (73.91s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        215.414s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->