### PR TITLE
`azuredevops_area` `azuredevops_iteration` `azuredevops_workitem`  Refactor code

### DIFF
--- a/azuredevops/internal/service/data_client_config.go
+++ b/azuredevops/internal/service/data_client_config.go
@@ -7,16 +7,12 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 )
 
-const (
-	organizationURL = "organization_url"
-)
-
 // DataClientConfig schema and implementation for AzDO client configuration
 func DataClientConfig() *schema.Resource {
 	return &schema.Resource{
 		Read: clientConfigRead,
 		Schema: map[string]*schema.Schema{
-			organizationURL: {
+			"organization_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -25,9 +21,7 @@ func DataClientConfig() *schema.Resource {
 }
 
 func clientConfigRead(d *schema.ResourceData, m interface{}) error {
-	// The ID is meaningless for this data source, so ID can act as a
-	// point in time snapshot
 	d.SetId(time.Now().UTC().String())
-	d.Set(organizationURL, m.(*client.AggregatedClient).OrganizationURL)
+	d.Set("organization_url", m.(*client.AggregatedClient).OrganizationURL)
 	return nil
 }

--- a/azuredevops/internal/service/wiki/resource_wiki.go
+++ b/azuredevops/internal/service/wiki/resource_wiki.go
@@ -33,10 +33,6 @@ func ResourceWiki() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -45,7 +41,21 @@ func ResourceWiki() *schema.Resource {
 					string(wiki.WikiTypeValues.CodeWiki)},
 					false),
 			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"mapped_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"repository_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -54,18 +64,8 @@ func ResourceWiki() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"repository_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"url": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"version": {
-				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},
@@ -80,10 +80,16 @@ func resourceWikiCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	wikiArgs := &wiki.WikiCreateParametersV2{Name: converter.String(d.Get("name").(string)), ProjectId: &uuidProject, Type: &wikiType}
+	wikiArgs := &wiki.WikiCreateParametersV2{
+		Name:      converter.String(d.Get("name").(string)),
+		ProjectId: &uuidProject,
+		Type:      &wikiType,
+	}
+
 	if mappedPath, ok := d.GetOk("mapped_path"); ok {
 		wikiArgs.MappedPath = converter.String(mappedPath.(string))
 	}
+
 	if repositoryId, ok := d.GetOk("repository_id"); ok {
 		repositoryUuid, err := uuid.Parse(repositoryId.(string))
 		if err != nil {
@@ -183,6 +189,5 @@ func resourceWikiDelete(d *schema.ResourceData, m interface{}) error {
 			return errors.New("projectWiki can only be removed when attached project is removed.")
 		}
 	}
-	d.SetId("")
 	return nil
 }

--- a/azuredevops/internal/service/workitemtracking/utils/classification.go
+++ b/azuredevops/internal/service/workitemtracking/utils/classification.go
@@ -99,7 +99,7 @@ func ReadClassificationNode(clients *client.AggregatedClient, d *schema.Resource
 		// "VS402485: The Area/Iteration name is not recognized"
 		d.SetId("")
 		js, _ := json.Marshal(params)
-		return fmt.Errorf(" getting ClassificationNode failed. %s", js)
+		return fmt.Errorf(" getting ClassificationNode failed. %s. Error: %w", js, err)
 	}
 
 	d.SetId(node.Identifier.String())

--- a/azuredevops/internal/service/workitemtracking/utils/classification.go
+++ b/azuredevops/internal/service/workitemtracking/utils/classification.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -82,31 +83,36 @@ func ReadClassificationNode(clients *client.AggregatedClient, d *schema.Resource
 	if d.Get("fetch_children").(bool) {
 		depth = 1
 	}
-	args := workitemtracking.GetClassificationNodeArgs{
+	params := workitemtracking.GetClassificationNodeArgs{
 		Project:        &projectID,
 		StructureGroup: &structureType,
 		Depth:          converter.Int(depth),
 	}
 
-	path, pathSet := d.GetOk("path")
-	if pathSet {
-		args.Path = converter.String(strings.TrimSpace(path.(string)))
+	if path, ok := d.GetOk("path"); ok {
+		params.Path = converter.String(strings.TrimSpace(path.(string)))
 	}
 
-	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, args)
+	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, params)
 	if err != nil {
 		// the following error will be returned in case the classification node isn't present
 		// "VS402485: The Area/Iteration name is not recognized"
 		d.SetId("")
-		return fmt.Errorf("Error getting Iteration with path %q: %w", path, err)
+		js, _ := json.Marshal(params)
+		return fmt.Errorf(" getting ClassificationNode failed. %s", js)
 	}
 
 	d.SetId(node.Identifier.String())
-	if args.Path == nil {
+	d.Set("name", node.Name)
+
+	if node.Path != nil {
 		d.Set("path", convertNodePath(node.Path))
 	}
-	d.Set("name", node.Name)
-	d.Set("has_children", converter.ToBool(node.HasChildren, false))
+
+	if node.HasChildren != nil {
+		d.Set("has_children", converter.ToBool(node.HasChildren, false))
+	}
+
 	d.Set("children", flattenClassificationChildNodes(projectID, node.Children))
 	return nil
 }


### PR DESCRIPTION
## All Submissions:

* [x Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

```log
=== RUN   TestAccWorkItem_basic
=== PAUSE TestAccWorkItem_basic
=== RUN   TestAccWorkItem_titleUpdate
=== PAUSE TestAccWorkItem_titleUpdate
=== RUN   TestAccWorkItem_tagUpdate
=== PAUSE TestAccWorkItem_tagUpdate
=== CONT  TestAccWorkItem_basic
=== CONT  TestAccWorkItem_tagUpdate
=== CONT  TestAccWorkItem_titleUpdate
--- PASS: TestAccWorkItem_basic (83.05s)
--- PASS: TestAccWorkItem_titleUpdate (104.19s)
--- PASS: TestAccWorkItem_tagUpdate (119.17s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        124.826s

=== RUN   TestAccAreaDataSource_Read
=== PAUSE TestAccAreaDataSource_Read
=== RUN   TestAccAreaDataSource_ReadNoChildren
=== PAUSE TestAccAreaDataSource_ReadNoChildren
=== CONT  TestAccAreaDataSource_Read
=== CONT  TestAccAreaDataSource_ReadNoChildren
--- PASS: TestAccAreaDataSource_ReadNoChildren (60.85s)
--- PASS: TestAccAreaDataSource_Read (61.08s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        61.616s

=== RUN   TestAccIterationDataSource_Read
=== PAUSE TestAccIterationDataSource_Read
=== RUN   TestAccIterationDataSource_ReadNoChildren
=== PAUSE TestAccIterationDataSource_ReadNoChildren
=== CONT  TestAccIterationDataSource_Read
=== CONT  TestAccIterationDataSource_ReadNoChildren
--- PASS: TestAccIterationDataSource_Read (48.31s)
--- PASS: TestAccIterationDataSource_ReadNoChildren (56.31s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        56.890s

=== RUN   TestAccWikiResource_Basic
=== PAUSE TestAccWikiResource_Basic
=== RUN   TestAccWikiResource_Complete
=== PAUSE TestAccWikiResource_Complete
=== RUN   TestAccWikiResource_CreateAndUpdate
=== PAUSE TestAccWikiResource_CreateAndUpdate
=== RUN   TestAccWikiResource_ImportErrorStep
=== PAUSE TestAccWikiResource_ImportErrorStep
=== CONT  TestAccWikiResource_Basic
=== CONT  TestAccWikiResource_CreateAndUpdate
=== CONT  TestAccWikiResource_Complete
=== CONT  TestAccWikiResource_ImportErrorStep
--- PASS: TestAccWikiResource_CreateAndUpdate (64.17s)
--- PASS: TestAccWikiResource_Basic (66.36s)
--- PASS: TestAccWikiResource_Complete (66.56s)
--- PASS: TestAccWikiResource_ImportErrorStep (72.34s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        78.053s

```

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->