### PR TITLE
New Resource `azuredevops_service_principal_entitlement`

### DIFF
--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -39,7 +39,6 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 			"origin": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ForceNew:     true,
 				Default:      string("aad"),
 				ValidateFunc: validation.StringIsNotWhiteSpace,

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -20,13 +20,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/suppress"
 )
 
-var (
-	spConfigurationKeys = []string{
-		"origin",
-		"origin_id",
-	}
-)
-
 func ResourceServicePrincipalEntitlement() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceServicePrincipalEntitlementCreate,
@@ -40,9 +33,7 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 			"origin_id": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Computed:     false,
 				ForceNew:     true,
-				ExactlyOneOf: spConfigurationKeys,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"origin": {
@@ -51,7 +42,6 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Default:      string("aad"),
-				ExactlyOneOf: spConfigurationKeys,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"account_license_type": {

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -206,10 +206,8 @@ func resourceServicePrincipalEntitlementUpdate(d *schema.ResourceData, m interfa
 		return fmt.Errorf("Updating service principal entitlement: %v", err)
 	}
 
-	result := *patchResponse.OperationResults
-
-	if !*result[0].IsSuccess {
-		return fmt.Errorf("Updating service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(&result))
+	if !*patchResponse.IsSuccess {
+		return fmt.Errorf("Updating service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(patchResponse.OperationResults))
 	}
 	return resourceServicePrincipalEntitlementRead(d, m)
 }

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -39,7 +39,7 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"origin_id": {
 				Type:         schema.TypeString,
-				Optional:     false,
+				Required:     true,
 				Computed:     false,
 				ForceNew:     true,
 				ExactlyOneOf: spConfigurationKeys,
@@ -47,9 +47,10 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 			},
 			"origin": {
 				Type:         schema.TypeString,
-				Optional:     false,
-				Computed:     false,
+				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
+				Default:      string("aad"),
 				ExactlyOneOf: spConfigurationKeys,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -62,16 +62,8 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 						string(licensing.AccountLicenseTypeValues.Express),
 						"basic",
 					}
-					stringInSlice := func(v string, valid []string) bool {
-						for _, str := range valid {
-							if strings.EqualFold(v, str) {
-								return true
-							}
-						}
-						return false
-					}
 					return strings.EqualFold(old, new) ||
-						(stringInSlice(old, equalEntitlements) && stringInSlice(new, equalEntitlements))
+						(slices.Contains(equalEntitlements, old) && slices.Contains(equalEntitlements, new))
 				},
 			},
 			"licensing_source": {

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	spConfigurationKeys = []string{
-		"display_name",
+		"origin",
 		"origin_id",
 	}
 )
@@ -37,37 +37,21 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 			State: importServicePrincipalEntitlement,
 		},
 		Schema: map[string]*schema.Schema{
-			"principal_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"display_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ConflictsWith: []string{"origin_id", "origin"},
-				ExactlyOneOf:  spConfigurationKeys,
-				ValidateFunc:  validation.StringIsNotWhiteSpace,
-			},
 			"origin_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"display_name"},
-				RequiredWith:  []string{"origin"},
-				ExactlyOneOf:  spConfigurationKeys,
-				ValidateFunc:  validation.StringIsNotWhiteSpace,
+				Type:         schema.TypeString,
+				Optional:     false,
+				Computed:     false,
+				ForceNew:     true,
+				ExactlyOneOf: spConfigurationKeys,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"origin": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"display_name"},
-				RequiredWith:  []string{"origin_id"},
-				ValidateFunc:  validation.StringIsNotWhiteSpace,
+				Type:         schema.TypeString,
+				Optional:     false,
+				Computed:     false,
+				ForceNew:     true,
+				ExactlyOneOf: spConfigurationKeys,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"account_license_type": {
 				Type:     schema.TypeString,
@@ -264,11 +248,7 @@ func flattenServicePrincipalEntitlement(d *schema.ResourceData, servicePrincipal
 	d.SetId(servicePrincipalEntitlement.Id.String())
 	d.Set("descriptor", *servicePrincipalEntitlement.ServicePrincipal.Descriptor)
 	d.Set("origin", *servicePrincipalEntitlement.ServicePrincipal.Origin)
-	d.Set("principal_name", *servicePrincipalEntitlement.ServicePrincipal.PrincipalName)
-	if servicePrincipalEntitlement.ServicePrincipal.OriginId != nil {
-		d.Set("origin_id", *servicePrincipalEntitlement.ServicePrincipal.OriginId)
-	}
-	d.Set("display_name", *servicePrincipalEntitlement.ServicePrincipal.DisplayName)
+	d.Set("origin_id", *servicePrincipalEntitlement.ServicePrincipal.OriginId)
 	d.Set("account_license_type", string(*servicePrincipalEntitlement.AccessLevel.AccountLicenseType))
 	d.Set("licensing_source", *servicePrincipalEntitlement.AccessLevel.LicensingSource)
 }
@@ -276,7 +256,6 @@ func flattenServicePrincipalEntitlement(d *schema.ResourceData, servicePrincipal
 func expandServicePrincipalEntitlement(d *schema.ResourceData) (*memberentitlementmanagement.ServicePrincipalEntitlement, error) {
 	origin := d.Get("origin").(string)
 	originID := d.Get("origin_id").(string)
-	displayName := d.Get("display_name").(string)
 
 	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
 	if err != nil {
@@ -296,7 +275,6 @@ func expandServicePrincipalEntitlement(d *schema.ResourceData) (*memberentitleme
 		ServicePrincipal: &graph.GraphServicePrincipal{
 			Origin:      &origin,
 			OriginId:    &originID,
-			DisplayName: &displayName,
 			SubjectKind: converter.String("servicePrincipal"),
 		},
 	}, nil

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -51,6 +51,7 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 					string(licensing.AccountLicenseTypeValues.Advanced),
 					string(licensing.AccountLicenseTypeValues.EarlyAdopter),
 					string(licensing.AccountLicenseTypeValues.Express),
+					"basic",
 					string(licensing.AccountLicenseTypeValues.None),
 					string(licensing.AccountLicenseTypeValues.Professional),
 					string(licensing.AccountLicenseTypeValues.Stakeholder),

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -1,0 +1,385 @@
+package memberentitlementmanagement
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ahmetb/go-linq"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/accounts"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/graph"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/licensing"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/memberentitlementmanagement"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/suppress"
+)
+
+var (
+	spConfigurationKeys = []string{
+		"origin_id",
+		"origin",
+		"principal_name",
+	}
+)
+
+// ResourceServicePrincipalEntitlement schema and implementation for service principal entitlement resource
+func ResourceServicePrincipalEntitlement() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServicePrincipalEntitlementCreate,
+		Read:   resourceServicePrincipalEntitlementRead,
+		Delete: resourceServicePrincipalEntitlementDelete,
+		Update: resourceServicePrincipalEntitlementUpdate,
+		Importer: &schema.ResourceImporter{
+			State: importServicePrincipalEntitlement,
+		},
+		Schema: map[string]*schema.Schema{
+			"principal_name": {
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"origin_id", "origin"},
+				AtLeastOneOf:     spConfigurationKeys,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     validation.StringIsNotWhiteSpace,
+			},
+			"origin_id": {
+				Type:          schema.TypeString,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"principal_name"},
+				AtLeastOneOf:  spConfigurationKeys,
+				ValidateFunc:  validation.StringIsNotWhiteSpace,
+			},
+			"origin": {
+				Type:          schema.TypeString,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"principal_name"},
+				AtLeastOneOf:  spConfigurationKeys,
+				ValidateFunc:  validation.StringIsNotWhiteSpace,
+			},
+			"account_license_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  licensing.AccountLicenseTypeValues.Express,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(licensing.AccountLicenseTypeValues.Advanced),
+					string(licensing.AccountLicenseTypeValues.EarlyAdopter),
+					string(licensing.AccountLicenseTypeValues.Express),
+					"basic",
+					string(licensing.AccountLicenseTypeValues.None),
+					string(licensing.AccountLicenseTypeValues.Professional),
+					string(licensing.AccountLicenseTypeValues.Stakeholder),
+				}, true),
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					equalEntitlements := []string{
+						string(licensing.AccountLicenseTypeValues.EarlyAdopter),
+						string(licensing.AccountLicenseTypeValues.Express),
+						"basic",
+					}
+					stringInSlice := func(v string, valid []string) bool {
+						for _, str := range valid {
+							if strings.EqualFold(v, str) {
+								return true
+							}
+						}
+						return false
+					}
+					return strings.EqualFold(old, new) ||
+						(stringInSlice(old, equalEntitlements) && stringInSlice(new, equalEntitlements))
+				},
+			},
+			"licensing_source": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(licensing.LicensingSourceValues.Account),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(licensing.LicensingSourceValues.None),
+					string(licensing.LicensingSourceValues.Account),
+					string(licensing.LicensingSourceValues.Msdn),
+					string(licensing.LicensingSourceValues.Profile),
+					string(licensing.LicensingSourceValues.Auto),
+					string(licensing.LicensingSourceValues.Trial),
+				}, true),
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+			"descriptor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceServicePrincipalEntitlementCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	servicePrincipalEntitlement, err := expandServicePrincipalEntitlement(d)
+	if err != nil {
+		return fmt.Errorf("Creating service principal entitlement: %v", err)
+	}
+
+	addedServicePrincipalEntitlement, err := addServicePrincipalEntitlement(clients, servicePrincipalEntitlement)
+	if err != nil {
+		return fmt.Errorf("Creating service principal entitlement: %v", err)
+	}
+
+	flattenServicePrincipalEntitlement(d, addedServicePrincipalEntitlement)
+	return resourceServicePrincipalEntitlementRead(d, m)
+}
+
+func resourceServicePrincipalEntitlementRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	servicePrincipalEntitlementID := d.Id()
+	id, err := uuid.Parse(servicePrincipalEntitlementID)
+	if err != nil {
+		return fmt.Errorf("Error parsing ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+	}
+
+	servicePrincipalEntitlement, err := readServicePrincipalEntitlement(clients, &id)
+
+	if err != nil {
+		if utils.ResponseWasNotFound(err) || isServicePrincipalDeleted(servicePrincipalEntitlement) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading service principal entitlement: %v", err)
+	}
+
+	flattenServicePrincipalEntitlement(d, servicePrincipalEntitlement)
+	return nil
+}
+
+func expandServicePrincipalEntitlement(d *schema.ResourceData) (*memberentitlementmanagement.ServicePrincipalEntitlement, error) {
+	origin := d.Get("origin").(string)
+	originID := d.Get("origin_id").(string)
+	principalName := d.Get("principal_name").(string)
+
+	if len(originID) > 0 && len(principalName) > 0 {
+		return nil, fmt.Errorf("Both origin_id and principal_name set. You can not use both: origin_id: %s principal_name %s", originID, principalName)
+	}
+
+	if len(originID) == 0 && len(principalName) == 0 {
+		return nil, fmt.Errorf("Neither origin_id and principal_name set. Use origin_id or principal_name")
+	}
+
+	if len(originID) > 0 && len(origin) == 0 {
+		return nil, fmt.Errorf("Origin_id requires an origin to be set")
+	}
+
+	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
+	if err != nil {
+		return nil, err
+	}
+	licensingSource, err := converter.AccountLicensingSource(d.Get("licensing_source").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	return &memberentitlementmanagement.ServicePrincipalEntitlement{
+
+		AccessLevel: &licensing.AccessLevel{
+			AccountLicenseType: accountLicenseType,
+			LicensingSource:    licensingSource,
+		},
+
+		// TODO check if it works in both case for GitHub and AzureDevOps
+		ServicePrincipal: &graph.GraphServicePrincipal{
+			Origin:        &origin,
+			OriginId:      &originID,
+			PrincipalName: &principalName,
+			SubjectKind:   converter.String("servicePrincipal"),
+		},
+	}, nil
+}
+
+func flattenServicePrincipalEntitlement(d *schema.ResourceData, servicePrincipalEntitlement *memberentitlementmanagement.ServicePrincipalEntitlement) {
+	d.SetId(servicePrincipalEntitlement.Id.String())
+	d.Set("descriptor", *servicePrincipalEntitlement.ServicePrincipal.Descriptor)
+	d.Set("origin", *servicePrincipalEntitlement.ServicePrincipal.Origin)
+	if servicePrincipalEntitlement.ServicePrincipal.OriginId != nil {
+		d.Set("origin_id", *servicePrincipalEntitlement.ServicePrincipal.OriginId)
+	}
+	d.Set("principal_name", *servicePrincipalEntitlement.ServicePrincipal.PrincipalName)
+	d.Set("account_license_type", string(*servicePrincipalEntitlement.AccessLevel.AccountLicenseType))
+	d.Set("licensing_source", *servicePrincipalEntitlement.AccessLevel.LicensingSource)
+}
+
+func addServicePrincipalEntitlement(clients *client.AggregatedClient, servicePrincipalEntitlement *memberentitlementmanagement.ServicePrincipalEntitlement) (*memberentitlementmanagement.ServicePrincipalEntitlement, error) {
+	servicePrincipalEntitlementsPostResponse, err := clients.MemberEntitleManagementClient.AddServicePrincipalEntitlement(clients.Ctx, memberentitlementmanagement.AddServicePrincipalEntitlementArgs{
+		ServicePrincipalEntitlement: servicePrincipalEntitlement,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !*servicePrincipalEntitlementsPostResponse.IsSuccess {
+		opResults := []memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{}
+		if servicePrincipalEntitlementsPostResponse.OperationResult != nil {
+			opResults = append(opResults, *servicePrincipalEntitlementsPostResponse.OperationResult)
+		}
+		return nil, fmt.Errorf("Adding service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(&opResults))
+	}
+
+	return servicePrincipalEntitlementsPostResponse.ServicePrincipalEntitlement, nil
+}
+
+func readServicePrincipalEntitlement(clients *client.AggregatedClient, id *uuid.UUID) (*memberentitlementmanagement.ServicePrincipalEntitlement, error) {
+	return clients.MemberEntitleManagementClient.GetServicePrincipalEntitlement(clients.Ctx, memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
+		ServicePrincipalId: id,
+	})
+}
+
+func resourceServicePrincipalEntitlementDelete(d *schema.ResourceData, m interface{}) error {
+	if d.Id() == "" {
+		return nil
+	}
+
+	servicePrincipalEntitlementID := d.Id()
+	id, err := uuid.Parse(servicePrincipalEntitlementID)
+	if err != nil {
+		return fmt.Errorf("Error parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+	}
+
+	clients := m.(*client.AggregatedClient)
+
+	err = clients.MemberEntitleManagementClient.DeleteServicePrincipalEntitlement(m.(*client.AggregatedClient).Ctx, memberentitlementmanagement.DeleteServicePrincipalEntitlementArgs{
+		ServicePrincipalId: &id,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Deleting service principal entitlement: %v", err)
+	}
+
+	return nil
+}
+
+func resourceServicePrincipalEntitlementUpdate(d *schema.ResourceData, m interface{}) error {
+	servicePrincipalEntitlementID := d.Id()
+	id, err := uuid.Parse(servicePrincipalEntitlementID)
+	if err != nil {
+		return fmt.Errorf("Parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+	}
+
+	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
+	if err != nil {
+		return err
+	}
+	licensingSource, ok := d.GetOk("licensing_source")
+	if !ok {
+		return fmt.Errorf("Reading account licensing source for ServicePrincipalEntitlementID: %s", servicePrincipalEntitlementID)
+	}
+
+	clients := m.(*client.AggregatedClient)
+
+	patchResponse, err := clients.MemberEntitleManagementClient.UpdateServicePrincipalEntitlement(clients.Ctx,
+		memberentitlementmanagement.UpdateServicePrincipalEntitlementArgs{
+			ServicePrincipalId: &id,
+			Document: &[]webapi.JsonPatchOperation{
+				{
+					Op:   &webapi.OperationValues.Replace,
+					From: nil,
+					Path: converter.String("/accessLevel"),
+					Value: struct {
+						AccountLicenseType string `json:"accountLicenseType"`
+						LicensingSource    string `json:"licensingSource"`
+					}{
+						string(*accountLicenseType),
+						licensingSource.(string),
+					},
+				},
+			},
+		})
+
+	if err != nil {
+		return fmt.Errorf("Updating service principal entitlement: %v", err)
+	}
+
+	if !*patchResponse.IsSuccess {
+		return fmt.Errorf("Updating service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(patchResponse.OperationResults))
+	}
+	return resourceServicePrincipalEntitlementRead(d, m)
+}
+
+var spEmailRegexp = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
+func importServicePrincipalEntitlement(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	_, err := uuid.Parse(d.Id())
+	if err != nil {
+		upn := d.Id()
+		if !spEmailRegexp.MatchString(upn) {
+			return nil, fmt.Errorf("Only UUID and UPN values can used for import [%s]", upn)
+		}
+
+		clients := m.(*client.AggregatedClient)
+		result, err := clients.IdentityClient.ReadIdentities(clients.Ctx, identity.ReadIdentitiesArgs{
+			SearchFilter: converter.String("General"),
+			FilterValue:  &upn,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if result == nil || len(*result) <= 0 {
+			return nil, fmt.Errorf("No entitlement found for [%s]", upn)
+		}
+		if len(*result) > 1 {
+			return nil, fmt.Errorf("More than one entitlement found for [%s]", upn)
+		}
+
+		d.SetId((*result)[0].Id.String())
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func getServicePrincipalEntitlementAPIErrorMessage(operationResults *[]memberentitlementmanagement.ServicePrincipalEntitlementOperationResult) string {
+	errMsg := "Unknown API error"
+	if operationResults != nil && len(*operationResults) > 0 {
+		errMsg = linq.From(*operationResults).
+			Where(func(elem interface{}) bool {
+				ueo := elem.(memberentitlementmanagement.ServicePrincipalEntitlementOperationResult)
+				return !*ueo.IsSuccess
+			}).
+			SelectMany(func(elem interface{}) linq.Query {
+				ueo := elem.(memberentitlementmanagement.ServicePrincipalEntitlementOperationResult)
+				if ueo.Errors == nil {
+					key := interface{}("0000")
+					value := interface{}("Unknown API error")
+					return linq.From([]azuredevops.KeyValuePair{
+						{
+							Key:   &key,
+							Value: &value,
+						},
+					})
+				}
+				return linq.From(*ueo.Errors)
+			}).
+			SelectT(func(err azuredevops.KeyValuePair) string {
+				return fmt.Sprintf("(%v) %s", *err.Key, *err.Value)
+			}).
+			AggregateT(func(agg string, elem string) string {
+				return agg + "\n" + elem
+			}).(string)
+	}
+	return errMsg
+}
+
+func isServicePrincipalDeleted(servicePrincipalEntitlement *memberentitlementmanagement.ServicePrincipalEntitlement) bool {
+	if servicePrincipalEntitlement == nil {
+		return true
+	}
+
+	return *servicePrincipalEntitlement.AccessLevel.Status == accounts.AccountUserStatusValues.Deleted ||
+		*servicePrincipalEntitlement.AccessLevel.Status == accounts.AccountUserStatusValues.None
+}

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -40,7 +40,7 @@ func ResourceServicePrincipalEntitlement() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				Default:      string("aad"),
+				Default:      "aad",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"account_license_type": {

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -234,7 +234,7 @@ func importServicePrincipalEntitlement(d *schema.ResourceData, m interface{}) ([
 }
 
 func flattenServicePrincipalEntitlement(d *schema.ResourceData, servicePrincipalEntitlement *memberentitlementmanagement.ServicePrincipalEntitlement) {
-	d.SetId(servicePrincipalEntitlement.Id.String())
+	
 	d.Set("descriptor", *servicePrincipalEntitlement.ServicePrincipal.Descriptor)
 	d.Set("origin", *servicePrincipalEntitlement.ServicePrincipal.Origin)
 	d.Set("origin_id", *servicePrincipalEntitlement.ServicePrincipal.OriginId)

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement_test.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement_test.go
@@ -1,0 +1,632 @@
+//go:build (all || resource_user_entitlement) && !exclude_resource_user_entitlement
+// +build all resource_user_entitlement
+// +build !exclude_resource_user_entitlement
+
+package memberentitlementmanagement
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/graph"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/licensing"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/memberentitlementmanagement"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// if origin_id is provided, it will be used. if principal_name is also supplied, an error will be reported.
+func TestServicePrincipalEntitlement_CreateServicePrincipalEntitlement_DoNotAllowToSetOridinIdAndPrincipalName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: nil,
+		Ctx:                           context.Background(),
+	}
+
+	originID := "e97b0e7f-0a61-41ad-860c-748ec5fcb20b"
+	principalName := "foobar@microsoft.com"
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.Set("origin_id", originID)
+	resourceData.Set("principal_name", principalName)
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	require.Regexp(t, "Both origin_id and principal_name set. You can not use both", err.Error())
+}
+
+// if origin_id is "" and principal_name is supplied, the principal_name will be used.
+func TestServicePrincipalEntitlement_CreateServicePrincipalEntitlement_WithPrincipalName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	accountLicenseType := licensing.AccountLicenseTypeValues.Express
+	origin := ""
+	originID := ""
+	principalName := "foobar@microsoft.com"
+	descriptor := "baz"
+	id := uuid.New()
+	mockServicePrincipalEntitlement := getMockServicePrincipalEntitlement(&id, accountLicenseType, origin, originID, principalName, descriptor)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.Set("principal_name", principalName)
+
+	expectedIsSuccess := true
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), MatchAddServicePrincipalEntitlementArgs(t, memberentitlementmanagement.AddServicePrincipalEntitlementArgs{
+			ServicePrincipalEntitlement: mockServicePrincipalEntitlement,
+		})).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPostResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: mockServicePrincipalEntitlement,
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
+			ServicePrincipalId: mockServicePrincipalEntitlement.Id,
+		}).
+		Return(mockServicePrincipalEntitlement, nil)
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.Nil(t, err, "err should not be nil")
+}
+
+// if origin_id is "" and principal_name is "", an error will be reported.
+func TestServicePrincipalEntitlement_CreateServicePrincipalEntitlement_Need_OriginID_Or_PrincipalName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: nil,
+		Ctx:                           context.Background(),
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	// originID and principalName is not set.
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	require.Regexp(t, "Use origin_id or principal_name", err.Error())
+}
+
+// if the REST-API return the failure, it should fail.
+
+func TestServicePrincipalEntitlement_CreateServicePrincipalEntitlement_WithError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	principalName := "foobar@microsoft.com"
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	// resourceData.Set("origin_id", originID)
+	resourceData.Set("account_license_type", "express")
+	resourceData.Set("principal_name", principalName)
+
+	// No error but it has a error on the response.
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("error foo")).
+		Times(1)
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+}
+
+// if the REST-API return the success, but fails on response
+func TestServicePrincipalEntitlement_CreateServicePrincipalEntitlement_WithEarlyAdopter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	principalName := "foobar@microsoft.com"
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	// resourceData.Set("origin_id", originID)
+	resourceData.Set("account_license_type", "earlyAdopter")
+	resourceData.Set("principal_name", principalName)
+
+	var expectedKey interface{} = 5000
+	var expectedValue interface{} = "A user cannot be assigned an Account-EarlyAdopter license."
+	expectedErrors := []azuredevops.KeyValuePair{
+		{
+			Key:   &expectedKey,
+			Value: &expectedValue,
+		},
+	}
+	expectedIsSuccess := false
+
+	// No error but it has a error on the response.
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPostResponse{
+			IsSuccess: &expectedIsSuccess,
+			OperationResult: &memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{
+				IsSuccess: &expectedIsSuccess,
+				Errors:    &expectedErrors,
+			},
+		}, nil).
+		Times(1)
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	require.Contains(t, err.Error(), "A user cannot be assigned an Account-EarlyAdopter license.")
+}
+
+// TestServicePrincipalEntitlement_Update_TestChangeEntitlement verfies that an entitlement can be changed
+func TestServicePrincipalEntitlement_Update_TestChangeEntitlement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	accountLicenseType := licensing.AccountLicenseTypeValues.Stakeholder
+	origin := ""
+	originID := ""
+	principalName := "foobar@microsoft.com"
+	descriptor := "baz"
+	id := uuid.New()
+	mockServicePrincipalEntitlement := getMockServicePrincipalEntitlement(&id, accountLicenseType, origin, originID, principalName, descriptor)
+	expectedIsSuccess := true
+
+	memberEntitlementClient.
+		EXPECT().
+		UpdateServicePrincipalEntitlement(gomock.Any(), memberentitlementmanagement.UpdateServicePrincipalEntitlementArgs{
+			ServicePrincipalId: &id,
+			Document: &[]webapi.JsonPatchOperation{
+				{
+					Op:   &webapi.OperationValues.Replace,
+					From: nil,
+					Path: converter.String("/accessLevel"),
+					Value: struct {
+						AccountLicenseType string `json:"accountLicenseType"`
+						LicensingSource    string `json:"licensingSource"`
+					}{
+						string(licensing.AccountLicenseTypeValues.Stakeholder),
+						string(licensing.LicensingSourceValues.Account),
+					},
+				},
+			},
+		}).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPatchResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: mockServicePrincipalEntitlement,
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
+			ServicePrincipalId: mockServicePrincipalEntitlement.Id,
+		}).
+		Return(mockServicePrincipalEntitlement, nil).
+		Times(1)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(id.String())
+	resourceData.Set("principal_name", principalName)
+	resourceData.Set("account_license_type", string(licensing.AccountLicenseTypeValues.Stakeholder))
+	resourceData.Set("licensing_source", string(licensing.LicensingSourceValues.Account))
+
+	err := resourceServicePrincipalEntitlementUpdate(resourceData, clients)
+	assert.Nil(t, err)
+}
+
+// TestServicePrincipalEntitlement_CreateUpdate_TestBasicEntitlement verifies that the (virtual) Basic entitlement can be set
+func TestServicePrincipalEntitlement_CreateUpdate_TestBasicEntitlement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	accountLicenseType := licensing.AccountLicenseTypeValues.Express
+	origin := ""
+	originID := ""
+	principalName := "foobar@microsoft.com"
+	descriptor := "baz"
+	id := uuid.New()
+	mockServicePrincipalEntitlement := getMockServicePrincipalEntitlement(&id, accountLicenseType, origin, originID, principalName, descriptor)
+	expectedIsSuccess := true
+
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), MatchAddServicePrincipalEntitlementArgs(t, memberentitlementmanagement.AddServicePrincipalEntitlementArgs{
+			ServicePrincipalEntitlement: mockServicePrincipalEntitlement,
+		})).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPostResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: mockServicePrincipalEntitlement,
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
+			ServicePrincipalId: mockServicePrincipalEntitlement.Id,
+		}).
+		Return(mockServicePrincipalEntitlement, nil)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.Set("principal_name", principalName)
+	resourceData.Set("account_license_type", "basic")
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.Nil(t, err, "err should be nil")
+}
+
+// TestServicePrincipalEntitlement_Import_TestUPN tests if import is successful using an UPN
+func TestServicePrincipalEntitlement_Import_TestUPN(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	identityClient := azdosdkmocks.NewMockIdentityClient(ctrl)
+	clients := &client.AggregatedClient{
+		IdentityClient: identityClient,
+		Ctx:            context.Background(),
+	}
+
+	principalName := "foobar@microsoft.com"
+	id := uuid.New()
+
+	identityClient.
+		EXPECT().
+		ReadIdentities(gomock.Any(), gomock.Any()).
+		Return(&[]identity.Identity{
+			{
+				Id: &id,
+			},
+		}, nil).
+		Times(1)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(principalName)
+
+	d, err := importServicePrincipalEntitlement(resourceData, clients)
+	assert.Nil(t, err)
+	assert.NotNil(t, d)
+	assert.Len(t, d, 1)
+	assert.Equal(t, id.String(), d[0].Id())
+}
+
+// TestServicePrincipalEntitlement_Import_TestID tests if import is successful using an UUID
+func TestServicePrincipalEntitlement_Import_TestID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id := uuid.New().String()
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(id)
+
+	d, err := importServicePrincipalEntitlement(resourceData, clients)
+	assert.Nil(t, err)
+	assert.NotNil(t, d)
+	assert.Len(t, d, 1)
+	assert.Equal(t, id, d[0].Id())
+}
+
+// TestServicePrincipalEntitlement_Import_TestInvalidValue tests if only a valid UPN and UUID can be used to import a resource
+func TestServicePrincipalEntitlement_Import_TestInvalidValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id := "InvalidValue-a73c5191-e20d"
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(id)
+
+	d, err := importServicePrincipalEntitlement(resourceData, clients)
+	assert.Nil(t, d)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Only UUID and UPN values can used for import")
+}
+
+func TestServicePrincipalEntitlement_Create_TestErrorFormatting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id, _ := uuid.NewUUID()
+	expectedIsSuccess := false
+	k1 := interface{}("9999")
+	v1 := interface{}("Error1")
+	k2 := interface{}("9998")
+	v2 := interface{}("Error2")
+
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPostResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: nil,
+			OperationResult: &memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{
+				IsSuccess:          &expectedIsSuccess,
+				Result:             nil,
+				ServicePrincipalId: &id,
+				Errors: &[]azuredevops.KeyValuePair{
+					{
+						Key:   &k1,
+						Value: &v1,
+					},
+					{
+						Key:   &k2,
+						Value: &v2,
+					},
+				},
+			},
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(0)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.Set("principal_name", "foobar@microsoft.com")
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	assert.Contains(t, err.Error(), "(9999) Error1")
+	assert.Contains(t, err.Error(), "(9998) Error2")
+}
+
+func TestServicePrincipalEntitlement_Create_TestEmptyErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id, _ := uuid.NewUUID()
+	expectedIsSuccess := false
+
+	memberEntitlementClient.
+		EXPECT().
+		AddServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPostResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: nil,
+			OperationResult: &memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{
+				IsSuccess:          &expectedIsSuccess,
+				Result:             nil,
+				ServicePrincipalId: &id,
+				Errors:             nil,
+			},
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(0)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.Set("principal_name", "foobar@microsoft.com")
+
+	err := resourceServicePrincipalEntitlementCreate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	assert.Contains(t, err.Error(), "Unknown API error")
+}
+
+func TestServicePrincipalEntitlement_Update_TestErrorFormatting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id, _ := uuid.NewUUID()
+	expectedIsSuccess := false
+	k1 := interface{}("9999")
+	v1 := interface{}("Error1")
+	k2 := interface{}("9998")
+	v2 := interface{}("Error2")
+
+	memberEntitlementClient.
+		EXPECT().
+		UpdateServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPatchResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: nil,
+			OperationResults: &[]memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{
+				{
+					IsSuccess:          &expectedIsSuccess,
+					Result:             nil,
+					ServicePrincipalId: &id,
+					Errors: &[]azuredevops.KeyValuePair{
+						{
+							Key:   &k1,
+							Value: &v1,
+						},
+						{
+							Key:   &k2,
+							Value: &v2,
+						},
+					},
+				},
+			},
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(0)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(id.String())
+	resourceData.Set("principal_name", "foobar@microsoft.com")
+
+	err := resourceServicePrincipalEntitlementUpdate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	assert.Contains(t, err.Error(), "(9999) Error1")
+	assert.Contains(t, err.Error(), "(9998) Error2")
+}
+
+func TestServicePrincipalEntitlement_Update_TestEmptyErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	memberEntitlementClient := azdosdkmocks.NewMockMemberentitlementmanagementClient(ctrl)
+	clients := &client.AggregatedClient{
+		MemberEntitleManagementClient: memberEntitlementClient,
+		Ctx:                           context.Background(),
+	}
+
+	id, _ := uuid.NewUUID()
+	expectedIsSuccess := false
+
+	memberEntitlementClient.
+		EXPECT().
+		UpdateServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(&memberentitlementmanagement.ServicePrincipalEntitlementsPatchResponse{
+			IsSuccess:                   &expectedIsSuccess,
+			ServicePrincipalEntitlement: nil,
+			OperationResults: &[]memberentitlementmanagement.ServicePrincipalEntitlementOperationResult{
+				{
+					IsSuccess:          &expectedIsSuccess,
+					Result:             nil,
+					ServicePrincipalId: &id,
+					Errors:             nil,
+				},
+			},
+		}, nil).
+		Times(1)
+
+	memberEntitlementClient.
+		EXPECT().
+		GetServicePrincipalEntitlement(gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(0)
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceServicePrincipalEntitlement().Schema, nil)
+	resourceData.SetId(id.String())
+	resourceData.Set("principal_name", "foobar@microsoft.com")
+
+	err := resourceServicePrincipalEntitlementUpdate(resourceData, clients)
+	assert.NotNil(t, err, "err should not be nil")
+	assert.Contains(t, err.Error(), "Unknown API error")
+}
+
+func getMockServicePrincipalEntitlement(id *uuid.UUID, accountLicenseType licensing.AccountLicenseType, origin string, originID string, principalName string, descriptor string) *memberentitlementmanagement.ServicePrincipalEntitlement {
+	subjectKind := "servicePrincipal"
+	licensingSource := licensing.LicensingSourceValues.Account
+
+	return &memberentitlementmanagement.ServicePrincipalEntitlement{
+		AccessLevel: &licensing.AccessLevel{
+			AccountLicenseType: &accountLicenseType,
+			LicensingSource:    &licensingSource,
+		},
+		Id: id,
+		ServicePrincipal: &graph.GraphServicePrincipal{
+			Origin:        &origin,
+			OriginId:      &originID,
+			PrincipalName: &principalName,
+			SubjectKind:   &subjectKind,
+			Descriptor:    &descriptor,
+		},
+	}
+}
+
+type matchAddServicePrincipalEntitlementArgs struct {
+	t *testing.T
+	x memberentitlementmanagement.AddServicePrincipalEntitlementArgs
+}
+
+func MatchAddServicePrincipalEntitlementArgs(t *testing.T, x memberentitlementmanagement.AddServicePrincipalEntitlementArgs) gomock.Matcher {
+	return &matchAddServicePrincipalEntitlementArgs{t, x}
+}
+
+func (m *matchAddServicePrincipalEntitlementArgs) Matches(x interface{}) bool {
+	args := x.(memberentitlementmanagement.AddServicePrincipalEntitlementArgs)
+	m.t.Logf("MatchAddServicePrincipalEntitlementArgs:\nVALUE: account_license_type: [%s], licensing_source: [%s], origin: [%s], origin_id: [%s], principal_name: [%s]\n  REF: account_license_type: [%s], licensing_source: [%s], origin: [%s], origin_id: [%s], principal_name: [%s]\n",
+		*args.ServicePrincipalEntitlement.AccessLevel.AccountLicenseType,
+		*args.ServicePrincipalEntitlement.AccessLevel.LicensingSource,
+		*args.ServicePrincipalEntitlement.ServicePrincipal.Origin,
+		*args.ServicePrincipalEntitlement.ServicePrincipal.OriginId,
+		*args.ServicePrincipalEntitlement.ServicePrincipal.PrincipalName,
+		*m.x.ServicePrincipalEntitlement.AccessLevel.AccountLicenseType,
+		*m.x.ServicePrincipalEntitlement.AccessLevel.LicensingSource,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.Origin,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.OriginId,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.PrincipalName)
+
+	return *args.ServicePrincipalEntitlement.AccessLevel.AccountLicenseType == *m.x.ServicePrincipalEntitlement.AccessLevel.AccountLicenseType &&
+		*args.ServicePrincipalEntitlement.ServicePrincipal.Origin == *m.x.ServicePrincipalEntitlement.ServicePrincipal.Origin &&
+		*args.ServicePrincipalEntitlement.ServicePrincipal.OriginId == *m.x.ServicePrincipalEntitlement.ServicePrincipal.OriginId &&
+		*args.ServicePrincipalEntitlement.ServicePrincipal.PrincipalName == *m.x.ServicePrincipalEntitlement.ServicePrincipal.PrincipalName
+}
+
+func (m *matchAddServicePrincipalEntitlementArgs) String() string {
+	return fmt.Sprintf("account_license_type: [%s], licensing_source: [%s], origin: [%s], origin_id: [%s], principal_name: [%s]",
+		*m.x.ServicePrincipalEntitlement.AccessLevel.AccountLicenseType,
+		*m.x.ServicePrincipalEntitlement.AccessLevel.LicensingSource,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.Origin,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.OriginId,
+		*m.x.ServicePrincipalEntitlement.ServicePrincipal.PrincipalName)
+}

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement_test.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement_test.go
@@ -1,6 +1,6 @@
-//go:build (all || resource_user_entitlement) && !exclude_resource_user_entitlement
-// +build all resource_user_entitlement
-// +build !exclude_resource_user_entitlement
+//go:build (all || resource_service_principal_entitlement) && !exclude_resource_service_principal_entitlement
+// +build all resource_service_principal_entitlement
+// +build !exclude_resource_service_principal_entitlement
 
 package memberentitlementmanagement
 

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -94,6 +94,7 @@ func Provider() *schema.Provider {
 			"azuredevops_git_repository_file":                    git.ResourceGitRepositoryFile(),
 			"azuredevops_user_entitlement":                       memberentitlementmanagement.ResourceUserEntitlement(),
 			"azuredevops_group_entitlement":                      memberentitlementmanagement.ResourceGroupEntitlement(),
+			"azuredevops_service_principal_entitlement":          memberentitlementmanagement.ResourceServicePrincipalEntitlement(),
 			"azuredevops_group_membership":                       graph.ResourceGroupMembership(),
 			"azuredevops_agent_pool":                             taskagent.ResourceAgentPool(),
 			"azuredevops_elastic_pool":                           taskagent.ResourceAgentPoolVMSS(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -96,6 +96,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_git_repository_file",
 		"azuredevops_user_entitlement",
 		"azuredevops_group_entitlement",
+		"azuredevops_service_principal_entitlement",
 		"azuredevops_group_membership",
 		"azuredevops_group",
 		"azuredevops_agent_pool",

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -45,6 +45,8 @@ The following attributes are exported:
 
 The resources allows the import via the UUID of a service principal entitlement or by using the principal name of a service principal owning an entitlement.
 
+```sh
+terraform import azuredevops_service_principal_entitlement.example 00000000-0000-0000-0000-000000000000
 ## PAT Permissions Required
 
 - **Member Entitlement Management**: Read & Write

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -20,7 +20,7 @@ resource "azuredevops_service_principal_entitlement" "example" {
 ## Argument Reference
 
 - `origin_id` - (Required) The object ID of the enterprise application.
-- `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `aad`.
+- `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `aad`. Possible value ad, aad, msa.
 - `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`.
 
   ~> **Note**

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -13,7 +13,7 @@ Manages a service principal entitlement within Azure DevOps.
 
 ```hcl
 resource "azuredevops_service_principal_entitlement" "example" {
-  origin_id = "90c9f86a-8ffb-4ff4-bae5-729100074a0c"
+  origin_id = "00000000-0000-0000-0000-000000000001"
 }
 ```
 

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -20,7 +20,7 @@ resource "azuredevops_service_principal_entitlement" "example" {
 ## Argument Reference
 
 - `origin_id` - (Required) The object ID of the enterprise application.
-- `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `aad`. Possible value ad, aad, msa.
+- `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `AAD`. Possible value `AAD`, `AD`, `MSA`.
 - `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`.
 
   ~> **Note**

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -13,19 +13,16 @@ Manages a service principal entitlement within Azure DevOps.
 
 ```hcl
 resource "azuredevops_service_principal_entitlement" "example" {
-  principal_name = "foo@contoso.com"
+  origin_id = "90c9f86a-8ffb-4ff4-bae5-729100074a0c"
 }
 ```
 
 ## Argument Reference
 
-- `principal_name` - (Optional) The principal name is the PrincipalName of a graph member from the source provider. Usually, e-mail address.
-- `origin_id` - (Optional) The unique identifier from the system of origin. Typically a sid, object id or Guid. e.g. Used for member of other tenant on Azure Active Directory.
-- `origin` - (Optional) The type of source provider for the origin identifier.
+- `origin_id` - (Required) The object ID of the enterprise application.
+- `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `aad`.
 - `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`. In addition the value `basic` is allowed which is an alias for `express` and reflects the name of the `express` license used in the Azure DevOps web interface.
 - `licensing_source` - (Optional) The source of the licensing (e.g. Account. MSDN etc.) Valid values: `account` (Default), `auto`, `msdn`, `none`, `profile`, `trial`
-
-> **NOTE:** A service principal can only be referenced by it's `principal_name` or by the combination of `origin_id` and `origin`.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_service_principal_entitlement"
+description: |-
+  Manages a service principal entitlement within Azure DevOps organization.
+---
+
+# azuredevops_service_principal_entitlement
+
+Manages a service principal entitlement within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_service_principal_entitlement" "example" {
+  principal_name = "foo@contoso.com"
+}
+```
+
+## Argument Reference
+
+- `principal_name` - (Optional) The principal name is the PrincipalName of a graph member from the source provider. Usually, e-mail address.
+- `origin_id` - (Optional) The unique identifier from the system of origin. Typically a sid, object id or Guid. e.g. Used for member of other tenant on Azure Active Directory.
+- `origin` - (Optional) The type of source provider for the origin identifier.
+- `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`. In addition the value `basic` is allowed which is an alias for `express` and reflects the name of the `express` license used in the Azure DevOps web interface.
+- `licensing_source` - (Optional) The source of the licensing (e.g. Account. MSDN etc.) Valid values: `account` (Default), `auto`, `msdn`, `none`, `profile`, `trial`
+
+> **NOTE:** A service principal can only be referenced by it's `principal_name` or by the combination of `origin_id` and `origin`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The id of the entitlement.
+- `descriptor` - The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the service principal graph subject.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - User Entitlements - Add](https://learn.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/service-principal-entitlements/add?view=azure-devops-rest-7.1)
+- [Programmatic mapping of access levels](https://docs.microsoft.com/en-us/azure/devops/organizations/security/access-levels?view=azure-devops#programmatic-mapping-of-access-levels)
+
+## Import
+
+The resources allows the import via the UUID of a service principal entitlement or by using the principal name of a service principal owning an entitlement.
+
+## PAT Permissions Required
+
+- **Member Entitlement Management**: Read & Write

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -21,7 +21,12 @@ resource "azuredevops_service_principal_entitlement" "example" {
 
 - `origin_id` - (Required) The object ID of the enterprise application.
 - `origin` - (Optional) The type of source provider for the origin identifier. Defaults to `aad`.
-- `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`. In addition the value `basic` is allowed which is an alias for `express` and reflects the name of the `express` license used in the Azure DevOps web interface.
+- `account_license_type` - (Optional) Type of Account License. Valid values: `advanced`, `earlyAdopter`, `express`, `none`, `professional`, or `stakeholder`. Defaults to `express`.
+
+  ~> **Note**
+  The value `basic` is allowed which is an alias for `express` and reflects the name of the `express` license used in the Azure DevOps web interface.
+
+
 - `licensing_source` - (Optional) The source of the licensing (e.g. Account. MSDN etc.) Valid values: `account` (Default), `auto`, `msdn`, `none`, `profile`, `trial`
 
 ## Attributes Reference

--- a/website/docs/r/service_principal_entitlement.html.markdown
+++ b/website/docs/r/service_principal_entitlement.html.markdown
@@ -27,7 +27,7 @@ resource "azuredevops_service_principal_entitlement" "example" {
   The value `basic` is allowed which is an alias for `express` and reflects the name of the `express` license used in the Azure DevOps web interface.
 
 
-- `licensing_source` - (Optional) The source of the licensing (e.g. Account. MSDN etc.) Valid values: `account` (Default), `auto`, `msdn`, `none`, `profile`, `trial`
+- `licensing_source` - (Optional) The source of the licensing (e.g. Account. MSDN etc.) Valid values: `account`, `auto`, `msdn`, `none`, `profile`, `trial`. Defaults to `account`
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Added new resource azuredevops_service_principal_entitlement to handle service principal entitlements. The API threw errors when attempting to use a principal name to add the principal, so I only implemented the use of origin and origin_id.

Issue Number: #1025 #797 #889

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

```
jhp@S1-0666-W:~/azdotest$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azuredevops_service_principal_entitlement.entitlement will be created
  + resource "azuredevops_service_principal_entitlement" "entitlement" {
      + account_license_type = "express"
      + descriptor           = (known after apply)
      + id                   = (known after apply)
      + licensing_source     = "account"
      + origin               = "aad"
      + origin_id            = "0f3bc8a7-70d6-471a-8224-1419cbfdf862"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azuredevops_service_principal_entitlement.entitlement: Creating...
azuredevops_service_principal_entitlement.entitlement: Creation complete after 2s [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
jhp@S1-0666-W:~/azdotest$ terraform apply --destroy --auto-approve
azuredevops_service_principal_entitlement.entitlement: Refreshing state... [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # azuredevops_service_principal_entitlement.entitlement will be destroyed
  - resource "azuredevops_service_principal_entitlement" "entitlement" {
      - account_license_type = "express" -> null
      - descriptor           = "aadsp.NTgzNTAxYTMtM2VhNS03ZTBkLTgzMjktNTJjOTVlZDk4NmEx" -> null
      - id                   = "583501a3-3ea5-6e0d-8329-52c95ed986a1" -> null
      - licensing_source     = "account" -> null
      - origin               = "aad" -> null
      - origin_id            = "0f3bc8a7-70d6-471a-8224-1419cbfdf862" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
azuredevops_service_principal_entitlement.entitlement: Destroying... [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]
azuredevops_service_principal_entitlement.entitlement: Destruction complete after 1s

Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
jhp@S1-0666-W:~/azdotest$

azuredevops_service_principal_entitlement.entitlement: Refreshing state... [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azuredevops_service_principal_entitlement.entitlement will be updated in-place
  ~ resource "azuredevops_service_principal_entitlement" "entitlement" {
      ~ account_license_type = "express" -> "Stakeholder"
        id                   = "583501a3-3ea5-6e0d-8329-52c95ed986a1"
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
azuredevops_service_principal_entitlement.entitlement: Modifying... [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]
azuredevops_service_principal_entitlement.entitlement: Modifications complete after 1s [id=583501a3-3ea5-6e0d-8329-52c95ed986a1]
```


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->