### PR TITLE
`azuredevops_check_approval`,`azuredevops_check_exclusive_lock`, `azuredevops_check_branch_control`, `azuredevops_check_business_hours`, `azuredevops_check_required_template` - Optimize flatten and setId

### DIFF
--- a/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
@@ -153,6 +153,7 @@ func TestCheckApproval_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckApproval()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *ApprovalCheckTest.Id))
 	flattenCheckApproval(resourceData, &ApprovalCheckTest, ApprovalCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_approval_test.go
@@ -7,6 +7,7 @@ package approvalsandchecks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -56,6 +57,7 @@ func TestCheckApproval_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceCheckApproval().Schema, nil)
 	flattenCheckApproval(resourceData, &ApprovalCheckTest, ApprovalCheckProjectID)
 
+	resourceData.SetId(fmt.Sprintf("%d", *ApprovalCheckTest.Id))
 	ApprovalCheckAfterRoundTrip, projectID, err := expandCheckApproval(resourceData)
 
 	require.Equal(t, ApprovalCheckTest, *ApprovalCheckAfterRoundTrip)
@@ -70,6 +72,7 @@ func TestCheckApproval_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckApproval()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *ApprovalCheckTest.Id))
 	flattenCheckApproval(resourceData, &ApprovalCheckTest, ApprovalCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -93,6 +96,7 @@ func TestCheckApproval_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckApproval()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *ApprovalCheckTest.Id))
 	flattenCheckApproval(resourceData, &ApprovalCheckTest, ApprovalCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -121,6 +125,7 @@ func TestCheckApproval_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckApproval()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *ApprovalCheckTest.Id))
 	flattenCheckApproval(resourceData, &ApprovalCheckTest, ApprovalCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control_test.go
@@ -7,6 +7,7 @@ package approvalsandchecks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -55,6 +56,7 @@ var branchControlCheckTest = pipelineschecksextras.CheckConfiguration{
 // verifies that the flatten/expand round trip yields the same branch control
 func TestCheckBranchControl_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceCheckBranchControl().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *branchControlCheckTest.Id))
 	flattenBranchControlCheck(resourceData, &branchControlCheckTest, branchControlCheckProjectID)
 
 	branchControlCheckAfterRoundTrip, projectID, err := expandBranchControlCheck(resourceData)
@@ -71,6 +73,7 @@ func TestCheckBranchControl_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBranchControl()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *branchControlCheckTest.Id))
 	flattenBranchControlCheck(resourceData, &branchControlCheckTest, branchControlCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -94,6 +97,7 @@ func TestCheckBranchControl_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBranchControl()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *branchControlCheckTest.Id))
 	flattenBranchControlCheck(resourceData, &branchControlCheckTest, branchControlCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -122,6 +126,7 @@ func TestCheckBranchControl_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBranchControl()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *branchControlCheckTest.Id))
 	flattenBranchControlCheck(resourceData, &branchControlCheckTest, branchControlCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -149,6 +154,7 @@ func TestCheckBranchControl_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBranchControl()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *branchControlCheckTest.Id))
 	flattenBranchControlCheck(resourceData, &branchControlCheckTest, branchControlCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_business_hours_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_business_hours_test.go
@@ -7,6 +7,7 @@ package approvalsandchecks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -48,6 +49,7 @@ var CheckBusinessHoursTest = pipelineschecksextras.CheckConfiguration{
 // verifies that the flatten/expand round trip yields the same business hours check
 func TestCheckBusinessHours_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceCheckBusinessHours().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckBusinessHoursID))
 	flattenBusinessHours(resourceData, &CheckBusinessHoursTest, CheckBusinessHoursProjectID)
 
 	CheckBusinessHoursAfterRoundTrip, projectID, err := expandBusinessHours(resourceData)
