### PR TITLE
`azuredevops_git_repository`  - Fix cannot set repo `default _branch` when updating

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -161,6 +161,12 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 			d.Get("project_id").(string), d.Get("name").(string), err)
 	}
 
+	if _, ok := d.GetOk("default_branch"); ok {
+		if strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Uninitialized)) {
+			return fmt.Errorf(" Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannt not be set.")
+		}
+	}
+
 	var parentRepoRef *git.GitRepositoryRef = nil
 	if parentRepoID, ok := d.GetOk("parent_repository_id"); ok {
 		parentRepo, err := gitRepositoryRead(clients, parentRepoID.(string), "", "")
@@ -476,12 +482,6 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 			initialization.sourceType = ""
 			initialization.sourceURL = ""
 			initialization.serviceConnectionID = ""
-		}
-
-		if _, ok := d.GetOk("default_branch"); ok {
-			if strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Uninitialized)) {
-				return nil, nil, nil, fmt.Errorf(" Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannt not be set.")
-			}
 		}
 	} else if len(initData) > 1 {
 		return nil, nil, nil, fmt.Errorf("Multiple initialization blocks")


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
Fixes: #1016 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->