### PR TITLE
docs: fix `azuredevops_elastic_pool` resource title

### DIFF
--- a/website/docs/r/elastic_pool.html.markdown
+++ b/website/docs/r/elastic_pool.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Manages Elastic pool within Azure DevOps organization.
 ---
 
-# azuredevops_agent_pool
+# azuredevops_elastic_pool
 
 Manages Elastic pool within Azure DevOps.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Title for the `azuredevops_elastic_pool` resource documentation was incorrect.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

Guessing it was just copy pasted from `azuredevops_agent_pool` and forgotten.