### PR TITLE
[Bug fix] - `azuredevops_git_repository` - Fix plan fails when repo deleted outside of Terraform

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -258,6 +258,11 @@ func resourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
 	}
 
+	if repo == nil {
+		d.SetId("")
+		return nil
+	}
+
 	err = flattenGitRepository(d, repo)
 	if err != nil {
 		return fmt.Errorf("Failed to flatten Git repository: %w", err)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1086 

```log
=== RUN   TestAccGitRepo_CreateAndUpdate
=== PAUSE TestAccGitRepo_CreateAndUpdate
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
=== PAUSE TestAccGitRepo_Create_IncorrectInitialization
=== RUN   TestAccGitRepo_Create_Import
=== PAUSE TestAccGitRepo_Create_Import
=== RUN   TestAccGitRepo_RepoInitialization_Clean
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== RUN   TestAccGitRepo_PrivateImport_BranchNotEmpty
=== PAUSE TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepo_CreateAndUpdate
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_Create_Import
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_PrivateImport_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (5.06s)
=== NAME  TestAccGitRepo_PrivateImport_BranchNotEmpty
    resource_git_repository_test.go:210: Step 1/1 error: Error running apply: exit status 1

        Error: Error import repository in Azure DevOps: Request returned status: 400 Bad Request

          with azuredevops_git_repository.import,
          on terraform_plugin_test.tf line 26, in resource "azuredevops_git_repository" "import":
          26:   resource "azuredevops_git_repository" "import" {

--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (61.00s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (62.29s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (65.21s)
--- FAIL: TestAccGitRepo_PrivateImport_BranchNotEmpty (75.26s)
--- PASS: TestAccGitRepo_Create_Import (87.40s)
--- PASS: TestAccGitRepo_CreateAndUpdate (102.15s)
FAIL
FAIL    github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        102.786s
FAIL

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [x] Yes
- [ ] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->