### PR TITLE
 Data user `azuredevops_users`- return empty if user not found

### DIFF
--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -63,6 +63,23 @@ func TestAccUsers_DataSource_All_WithFeatures(t *testing.T) {
 	})
 }
 
+func TestAccUsers_DataSource_userNotFound(t *testing.T) {
+	tfNode := "data.azuredevops_users.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclDataUserUserNotFound(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "users.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func hclDataUserAllWithFeatures(numWorkers int) string {
 	return fmt.Sprintf(`
 data "azuredevops_users" "test" {
@@ -90,4 +107,12 @@ data "azuredevops_users" "test" {
   principal_name = "%[1]s"
   depends_on     = [azuredevops_user_entitlement.test]
 }`, uname)
+}
+
+func hclDataUserUserNotFound() string {
+	return fmt.Sprintf(`
+
+data "azuredevops_users" "test" {
+  principal_name = "dummy"
+}`)
 }

--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -110,8 +110,8 @@ data "azuredevops_users" "test" {
 }
 
 func hclDataUserUserNotFound() string {
-	return fmt.Sprintf(`
+	return `
 data "azuredevops_users" "test" {
   principal_name = "dummy"
-}`)
+}`
 }

--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -111,7 +111,6 @@ data "azuredevops_users" "test" {
 
 func hclDataUserUserNotFound() string {
 	return fmt.Sprintf(`
-
 data "azuredevops_users" "test" {
   principal_name = "dummy"
 }`)

--- a/azuredevops/internal/service/graph/data_users.go
+++ b/azuredevops/internal/service/graph/data_users.go
@@ -174,14 +174,6 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 		).
 		ToSlice(&descriptors)
 
-	if len(users) == 0 {
-		if principalName != "" {
-			return fmt.Errorf(" User not found. Principal Name: %s", principalName)
-		} else if originID != "" {
-			return fmt.Errorf(" User not found. Origin ID: %s", originID)
-		}
-	}
-
 	h := sha1.New()
 	if _, err := h.Write([]byte(strings.Join(descriptors, "-"))); err != nil {
 		return fmt.Errorf("Unable to compute hash for user descriptors: %v", err)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1110
Revert the changes brought by #1110 , return empty if user not found.
```log
=== RUN   TestAccUsers_DataSource_AllSvc
=== PAUSE TestAccUsers_DataSource_AllSvc
=== RUN   TestAccUsers_DataSource_All_WithFeatures
=== PAUSE TestAccUsers_DataSource_All_WithFeatures
=== RUN   TestAccUsers_DataSource_userNotFound
=== PAUSE TestAccUsers_DataSource_userNotFound
=== CONT  TestAccUsers_DataSource_AllSvc
=== CONT  TestAccUsers_DataSource_userNotFound
=== CONT  TestAccUsers_DataSource_All_WithFeatures
--- PASS: TestAccUsers_DataSource_AllSvc (44.28s)
--- PASS: TestAccUsers_DataSource_userNotFound (44.45s)
--- PASS: TestAccUsers_DataSource_All_WithFeatures (1893.52s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        1894.027s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->