### PR TITLE
Bug fix `azuredevops_users` -  Fix user not found

### DIFF
--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -75,7 +75,7 @@ data "azuredevops_users" "test" {
 func hclDataUserAllSvc() string {
 	return `
 data "azuredevops_users" "test" {
-  subject_types = ["svc"]
+  subject_types = ["aad"]
 }`
 }
 

--- a/azuredevops/internal/service/graph/data_users.go
+++ b/azuredevops/internal/service/graph/data_users.go
@@ -174,6 +174,14 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 		).
 		ToSlice(&descriptors)
 
+	if len(users) == 0 {
+		if principalName != "" {
+			return fmt.Errorf(" User not found. Prinicipal Name: %s", principalName)
+		} else if originID != "" {
+			return fmt.Errorf(" User not found. Origin ID: %s", originID)
+		}
+	}
+
 	h := sha1.New()
 	if _, err := h.Write([]byte(strings.Join(descriptors, "-"))); err != nil {
 		return fmt.Errorf("Unable to compute hash for user descriptors: %v", err)

--- a/azuredevops/internal/service/graph/data_users.go
+++ b/azuredevops/internal/service/graph/data_users.go
@@ -176,7 +176,7 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 
 	if len(users) == 0 {
 		if principalName != "" {
-			return fmt.Errorf(" User not found. Prinicipal Name: %s", principalName)
+			return fmt.Errorf(" User not found. Principal Name: %s", principalName)
 		} else if originID != "" {
 			return fmt.Errorf(" User not found. Origin ID: %s", originID)
 		}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #936 
Return error if user not found. 

```log
=== RUN   TestAccUsers_DataSource
=== PAUSE TestAccUsers_DataSource
=== RUN   TestAccUsers_DataSource_AllSvc
=== PAUSE TestAccUsers_DataSource_AllSvc
=== RUN   TestAccUsers_DataSource_All_WithFeatures
=== PAUSE TestAccUsers_DataSource_All_WithFeatures
=== CONT  TestAccUsers_DataSource
=== CONT  TestAccUsers_DataSource_All_WithFeatures
=== CONT  TestAccUsers_DataSource_AllSvc
--- PASS: TestAccUsers_DataSource_AllSvc (33.25s)
--- PASS: TestAccUsers_DataSource (42.58s)
--- PASS: TestAccUsers_DataSource_All_WithFeatures (1592.93s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        1593.456s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->