### PR TITLE
`azuredevops_variable_group` - Add validation that variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes

### DIFF
--- a/website/docs/r/variable_group.html.markdown
+++ b/website/docs/r/variable_group.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 A `variable` block supports the following:
 
+!> **Warning** variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes
+
 - `name` - (Required) The key value used for the variable. Must be unique within the Variable Group.
 - `value` - (Optional) The value of the variable. If omitted, it will default to empty string.
 - `secret_value` - (Optional) The secret value of the variable. If omitted, it will default to empty string. Used when `is_secret` set to `true`.


### PR DESCRIPTION
A temporary fix till https://github.com/microsoft/terraform-provider-azuredevops/pull/887 or any better solution is merged.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->