### PR TITLE
Git resources - Update test cases

### DIFF
--- a/azuredevops/internal/acceptancetests/data_git_repositories_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repositories_test.go
@@ -12,33 +12,96 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-// Verifies that the following sequence of events occurrs without error:
-//
-//	(1) TF can create a project
-//	(2) A data source is added to the configuration, and that data source can find the created project
-func TestAccAzureTfsGitRepositories_DataSource(t *testing.T) {
+func TestAccTfsGitRepositories_DataSource_Basic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
-	gitRepoName := testutils.GenerateResourceName()
-	tfConfigStep1 := testutils.HclGitRepoResource(projectName, gitRepoName, "Clean")
-	tfConfigStep2 := fmt.Sprintf("%s\n%s", tfConfigStep1, testutils.HclProjectGitRepositories(projectName, gitRepoName))
+	repoName := testutils.GenerateResourceName()
 
-	tfNode := "data.azuredevops_git_repositories.repositories"
+	tfNode := "data.azuredevops_git_repositories.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testutils.PreCheck(t, nil) },
 		Providers:                 testutils.GetProviders(),
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigStep1,
-			}, {
-				Config: tfConfigStep2,
+				Config: hckGitRepositoriesDatSourceBasic(projectName, repoName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(tfNode, "name", gitRepoName),
-					resource.TestCheckResourceAttr(tfNode, "repositories.0.name", gitRepoName),
+					resource.TestCheckResourceAttr(tfNode, "name", repoName),
+					resource.TestCheckResourceAttr(tfNode, "repositories.0.name", repoName),
 					resource.TestCheckResourceAttr(tfNode, "repositories.0.default_branch", "refs/heads/master"),
 					resource.TestCheckResourceAttrSet(tfNode, "repositories.0.disabled"),
 				),
 			},
 		},
 	})
+}
+
+func TestAccTfsGitRepositories_DataSource_all(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	tfNode := "data.azuredevops_git_repositories.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testutils.PreCheck(t, nil) },
+		Providers:                 testutils.GetProviders(),
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: hckGitRepositoriesDatSourceAll(projectName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "repositories.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func hckGitRepositoriesDatSourceBasic(projectName, repoName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+data "azuredevops_git_repositories" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  depends_on = [azuredevops_git_repository.test]
+}
+`, projectName, repoName)
+}
+
+func hckGitRepositoriesDatSourceAll(projectName, repoName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+data "azuredevops_git_repositories" "test" {
+  project_id = azuredevops_project.test.id
+  depends_on = [azuredevops_git_repository.test]
+}
+`, projectName, repoName)
 }

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -6,6 +6,7 @@ package acceptancetests
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -199,6 +200,10 @@ func TestAccGitRepo_RepoFork_BranchNotEmpty(t *testing.T) {
 }
 
 func TestAccGitRepo_PrivateImport_BranchNotEmpty(t *testing.T) {
+	if os.Getenv("AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME") == "" ||
+		os.Getenv("AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD") == "" {
+		t.Skip("Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified")
+	}
 	projectName := testutils.GenerateResourceName()
 	gitRepoName := testutils.GenerateResourceName()
 	gitImportRepoName := testutils.GenerateResourceName()

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -111,19 +111,6 @@ resource "azuredevops_project" "project" {
 }`, projectName, projectName, featureStateTestplans, featureStateArtifacts)
 }
 
-// HclProjectGitRepositories HCL describing a multi value data source for AzDO git repositories
-func HclProjectGitRepositories(projectName string, gitRepoName string) string {
-	return fmt.Sprintf(`
-data "azuredevops_project" "project" {
-	name = azuredevops_project.project.name
-}
-
-data "azuredevops_git_repositories" "repositories" {
-	project_id = data.azuredevops_project.project.id
-	name = "%s"
-}`, gitRepoName)
-}
-
 // HclProjectGitRepositoryImport HCL describing a AzDO git repositories
 func HclProjectGitRepositoryImport(gitRepoName string, projectName string) string {
 	azureGitRepoResource := fmt.Sprintf(`

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -37,13 +37,27 @@ var RepoInitTypeValues = repoInitTypeValuesType{
 	Import:        "Import",
 }
 
+// A helper type that is used for transient info only used during repo creation
+type repoInitializationMeta struct {
+	initType            string
+	sourceType          string
+	sourceURL           string
+	serviceConnectionID string
+}
+
 // ResourceGitRepository schema and implementation for git repo resource
 func ResourceGitRepository() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceGitRepositoryCreate,
-		Read:     resourceGitRepositoryRead,
-		Update:   resourceGitRepositoryUpdate,
-		Delete:   resourceGitRepositoryDelete,
+		Create: resourceGitRepositoryCreate,
+		Read:   resourceGitRepositoryRead,
+		Update: resourceGitRepositoryUpdate,
+		Delete: resourceGitRepositoryDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 		Importer: tfhelper.ImportProjectQualifiedResource(),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -59,46 +73,6 @@ func ResourceGitRepository() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     validation.NoZeroValues,
 				DiffSuppressFunc: suppress.CaseDifference,
-			},
-			"parent_repository_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.IsUUID,
-				DiffSuppressFunc: suppress.CaseDifference,
-			},
-			"default_branch": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.NoZeroValues,
-			},
-			"is_fork": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"remote_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"ssh_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"web_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"disabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
 			},
 			"initialization": {
 				Type:     schema.TypeList,
@@ -145,18 +119,49 @@ func ResourceGitRepository() *schema.Resource {
 					},
 				},
 			},
