### PR TITLE
Bug Fix - `azuredevops_serviceendpoint_azurecr` - Expect `serviceprincipalkey` only if ServicePrincipal authentication is used

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -327,7 +327,9 @@ func flattenServiceEndpointAzureCR(d *schema.ResourceData, serviceEndpoint *serv
 		if _, ok := d.GetOk("credentials"); !ok {
 			credentials := make(map[string]interface{})
 			credentials["serviceprincipalid"] = (*serviceEndpoint.Authorization.Parameters)["serviceprincipalid"]
-			credentials["serviceprincipalkey"] = d.Get("credentials.0.serviceprincipalkey").(string)
+			if serviceEndPointType == ServicePrincipal {
+				credentials["serviceprincipalkey"] = d.Get("credentials.0.serviceprincipalkey").(string)
+			}
 			d.Set("credentials", []interface{}{credentials})
 		}
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When mapping Azure API response for `azuredevops_serviceendpoint_azurecr` resource to Terraform data structure, the credential key value `authorization.parameters.serviceprincipalkey` should only be processed when ServicePrincipal authentication scheme is used.
`WorkloadIdentityFederation` scheme does not have such a key in the API response.

Issue Number: #1124 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->