@@ -64,6 +66,7 @@ func TestCheckBusinessHours_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBusinessHours()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckBusinessHoursID))
 	flattenBusinessHours(resourceData, &CheckBusinessHoursTest, CheckBusinessHoursProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -87,6 +90,7 @@ func TestCheckBusinessHours_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBusinessHours()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *CheckBusinessHoursTest.Id))
 	flattenBusinessHours(resourceData, &CheckBusinessHoursTest, CheckBusinessHoursProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -115,6 +119,7 @@ func TestCheckBusinessHours_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBusinessHours()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *CheckBusinessHoursTest.Id))
 	flattenBusinessHours(resourceData, &CheckBusinessHoursTest, CheckBusinessHoursProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -142,6 +147,7 @@ func TestCheckBusinessHours_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckBusinessHours()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *CheckBusinessHoursTest.Id))
 	flattenBusinessHours(resourceData, &CheckBusinessHoursTest, CheckBusinessHoursProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_exclusive_lock_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_exclusive_lock_test.go
@@ -7,6 +7,7 @@ package approvalsandchecks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -39,6 +40,7 @@ var CheckExclusiveLockTest = pipelineschecksextras.CheckConfiguration{
 // verifies that the flatten/expand round trip yields the same exclusive lock check
 func TestCheckExclusiveLock_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceCheckApproval().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckExclusiveLockID))
 	flattenExclusiveLock(resourceData, &CheckExclusiveLockTest, CheckExclusiveLockProjectID)
 
 	CheckExclusiveLockAfterRoundTrip, projectID, err := expandExclusiveLock(resourceData)
@@ -55,6 +57,7 @@ func TestCheckExclusiveLock_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckExclusiveLock()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckExclusiveLockID))
 	flattenExclusiveLock(resourceData, &CheckExclusiveLockTest, CheckExclusiveLockProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -78,6 +81,7 @@ func TestCheckExclusiveLock_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckExclusiveLock()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckExclusiveLockID))
 	flattenExclusiveLock(resourceData, &CheckExclusiveLockTest, CheckExclusiveLockProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -106,6 +110,7 @@ func TestCheckExclusiveLock_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckExclusiveLock()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckExclusiveLockID))
 	flattenExclusiveLock(resourceData, &CheckExclusiveLockTest, CheckExclusiveLockProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -133,6 +138,7 @@ func TestCheckExclusiveLock_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckExclusiveLock()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", CheckExclusiveLockID))
 	flattenExclusiveLock(resourceData, &CheckExclusiveLockTest, CheckExclusiveLockProjectID)
 
 	pipelinesCheckClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_required_template_test.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_required_template_test.go
@@ -3,16 +3,15 @@ package approvalsandchecks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
-
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/pipelineschecksextras"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +53,7 @@ func TestCheckRequiredTemplate_ExpandFlatten_Roundtrip(t *testing.T) {
 	flattenErr := flattenCheckRequiredTemplate(resourceData, &requiredTemplateCheckTest, requiredTemplateCheckProjectID)
 
 	requiredTemplateCheckAfterRoundTrip, projectID, expandErr := expandCheckRequiredTemplate(resourceData)
+	requiredTemplateCheckAfterRoundTrip.Id = requiredTemplateCheckTest.Id
 
 	require.Equal(t, requiredTemplateCheckTest, *requiredTemplateCheckAfterRoundTrip)
 	require.Equal(t, requiredTemplateCheckProjectID, projectID)
@@ -68,12 +68,14 @@ func TestCheckRequiredTemplate_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckRequiredTemplate()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *requiredTemplateCheckTest.Id))
 	flattenErr := flattenCheckRequiredTemplate(resourceData, &requiredTemplateCheckTest, requiredTemplateCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
 	clients := &client.AggregatedClient{PipelinesChecksClientExtras: pipelinesChecksClient, Ctx: context.Background()}
 
 	expectedArgs := pipelineschecksextras.AddCheckConfigurationArgs{Configuration: &requiredTemplateCheckTest, Project: &requiredTemplateCheckProjectID}
+	//expectedArgs = requiredTemplateCheckTest.Id
 	pipelinesChecksClient.
 		EXPECT().
 		AddCheckConfiguration(clients.Ctx, expectedArgs).
@@ -92,6 +94,7 @@ func TestCheckRequiredTemplate_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckRequiredTemplate()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *requiredTemplateCheckTest.Id))
 	flattenErr := flattenCheckRequiredTemplate(resourceData, &requiredTemplateCheckTest, requiredTemplateCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -121,6 +124,7 @@ func TestCheckRequiredTemplate_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckRequiredTemplate()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *requiredTemplateCheckTest.Id))
 	flattenErr := flattenCheckRequiredTemplate(resourceData, &requiredTemplateCheckTest, requiredTemplateCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)