+			"parent_repository_id": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.IsUUID,
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+			"default_branch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"is_fork": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"remote_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ssh_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"web_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
-
-// A helper type that is used for transient info only used during repo creation
-type repoInitializationMeta struct {
-	initType            string
-	sourceType          string
-	sourceURL           string
-	serviceConnectionID string
-}
-
 func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	repo, initialization, projectID, err := expandGitRepository(d)
@@ -186,7 +191,7 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 
 	createdRepo, err := createGitRepository(clients, repo.Name, projectID, parentRepoRef)
 	if err != nil {
-		return fmt.Errorf("Error creating repository in Azure DevOps: %+v", err)
+		return fmt.Errorf(" Creating repository in Azure DevOps: %+v", err)
 	}
 
 	// set the id immediately after successfully creating the repository, which will allow terraform to track the

--- a/azuredevops/internal/service/git/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch_test.go
@@ -73,7 +73,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": an-error")),
 		},
 		{
 			"When more than one of ref_commit_id, ref_tag, or ref_branch are given, the first one from left to right wins",
@@ -108,7 +108,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": an-error")),
 		},
 		{
 			"When invalid RefUpdate UpdateStatus, throw error",
@@ -159,7 +159,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf("Error creating branch \"a-branch\": Error got invalid GitRefUpdate.UpdateStatus: invalidRefName")),
+			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": Error got invalid GitRefUpdate.UpdateStatus: invalidRefName")),
 		},
 	}
 	for _, tt := range tests {
@@ -215,7 +215,7 @@ func TestGitRepositoryBranch_Read(t *testing.T) {
 					m:   clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf("Error reading branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf(" Reading branch \"a-branch\": an-error")),
 		},
 	}
 	for _, tt := range tests {
@@ -286,7 +286,7 @@ func TestGitRepositoryBranch_Delete(t *testing.T) {
 					m:   clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf("Error deleting branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf(" Deleting branch \"a-branch\": an-error")),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

1. Update test cases
2. Optimize code
3. Add timeout

```log


=== RUN   TestAccTfsGitRepositories_DataSource_Basic
=== PAUSE TestAccTfsGitRepositories_DataSource_Basic
=== RUN   TestAccTfsGitRepositories_DataSource_all
=== PAUSE TestAccTfsGitRepositories_DataSource_all
=== CONT  TestAccTfsGitRepositories_DataSource_Basic
=== CONT  TestAccTfsGitRepositories_DataSource_all
--- PASS: TestAccTfsGitRepositories_DataSource_Basic (58.66s)
--- PASS: TestAccTfsGitRepositories_DataSource_all (58.95s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        60.032s

=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_DataSource_notExist
--- PASS: TestAccGitRepository_DataSource_notExist (59.78s)
--- PASS: TestAccGitRepository_DataSource (79.01s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        79.612s

=== RUN   TestAccGitRepo_CreateAndUpdate
=== PAUSE TestAccGitRepo_CreateAndUpdate
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
=== PAUSE TestAccGitRepo_Create_IncorrectInitialization
=== RUN   TestAccGitRepo_Create_Import
=== PAUSE TestAccGitRepo_Create_Import
=== RUN   TestAccGitRepo_RepoInitialization_Clean
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== RUN   TestAccGitRepo_PrivateImport_BranchNotEmpty
    resource_git_repository_test.go:205: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepo_PrivateImport_BranchNotEmpty (0.00s)
=== CONT  TestAccGitRepo_CreateAndUpdate
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_Create_Import
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (8.36s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (82.70s)
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (83.63s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (87.86s)
--- PASS: TestAccGitRepo_Create_Import (88.35s)
--- PASS: TestAccGitRepo_CreateAndUpdate (103.66s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        104.390s

=== RUN   TestAccGitRepoBranch_CreateAndUpdate
--- PASS: TestAccGitRepoBranch_CreateAndUpdate (76.83s)
=== RUN   TestAccGitRepoBranch_InvalidRef
--- PASS: TestAccGitRepoBranch_InvalidRef (37.45s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        114.868s


=== RUN   TestAccGitRepoFile_CreateAndUpdate
--- PASS: TestAccGitRepoFile_CreateAndUpdate (75.28s)
=== RUN   TestAccGitRepoFile_IncorrectBranch
--- PASS: TestAccGitRepoFile_IncorrectBranch (34.95s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        117.102s

``` 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->