### PR TITLE
`azuredevops_serviceendpoint_azurerm` support `AzureUSGovernment` and `AzureGermanCloud` clouds

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -110,7 +110,7 @@ func ResourceServiceEndpointAzureRM() *schema.Resource {
 		ForceNew:     true,
 		Description:  "Environment (Azure Cloud type)",
 		Default:      "AzureCloud",
-		ValidateFunc: validation.StringInSlice([]string{"AzureCloud", "AzureChinaCloud"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"AzureCloud", "AzureChinaCloud", "AzureUSGovernment", "AzureGermanCloud"}, false),
 	}
 
 	r.Schema["service_endpoint_authentication_scheme"] = &schema.Schema{
@@ -396,6 +396,10 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 		endpointUrl = "https://management.azure.com/"
 	} else if environment == "AzureChinaCloud" {
 		endpointUrl = "https://management.chinacloudapi.cn/"
+	} else if environment == "AzureUSGovernment" {
+		endpointUrl = "https://management.usgovcloudapi.net/"
+	} else if environment == "AzureGermanCloud" {
+		endpointUrl = "https://management.microsoftazure.de"
 	}
 
 	if scopeLevel == "Subscription" || scopeLevel == "ResourceGroup" {

--- a/website/docs/d/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/d/serviceendpoint_azurerm.html.markdown
@@ -70,7 +70,7 @@ In addition to the Arguments list above - the following Attributes are exported:
 * `resource_group` - Specifies the Resource Group of the Service Endpoint target, if available.
 * `azurerm_spn_tenantid` - Specifies the Tenant ID of the Azure targets.
 * `description` - Specifies the description of the Service Endpoint.
-* `environment` - The Cloud Environment. Possible values are `AzureCloud` and `AzureChinaCloud`.
+* `environment` - The Cloud Environment. Possible values are `AzureCloud`, `AzureChinaCloud`, `AzureUSGovernment`, and `AzureGermanCloud`.
 * `service_endpoint_authentication_scheme` - Specifies the authentication scheme of azurerm endpoint, either `WorkloadIdentityFederation`, `ManagedServiceIdentity` or `ServicePrincipal`. 
 * `workload_identity_federation_issuer` - The issuer if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. This looks like `https://vstoken.dev.azure.com/f66a4bc2-08ad-4ec0-a25e-e769d6b3b294`, where the GUID is the Organization ID of your Azure DevOps Organisation.
 * `workload_identity_federation_subject` - The subject if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. This looks like `sc://my-organisation/my-project/my-service-connection-name`.

--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -206,7 +206,7 @@ The following arguments are supported:
 - `azurerm_management_group_name` - (Optional) The Management group Name of the targets.
 - `azurerm_subscription_id` - (Optional) The Subscription ID of the Azure targets.
 - `azurerm_subscription_name` - (Optional) The Subscription Name of the targets.
-- `environment` - (Optional) The Cloud Environment to use. Defaults to `AzureCloud`. Possible values are `AzureCloud`, `AzureChinaCloud`. Changing this forces a new resource to be created.
+- `environment` - (Optional) The Cloud Environment to use. Defaults to `AzureCloud`. Possible values are `AzureCloud`, `AzureChinaCloud`, `AzureUSGovernment`, and `AzureGermanCloud`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** One of either `Subscription` scoped i.e. `azurerm_subscription_id`, `azurerm_subscription_name` or `ManagementGroup` scoped i.e. `azurerm_management_group_id`, `azurerm_management_group_name` values must be specified.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

`azuredevops_serviceendpoint_azurerm` resource can now create service endpoints targeting subscriptions in other national cloud offerings: AzureUSGovernment and AzureGermanCloud.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/919

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

Running terraform apply with a local build succeeded in creating a service endpoint targeting AzureUSGovernment:
```terraform
Terraform will perform the following actions:

  # azuredevops_serviceendpoint_azurerm.example will be created
  + resource "azuredevops_serviceendpoint_azurerm" "example" {
      + authorization                          = (known after apply)
      + azurerm_spn_tenantid                   = "<redacted>"
      + azurerm_subscription_id                = "<redacted>"
      + azurerm_subscription_name              = "<redacted>"
      + description                            = "Managed by Terraform"
      + environment                            = "AzureUSGovernment"
      + id                                     = (known after apply)
      + project_id                             = "d8e7853a-8835-47ec-bb39-2e503b953bf6"
      + service_endpoint_authentication_scheme = "ServicePrincipal"
      + service_endpoint_name                  = "Test AzureUSGovernment AzureRM"
      + service_principal_id                   = (known after apply)
      + workload_identity_federation_issuer    = (known after apply)
      + workload_identity_federation_subject   = (known after apply)

      + credentials {
          + serviceprincipalid  = "<redacted>"
          + serviceprincipalkey = (sensitive value)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

azuredevops_serviceendpoint_azurerm.example: Creating...
azuredevops_serviceendpoint_azurerm.example: Still creating... [10s elapsed]
azuredevops_serviceendpoint_azurerm.example: Creation complete after 11s [id=f107474e-beeb-4998-84c3-4c6b9424e010]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<img width="954" alt="Screenshot 2024-05-25 at 12 11 40 PM" src="https://github.com/microsoft/terraform-provider-azuredevops/assets/63941816/7eef2cca-7819-458c-a3d2-4a5b13997052">


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->