### PR TITLE
`azuredevops_serviceendpoint_azurecr` - Fix `tenantId` not set as expected

### DIFF
--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -265,23 +265,6 @@ resource "azuredevops_serviceendpoint_dockerregistry" "serviceendpoint" {
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
-// HclServiceEndpointAzureCRResource HCL describing an AzDO service endpoint
-func HclServiceEndpointAzureCRResource(projectName string, serviceEndpointName string) string {
-	serviceEndpointResource := fmt.Sprintf(`
-resource "azuredevops_serviceendpoint_azurecr" "serviceendpoint" {
-	project_id                = azuredevops_project.project.id
-	service_endpoint_name     = "%s"
-	azurecr_spn_tenantid      = "9c59cbe5-2ca1-4516-b303-8968a070edd2"
-	azurecr_subscription_id   = "3b0fee91-c36d-4d70-b1e9-fc4b9d608c3d"
-	azurecr_subscription_name = "Microsoft Azure DEMO"
-	resource_group            = "testrg"
-	azurecr_name              = "testacr"
-}`, serviceEndpointName)
-
-	projectResource := HclProjectResource(projectName)
-	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
-}
-
 // HclServiceEndpointKubernetesResource HCL describing an AzDO kubernetes service endpoint
 func HclServiceEndpointKubernetesResource(projectName string, serviceEndpointName string, authorizationType string) string {
 	var serviceEndpointResource string

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -231,7 +231,7 @@ func expandServiceEndpointAzureCR(d *schema.ResourceData) (*serviceendpoint.Serv
 			serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
 				Parameters: &map[string]string{
 					"authenticationType": "spnKey",
-					"tenantid":           d.Get("azurecr_spn_tenantid").(string),
+					"tenantId":           d.Get("azurecr_spn_tenantid").(string),
 					"loginServer":        loginServer,
 					"scope":              scope,
 					"serviceprincipalid": d.Get("service_principal_id").(string),
@@ -313,7 +313,7 @@ func flattenServiceEndpointAzureCR(d *schema.ResourceData, serviceEndpoint *serv
 	d.Set("service_endpoint_authentication_scheme", string(serviceEndPointType))
 
 	if serviceEndpoint.Authorization != nil && serviceEndpoint.Authorization.Parameters != nil {
-		d.Set("azurecr_spn_tenantid", (*serviceEndpoint.Authorization.Parameters)["tenantid"])
+		d.Set("azurecr_spn_tenantid", (*serviceEndpoint.Authorization.Parameters)["tenantId"])
 		d.Set("service_principal_id", (*serviceEndpoint.Authorization.Parameters)["serviceprincipalid"])
 
 		if scope, ok := (*serviceEndpoint.Authorization.Parameters)["scope"]; ok {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
```log
=== RUN   TestAccServiceEndpointAzureCR_Spn_Basic
=== PAUSE TestAccServiceEndpointAzureCR_Spn_Basic
=== RUN   TestAccServiceEndpointAzureCR_Spn_Update
=== PAUSE TestAccServiceEndpointAzureCR_Spn_Update
=== CONT  TestAccServiceEndpointAzureCR_Spn_Basic
=== CONT  TestAccServiceEndpointAzureCR_Spn_Update
--- PASS: TestAccServiceEndpointAzureCR_Spn_Basic (97.91s)
--- PASS: TestAccServiceEndpointAzureCR_Spn_Update (147.08s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        153.092s

```


## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->