### PR TITLE
`azuredevops_git_repository_branch` - Fix not refresh the state when branch is deleted

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -2,12 +2,15 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
@@ -163,6 +166,14 @@ func resourceGitRepositoryBranchRead(ctx context.Context, d *schema.ResourceData
 		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
 			return nil
+		}
+		var branchErr azuredevops.WrappedError
+		if errors.As(err, &branchErr) {
+			regx := regexp.MustCompile(fmt.Sprintf("Branch \"%[1]s\" does not exist in the %[2]s repository.", shortBranchName, repoId))
+			if branchErr.Message != nil && regx.MatchString(*branchErr.Message) {
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.FromErr(fmt.Errorf("Error reading branch %q: %w", name, err))
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #984
```log
=== RUN   TestAccGitRepoBranch_CreateAndUpdate
--- PASS: TestAccGitRepoBranch_CreateAndUpdate (125.55s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        142.133s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->