### PR TITLE
`azuredevops_build_definition`,`azuredevops_build_folder`,`azuredevops_pipeline_authorization`,`azuredevops_resource_authorization` - Optimize CRUD and fix unit tests

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition_test.go
+++ b/azuredevops/internal/service/build/resource_build_definition_test.go
@@ -7,6 +7,7 @@ package build
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -384,6 +385,7 @@ func TestAzureDevOpsBuildDefinition_CITriggers_Bitbucket(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinitionBitbucketWithCITrigger, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
@@ -406,6 +408,7 @@ func TestAzureDevOpsBuildDefinition_CITriggers_GitHubEnterprise(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinitionGitHubEnterpriseWithCITrigger, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
@@ -425,6 +428,7 @@ func TestAzureDevOpsBuildDefinition_CITriggers_GitHubEnterprise(t *testing.T) {
 // verifies that the flatten/expand round trip yields the same build definition
 func TestBuildDefinition_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	for _, triggerGroup := range triggerGroups {
 		testBuildDefinitionWithCustomTriggers := testBuildDefinition
 		testBuildDefinitionWithCustomTriggers.Triggers = &triggerGroup
@@ -450,6 +454,7 @@ func TestBuildDefinition_Create_DoesNotSwallowError(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinition, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
@@ -472,6 +477,7 @@ func TestBuildDefinition_Read_DoesNotSwallowError(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinition, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
@@ -494,6 +500,7 @@ func TestBuildDefinition_Delete_DoesNotSwallowError(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinition, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)
@@ -516,6 +523,7 @@ func TestBuildDefinition_Update_DoesNotSwallowError(t *testing.T) {
 	defer ctrl.Finish()
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceBuildDefinition().Schema, nil)
+	resourceData.SetId(fmt.Sprintf("%d", *testBuildDefinitionBitbucketWithCITrigger.Id))
 	flattenBuildDefinition(resourceData, &testBuildDefinition, testProjectID)
 
 	buildClient := azdosdkmocks.NewMockBuildClient(ctrl)

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -170,7 +170,6 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 		}
 	}
 
-	d.SetId(*resp.Resource.Id)
 	return nil
 }
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
```log
=== RUN   TestAccBuildFolder_basic
=== PAUSE TestAccBuildFolder_basic
=== RUN   TestAccBuildFolder_update
=== PAUSE TestAccBuildFolder_update
=== RUN   TestAccBuildFolder_requiresImportErrorStep
=== PAUSE TestAccBuildFolder_requiresImportErrorStep
=== CONT  TestAccBuildFolder_basic
=== CONT  TestAccBuildFolder_requiresImportErrorStep
=== CONT  TestAccBuildFolder_update
--- PASS: TestAccBuildFolder_basic (54.54s)
--- PASS: TestAccBuildFolder_requiresImportErrorStep (63.59s)
--- PASS: TestAccBuildFolder_update (92.39s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        99.177s

=== RUN   TestAccBuildDefinition_DataSource
=== PAUSE TestAccBuildDefinition_DataSource
=== RUN   TestAccBuildDefinition_with_path_DataSource
=== PAUSE TestAccBuildDefinition_with_path_DataSource
=== RUN   TestAccBuildDefinition_Basic
=== PAUSE TestAccBuildDefinition_Basic
=== RUN   TestAccBuildDefinition_PathUpdate
=== PAUSE TestAccBuildDefinition_PathUpdate
=== RUN   TestAccBuildDefinition_WithVariables
=== PAUSE TestAccBuildDefinition_WithVariables
=== RUN   TestAccBuildDefinition_Schedules
=== PAUSE TestAccBuildDefinition_Schedules
=== CONT  TestAccBuildDefinition_DataSource
=== CONT  TestAccBuildDefinition_WithVariables
=== CONT  TestAccBuildDefinition_Basic
=== CONT  TestAccBuildDefinition_with_path_DataSource
=== CONT  TestAccBuildDefinition_PathUpdate
=== CONT  TestAccBuildDefinition_Schedules
--- PASS: TestAccBuildDefinition_Schedules (63.61s)
--- PASS: TestAccBuildDefinition_DataSource (64.36s)
--- PASS: TestAccBuildDefinition_with_path_DataSource (65.16s)
--- PASS: TestAccBuildDefinition_Basic (66.00s)
--- PASS: TestAccBuildDefinition_PathUpdate (83.36s)
--- PASS: TestAccBuildDefinition_WithVariables (101.00s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        102.464s

=== RUN   TestAccPipelineAuthorization_allPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipeline_queue
=== RUN   TestAccPipelineAuthorization_pipeline_queue
=== PAUSE TestAccPipelineAuthorization_pipeline_queue
=== RUN   TestAccPipelineAuthorization_multiPipeline_queue
=== PAUSE TestAccPipelineAuthorization_multiPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== PAUSE TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== RUN   TestAccPipelineAuthorization_allPipeline_environment
=== PAUSE TestAccPipelineAuthorization_allPipeline_environment
=== RUN   TestAccPipelineAuthorization_pipeline_environment
=== PAUSE TestAccPipelineAuthorization_pipeline_environment
=== RUN   TestAccPipelineAuthorization_allPipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_allPipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_pipeline_variableGroup
=== PAUSE TestAccPipelineAuthorization_pipeline_variableGroup
=== RUN   TestAccPipelineAuthorization_allPipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_allPipeline_endpoint
=== RUN   TestAccPipelineAuthorization_pipeline_endpoint
=== PAUSE TestAccPipelineAuthorization_pipeline_endpoint
=== RUN   TestAccPipelineAuthorization_allPipeline_repository
=== PAUSE TestAccPipelineAuthorization_allPipeline_repository
=== RUN   TestAccPipelineAuthorization_pipeline_repository
=== PAUSE TestAccPipelineAuthorization_pipeline_repository
=== RUN   TestAccPipelineAuthorization_pipeline_cross_project_repository
=== PAUSE TestAccPipelineAuthorization_pipeline_cross_project_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_queue
=== CONT  TestAccPipelineAuthorization_pipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_allPipeline_environment
=== CONT  TestAccPipelineAuthorization_pipeline_cross_project_repository
=== CONT  TestAccPipelineAuthorization_pipeline_repository
=== CONT  TestAccPipelineAuthorization_allPipeline_endpoint
=== CONT  TestAccPipelineAuthorization_multiPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipelineWithPipeline_queue
=== CONT  TestAccPipelineAuthorization_allPipeline_variableGroup
=== CONT  TestAccPipelineAuthorization_pipeline_queue
=== CONT  TestAccPipelineAuthorization_pipeline_environment
=== CONT  TestAccPipelineAuthorization_allPipeline_repository
=== CONT  TestAccPipelineAuthorization_pipeline_endpoint
--- PASS: TestAccPipelineAuthorization_allPipeline_environment (79.67s)
--- PASS: TestAccPipelineAuthorization_allPipeline_repository (81.28s)
--- PASS: TestAccPipelineAuthorization_pipeline_repository (81.82s)
--- PASS: TestAccPipelineAuthorization_pipeline_environment (87.55s)
--- PASS: TestAccPipelineAuthorization_allPipelineWithPipeline_queue (89.66s)
--- PASS: TestAccPipelineAuthorization_allPipeline_queue (92.95s)
--- PASS: TestAccPipelineAuthorization_multiPipeline_queue (97.31s)
--- PASS: TestAccPipelineAuthorization_pipeline_queue (97.75s)
--- PASS: TestAccPipelineAuthorization_pipeline_cross_project_repository (98.10s)
--- PASS: TestAccPipelineAuthorization_pipeline_variableGroup (100.66s)
--- PASS: TestAccPipelineAuthorization_allPipeline_variableGroup (101.18s)
--- PASS: TestAccPipelineAuthorization_allPipeline_endpoint (105.60s)
--- PASS: TestAccPipelineAuthorization_pipeline_endpoint (108.51s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        109.080s

=== RUN   TestAccResourceAuthorization_CRUD
=== PAUSE TestAccResourceAuthorization_CRUD
=== RUN   TestAccResourceAuthorization_Definition_CRUD
=== PAUSE TestAccResourceAuthorization_Definition_CRUD
=== CONT  TestAccResourceAuthorization_CRUD
=== CONT  TestAccResourceAuthorization_Definition_CRUD
--- PASS: TestAccResourceAuthorization_Definition_CRUD (87.56s)
--- PASS: TestAccResourceAuthorization_CRUD (94.31s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        94.809s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->