### PR TITLE
`azuredevops_pipeline_authorization` - Check Pipeline Project for Resource Permissions

### DIFF
--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -224,6 +224,10 @@ func checkPipelineAuthorization(clients *client.AggregatedClient, d *schema.Reso
 		projectId := d.Get("project_id").(string)
 		resourceType := d.Get("type").(string)
 		resourceId := d.Get("resource_id").(string)
+		pipelineProjectId := projectId
+		if d.Get("pipeline_project_id").(string) != "" {
+			pipelineProjectId = d.Get("pipeline_project_id").(string)
+		}
 
 		if strings.EqualFold(resourceType, "repository") {
 			resourceId = projectId + "." + resourceId
@@ -231,7 +235,7 @@ func checkPipelineAuthorization(clients *client.AggregatedClient, d *schema.Reso
 
 		resp, err := clients.PipelinePermissionsClient.GetPipelinePermissionsForResource(clients.Ctx,
 			pipelinepermissions.GetPipelinePermissionsForResourceArgs{
-				Project:      &projectId,
+				Project:      &pipelineProjectId,
 				ResourceType: &resourceType,
 				ResourceId:   &resourceId,
 			},


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly. <- N/A
* [x] I have added tests to cover my changes. <- N/A
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
As per issue #1038, I have found that since the changes introduced in PR #973, the provider can now create cross Project pipeline permissions for repositories, _however_ they do not finish creating and instead time out. This would seem to be due to the fact that the `checkPipelineAuthorization` function was not updated to reference the pipelineProjectId unlike all other functions here. This PR Corrects this and allows the resources to create properly.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1038 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
Previously we would always get `waiting for pipeline authorization ready. timeout while waiting for state to become ‘succeed, failed’ (last state: ‘waiting’, timeout: 2m0s)` as an error on creation of this resource

