### PR TITLE
`azuredevops_serviceendpoint_azurerm` - Fix `azurerm_subscription_id` conflicts with `azurerm_management_group_id`

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -52,11 +52,10 @@ func ResourceServiceEndpointAzureRM() *schema.Resource {
 
 	// Subscription scopeLevel
 	r.Schema["azurerm_subscription_id"] = &schema.Schema{
-		Type:          schema.TypeString,
-		Optional:      true,
-		DefaultFunc:   schema.EnvDefaultFunc("ARM_SUBSCRIPTION_ID", nil),
-		Description:   "The Azure subscription Id which should be used.",
-		ConflictsWith: []string{"azurerm_management_group_id"},
+		Type:        schema.TypeString,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("ARM_SUBSCRIPTION_ID", nil),
+		Description: "The Azure subscription Id which should be used.",
 	}
 
 	r.Schema["azurerm_subscription_name"] = &schema.Schema{
@@ -472,18 +471,6 @@ func validateScopeLevel(scopeMap map[string][]string) error {
 	// Check for empty
 	if strings.TrimSpace(strings.Join(scopeMap["subscription"], "")) == "" && strings.TrimSpace(strings.Join(scopeMap["managementGroup"], "")) == "" {
 		return fmt.Errorf("One of either subscription scoped (azurerm_subscription_id, azurerm_subscription_name) or managementGroup scoped (azurerm_management_ggroup_id, azurerm_management_group_name) details must be provided")
-	}
-
-	// check for valid subscription details
-	var subElementCount int
-	for _, ele := range scopeMap["subscription"] {
-		if ele == "" {
-			subElementCount = subElementCount + 1
-		}
-	}
-
-	if subElementCount == 1 {
-		return fmt.Errorf("azurerm_subscription_id and azurerm_subscription_name must be provided")
 	}
 
 	// check for valid managementGroup details


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #833 
```log
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_Create_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_Create_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_Create_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
--- PASS: TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate (85.29s)
--- PASS: TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate (114.55s)
--- PASS: TestAccServiceEndpointAzureRm_Create_WithValidate (120.44s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate (128.01s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate (129.82s)
--- PASS: TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate (129.99s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate (146.62s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate (156.98s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        160.927s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->