@@ -149,6 +153,7 @@ func TestCheckRequiredTemplate_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceCheckRequiredTemplate()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *requiredTemplateCheckTest.Id))
 	flattenErr := flattenCheckRequiredTemplate(resourceData, &requiredTemplateCheckTest, requiredTemplateCheckProjectID)
 
 	pipelinesChecksClient := azdosdkmocks.NewMockPipelineschecksextrasClient(ctrl)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
```log
--- PASS: TestAccCheckApproval_basic (107.97s)
--- PASS: TestAccCheckApproval_complete (108.19s)
--- PASS: TestAccCheckApproval_update (147.13s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        147.733s

=== RUN   TestAccCheckBranchControl_basic
=== PAUSE TestAccCheckBranchControl_basic
=== RUN   TestAccCheckBranchControl_complete
=== PAUSE TestAccCheckBranchControl_complete
=== RUN   TestAccCheckBranchControl_update
=== PAUSE TestAccCheckBranchControl_update
=== CONT  TestAccCheckBranchControl_basic
=== CONT  TestAccCheckBranchControl_update
=== CONT  TestAccCheckBranchControl_complete
--- PASS: TestAccCheckBranchControl_basic (79.40s)
--- PASS: TestAccCheckBranchControl_complete (86.49s)
--- PASS: TestAccCheckBranchControl_update (114.05s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        114.459s

=== RUN   TestAccCheckBusinessHours_basic
=== PAUSE TestAccCheckBusinessHours_basic
=== RUN   TestAccCheckBusinessHours_complete
=== PAUSE TestAccCheckBusinessHours_complete
=== RUN   TestAccCheckBusinessHours_update
=== PAUSE TestAccCheckBusinessHours_update
=== CONT  TestAccCheckBusinessHours_basic
=== CONT  TestAccCheckBusinessHours_update
=== CONT  TestAccCheckBusinessHours_complete
--- PASS: TestAccCheckBusinessHours_basic (99.70s)
--- PASS: TestAccCheckBusinessHours_complete (99.94s)
--- PASS: TestAccCheckBusinessHours_update (126.88s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        127.451s

=== RUN   TestAccCheckExclusiveLock_basic
=== PAUSE TestAccCheckExclusiveLock_basic
=== CONT  TestAccCheckExclusiveLock_basic
--- PASS: TestAccCheckExclusiveLock_basic (103.05s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        103.613s

=== RUN   TestAccCheckRequiredTemplate_basic
=== PAUSE TestAccCheckRequiredTemplate_basic
=== RUN   TestAccCheckRequiredTemplate_complete
=== PAUSE TestAccCheckRequiredTemplate_complete
=== RUN   TestAccCheckRequiredTemplate_update
=== PAUSE TestAccCheckRequiredTemplate_update
=== CONT  TestAccCheckRequiredTemplate_basic
=== CONT  TestAccCheckRequiredTemplate_update
=== CONT  TestAccCheckRequiredTemplate_complete
--- PASS: TestAccCheckRequiredTemplate_complete (85.25s)
--- PASS: TestAccCheckRequiredTemplate_basic (85.33s)
--- PASS: TestAccCheckRequiredTemplate_update (116.01s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        116.497s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->