### PR TITLE
Bug fix `azuredevops_team` - Add members should not fail if the member is already present

### DIFF
--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -450,7 +450,7 @@ func addTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, que
 		}
 		if ok != nil && !*ok {
 			if !isAddMode {
-			    return fmt.Errorf("Failed adding member %s to team %s", *id.SubjectDescriptor, *team.Name)
+				return fmt.Errorf("Failed adding member %s to team %s", *id.SubjectDescriptor, *team.Name)
 			} else {
 				log.Printf("[TRACE] Member %s is already a member of team %s", *id.SubjectDescriptor, *team.Name)
 			}

--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -377,7 +377,7 @@ func setTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, sub
 	}
 
 	// determine the list of all added members
-	err = addTeamMembers(clients, team, linq.From(*subjectDescriptors).Except(linq.From(currentMembers)))
+	err = addTeamMembers(clients, team, linq.From(*subjectDescriptors).Except(linq.From(currentMembers)), false)
 	if err != nil {
 		return err
 	}

--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -429,7 +429,7 @@ func removeTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, 
 	return nil
 }
 
-func addTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, query linq.Query) error {
+func addTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, query linq.Query, isAddMode bool) error {
 	idList, err := getIdentitiesFromSubjects(clients, query)
 	if err != nil {
 		return err
@@ -449,7 +449,11 @@ func addTeamMembers(clients *client.AggregatedClient, team *core.WebApiTeam, que
 			return fmt.Errorf("Error adding member %s to team %s: %+v", *id.SubjectDescriptor, *team.Name, err)
 		}
 		if ok != nil && !*ok {
-			return fmt.Errorf("Failed adding member %s to team %s", *id.SubjectDescriptor, *team.Name)
+			if !isAddMode {
+			    return fmt.Errorf("Failed adding member %s to team %s", *id.SubjectDescriptor, *team.Name)
+			} else {
+				log.Printf("[TRACE] Member %s is already a member of team %s", *id.SubjectDescriptor, *team.Name)
+			}
 		}
 	}
 

--- a/azuredevops/internal/service/core/resource_team_members.go
+++ b/azuredevops/internal/service/core/resource_team_members.go
@@ -201,7 +201,7 @@ func resourceTeamMembersUpdate(d *schema.ResourceData, m interface{}) error {
 
 		// members that need to be added will be missing from the old data, but present in the new data
 		membersToAdd = newData.(*schema.Set).Difference(oldData.(*schema.Set))
-		err = addTeamMembers(clients, team, linq.From(membersToAdd.List()))
+		err = addTeamMembers(clients, team, linq.From(membersToAdd.List()), true)
 		if err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/core/resource_team_members.go
+++ b/azuredevops/internal/service/core/resource_team_members.go
@@ -92,7 +92,7 @@ func resourceTeamMembersCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	} else {
 		membersToAdd = d.Get("members").(*schema.Set)
-		err = addTeamMembers(clients, team, linq.From(membersToAdd.List()))
+		err = addTeamMembers(clients, team, linq.From(membersToAdd.List()), true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When adding a member to a group,
If this member is already part of the group,
We should be considering the `mode` specified on the resource
And NOT fail if the user is already member of the group.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1129

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->