### PR TITLE
Update permission resources

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
@@ -13,28 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclAreaPermissions(projectName string, permissions map[string]map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_area_permissions" "root-permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-
-`, testutils.HclProjectResource(projectName), rootPermissions)
-}
-
 func TestAccAreaPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclAreaPermissions(projectName, map[string]map[string]string{
@@ -128,4 +106,27 @@ func TestAccAreaPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclAreaPermissions(projectName string, permissions map[string]map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_area_permissions" "root-permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+		%s
+  }
+}
+
+
+`, testutils.HclProjectResource(projectName), rootPermissions)
 }

--- a/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
@@ -13,34 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclBuildDefinitionPermissions(projectName string, path string, permissions map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions, "=", "\n")
-	buildDefinitionNameFirst := testutils.GenerateResourceName()
-
-	return fmt.Sprintf(`
-%s
-
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_build_definition_permissions" "permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-
-	build_definition_id   = azuredevops_build_definition.build.id
-
-	permissions = {
-		%s
-	}
-}
-`,
-		testutils.HclBuildDefinitionResourceGitHub(projectName, buildDefinitionNameFirst, path),
-		rootPermissions,
-	)
-}
-
 func TestAccBuildDefinitionPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclBuildDefinitionPermissions(projectName, `\`, map[string]string{
@@ -128,4 +100,31 @@ func TestAccBuildDefinitionPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclBuildDefinitionPermissions(projectName string, path string, permissions map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions, "=", "\n")
+	buildDefinitionNameFirst := testutils.GenerateResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_build_definition_permissions" "permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+
+  build_definition_id = azuredevops_build_definition.build.id
+
+  permissions = {
+		%s
+  }
+}
+`, testutils.HclBuildDefinitionResourceGitHub(projectName, buildDefinitionNameFirst, path),
+		rootPermissions,
+	)
 }

--- a/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
@@ -13,43 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclBuildFolderPermissions(projectName string, path string, permissions map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions, "=", "\n")
-	var requiredResources string
-	var pathArgument string
-	if path != `\\` {
-		pathArgument = `azuredevops_build_folder.test_folder.path`
-		description := "Integration Test Folder"
-		requiredResources = testutils.HclBuildFolder(projectName, path, description)
-	} else {
-		pathArgument = `"\\"`
-		requiredResources = testutils.HclProjectResource(projectName)
-	}
-
-	return fmt.Sprintf(`
-%s
-
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_build_folder_permissions" "permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	path        = %s
-
-	permissions = {
-		%s
-	}
-}
-`,
-		requiredResources,
-		pathArgument,
-		rootPermissions,
-	)
-}
-
 func TestAccBuildFolderPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	permissions := map[string]string{
@@ -152,4 +115,40 @@ func TestAccBuildFolderPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclBuildFolderPermissions(projectName string, path string, permissions map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions, "=", "\n")
+	var requiredResources string
+	var pathArgument string
+	if path != `\\` {
+		pathArgument = `azuredevops_build_folder.test_folder.path`
+		description := "Integration Test Folder"
+		requiredResources = testutils.HclBuildFolder(projectName, path, description)
+	} else {
+		pathArgument = `"\\"`
+		requiredResources = testutils.HclProjectResource(projectName)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_build_folder_permissions" "permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  path       = %s
+
+  permissions = {
+		%s
+  }
+}
+`, requiredResources,
+		pathArgument,
+		rootPermissions,
+	)
 }

--- a/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
@@ -13,38 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclIterationPermissions(projectName string, permissions map[string]map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
-	iterationPermissions := datahelper.JoinMap(permissions["iteration"], "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_iteration_permissions" "root-permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-
-resource "azuredevops_iteration_permissions" "iteration-permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	path        = "Iteration 1"
-	permissions = {
-		%s
-	}
-}
-
-`, testutils.HclProjectResource(projectName), rootPermissions, iterationPermissions)
-}
-
 func TestAccIterationPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclIterationPermissions(projectName, map[string]map[string]string{
@@ -167,4 +135,37 @@ func TestAccIterationPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclIterationPermissions(projectName string, permissions map[string]map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
+	iterationPermissions := datahelper.JoinMap(permissions["iteration"], "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_iteration_permissions" "root-permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+		%s
+  }
+}
+
+resource "azuredevops_iteration_permissions" "iteration-permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  path       = "Iteration 1"
+  permissions = {
+		%s
+  }
+}
+
+
+`, testutils.HclProjectResource(projectName), rootPermissions, iterationPermissions)
 }

--- a/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
@@ -13,30 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclLibraryPermissions(projectName string, permissions map[string]string) string {
-	LibraryPermissions := datahelper.JoinMap(permissions, "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_library_permissions" "permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-
-`,
-		testutils.HclProjectResource(projectName),
-		LibraryPermissions,
-	)
-}
-
 func TestAccLibraryPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclLibraryPermissions(projectName, map[string]string{
@@ -131,4 +107,28 @@ func TestAccLibraryPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclLibraryPermissions(projectName string, permissions map[string]string) string {
+	LibraryPermissions := datahelper.JoinMap(permissions, "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_library_permissions" "permissions" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+		%s
+  }
+}
+
+
+`, testutils.HclProjectResource(projectName),
+		LibraryPermissions,
+	)
 }

--- a/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
@@ -13,25 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclServiceHookPermissions(projectName string, permissions map[string]map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-resource "azuredevops_servicehook_permissions" "acctest" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-`, testutils.HclProjectResource(projectName), rootPermissions)
-}
-
 func TestAccServiceHookPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclServiceHookPermissions(projectName, map[string]map[string]string{
@@ -125,4 +106,25 @@ func TestAccServiceHookPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclServiceHookPermissions(projectName string, permissions map[string]map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_servicehook_permissions" "acctest" {
+  project_id = azuredevops_project.project.id
+  principal  = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+		%s
+  }
+}
+`, testutils.HclProjectResource(projectName), rootPermissions)
 }

--- a/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
@@ -13,25 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclTaggingPermissions(projectName string, permissions map[string]map[string]string) string {
-	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-resource "azuredevops_tagging_permissions" "acctest" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-`, testutils.HclProjectResource(projectName), rootPermissions)
-}
-
 func TestAccTaggingPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	config := hclTaggingPermissions(projectName, map[string]map[string]string{
@@ -125,4 +106,25 @@ func TestAccTaggingPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclTaggingPermissions(projectName string, permissions map[string]map[string]string) string {
+	rootPermissions := datahelper.JoinMap(permissions["root"], "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "tf-project-readers" {
+	project_id = azuredevops_project.project.id
+	name       = "Readers"
+}
+
+resource "azuredevops_tagging_permissions" "acctest" {
+	project_id  = azuredevops_project.project.id
+	principal   = data.azuredevops_group.tf-project-readers.id
+	permissions = {
+		%s
+	}
+}
+`, testutils.HclProjectResource(projectName), rootPermissions)
 }

--- a/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
@@ -13,45 +13,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclVariableGroupPermissions(projectName string, variableGroupName string, permissions map[string]string) string {
-	variableGroupPermissions := datahelper.JoinMap(permissions, "=", "\n")
-
-	return fmt.Sprintf(`
-%s
-
-resource "azuredevops_variable_group" "example" {
-	project_id   = azuredevops_project.project.id
-	name         = "%s"
-	description  = "Test Description"
-	allow_access = true
-
-	variable {
-	  name  = "key1"
-	  value = "val1"
-	}
-  }
-
-data "azuredevops_group" "tf-project-readers" {
-	project_id = azuredevops_project.project.id
-	name       = "Readers"
-}
-
-resource "azuredevops_variable_group_permissions" "permissions" {
-	project_id  = azuredevops_project.project.id
-	variable_group_id = azuredevops_variable_group.example.id
-	principal   = data.azuredevops_group.tf-project-readers.id
-	permissions = {
-		%s
-	}
-}
-
-`,
-		testutils.HclProjectResource(projectName),
-		variableGroupName,
-		variableGroupPermissions,
-	)
-}
-
 func TestAccVariableGroupPermissions_SetPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	variableGroupName := testutils.GenerateResourceName()
@@ -150,4 +111,43 @@ func TestAccVariableGroupPermissions_UpdatePermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclVariableGroupPermissions(projectName string, variableGroupName string, permissions map[string]string) string {
+	variableGroupPermissions := datahelper.JoinMap(permissions, "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_variable_group" "example" {
+  project_id   = azuredevops_project.project.id
+  name         = "%s"
+  description  = "Test Description"
+  allow_access = true
+
+  variable {
+    name  = "key1"
+    value = "val1"
+  }
+}
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_variable_group_permissions" "permissions" {
+  project_id        = azuredevops_project.project.id
+  variable_group_id = azuredevops_variable_group.example.id
+  principal         = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+		%s
+  }
+}
+
+
+`, testutils.HclProjectResource(projectName),
+		variableGroupName,
+		variableGroupPermissions,
+	)
 }

--- a/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
@@ -14,33 +14,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
 )
 
-func hclWorkItemQueryPermissions(projectName string, path string, permissions map[string]string) string {
-	projectResource := testutils.HclProjectResource(projectName)
-	szPermissions := datahelper.JoinMap(permissions, "=", "\n")
-	szPath := ""
-	if path != "" {
-		szPath = fmt.Sprintf("path = \"%s\"", path)
-	}
-
-	return fmt.Sprintf(`
-%s
-
-data "azuredevops_group" "project-administrators" {
-	project_id = azuredevops_project.project.id
-	name       = "Project administrators"
-}
-
-resource "azuredevops_workitemquery_permissions" "wiq-permissions" {
-	project_id  = azuredevops_project.project.id
-	principal   = data.azuredevops_group.project-administrators.id
-	%s
-	permissions = {
-		%s
-	}
-}
-`, projectResource, szPath, szPermissions)
-}
-
 func TestAccWorkItemQueryPermissions_SetProjectPermissions(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	permissions := map[string]string{
@@ -179,4 +152,31 @@ func TestAccWorkItemQueryPermissions_SetInvalidFolderPermissions(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclWorkItemQueryPermissions(projectName string, path string, permissions map[string]string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	szPermissions := datahelper.JoinMap(permissions, "=", "\n")
+	szPath := ""
+	if path != "" {
+		szPath = fmt.Sprintf("path = \"%s\"", path)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "project-administrators" {
+	project_id = azuredevops_project.project.id
+	name       = "Project administrators"
+}
+
+resource "azuredevops_workitemquery_permissions" "wiq-permissions" {
+	project_id  = azuredevops_project.project.id
+	principal   = data.azuredevops_group.project-administrators.id
+	%s
+	permissions = {
+		%s
+	}
+}
+`, projectResource, szPath, szPermissions)
 }

--- a/azuredevops/internal/service/permissions/resource_area_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_area_permissions.go
@@ -90,7 +90,6 @@ func resourceAreaPermissionsDelete(d *schema.ResourceData, m interface{}) error 
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_build_definition_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_build_definition_permissions.go
@@ -97,7 +97,6 @@ func resourceBuildDefinitionPermissionsDelete(d *schema.ResourceData, m interfac
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
@@ -90,7 +90,6 @@ func resourceBuildFolderPermissionsDelete(d *schema.ResourceData, m interface{})
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_git_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_git_permissions.go
@@ -100,7 +100,6 @@ func resourceGitPermissionsDelete(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_iteration_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_iteration_permissions.go
@@ -91,7 +91,6 @@ func resourceIterationPermissionsDelete(d *schema.ResourceData, m interface{}) e
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_library_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_library_permissions.go
@@ -83,7 +83,6 @@ func resourceLibraryPermissionsDelete(d *schema.ResourceData, m interface{}) err
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_project_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_project_permissions.go
@@ -83,7 +83,6 @@ func resourceProjectPermissionsDelete(d *schema.ResourceData, m interface{}) err
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_serviceendpoint_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_serviceendpoint_permissions.go
@@ -89,7 +89,6 @@ func resourceServiceEndpointPermissionsDelete(d *schema.ResourceData, m interfac
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_servicehook_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_servicehook_permissions.go
@@ -83,7 +83,6 @@ func resourceServiceHookPermissionsDelete(d *schema.ResourceData, m interface{})
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_tagging_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_tagging_permissions.go
@@ -83,7 +83,6 @@ func resourceTaggingPermissionsDelete(d *schema.ResourceData, m interface{}) err
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_variable_group_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_variable_group_permissions.go
@@ -88,7 +88,6 @@ func resourceVariableGroupPermissionsDelete(d *schema.ResourceData, m interface{
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_workitemquery_permissions.go
@@ -98,7 +98,6 @@ func ResourceWorkItemQueryPermissionsDelete(d *schema.ResourceData, m interface{
 	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
 		return err
 	}
-	d.SetId("")
 	return nil
 }
 

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -16,12 +16,6 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
 
-const (
-	envProjectId   = "project_id"
-	envName        = "name"
-	envDescription = "description"
-)
-
 // ResourceEnvironment schema and implementation for environment resource
 func ResourceEnvironment() *schema.Resource {
 	return &schema.Resource{
@@ -37,18 +31,18 @@ func ResourceEnvironment() *schema.Resource {
 		},
 		Importer: tfhelper.ImportProjectQualifiedResourceInteger(),
 		Schema: map[string]*schema.Schema{
-			envProjectId: {
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IsUUID,
 			},
-			envName: {
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.EnvironmentName,
 			},
-			envDescription: {
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "",
@@ -61,12 +55,12 @@ func resourceEnvironmentCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	environment, err := expandEnvironment(d)
 	if err != nil {
-		return fmt.Errorf("Error expanding the environment resource from state: %+v", err)
+		return fmt.Errorf(" Expanding the environment resource from state: %+v", err)
 	}
 
 	createdEnvironment, err := createEnvironment(clients, environment)
 	if err != nil {
-		return fmt.Errorf("Error creating environment in Azure DevOps: %+v", err)
+		return fmt.Errorf(" Creating environment in Azure DevOps: %+v", err)
 	}
 
 	flattenEnvironment(d, createdEnvironment)
@@ -158,13 +152,13 @@ func updateEnvironment(clients *client.AggregatedClient, environment *taskagent.
 }
 
 func expandEnvironment(d *schema.ResourceData) (*taskagent.EnvironmentInstance, error) {
-	projectId, err := uuid.Parse(d.Get(envProjectId).(string))
+	projectId, err := uuid.Parse(d.Get("project_id").(string))
 	if err != nil {
 		return nil, fmt.Errorf(" faild parse project ID to UUID: %s, %+v", "project_id", err)
 	}
 	environment := &taskagent.EnvironmentInstance{
-		Name:        converter.String(d.Get(envName).(string)),
-		Description: converter.String(d.Get(envDescription).(string)),
+		Name:        converter.String(d.Get("name").(string)),
+		Description: converter.String(d.Get("description").(string)),
 		Project: &taskagent.ProjectReference{
 			Id: &projectId,
 		},
@@ -183,7 +177,7 @@ func expandEnvironment(d *schema.ResourceData) (*taskagent.EnvironmentInstance, 
 
 func flattenEnvironment(d *schema.ResourceData, environment *taskagent.EnvironmentInstance) {
 	d.SetId(strconv.Itoa(*environment.Id))
-	d.Set(envProjectId, environment.Project.Id.String())
-	d.Set(envName, *environment.Name)
-	d.Set(envDescription, converter.ToString(environment.Description, ""))
+	d.Set("project_id", environment.Project.Id.String())
+	d.Set("name", *environment.Name)
+	d.Set("description", converter.ToString(environment.Description, ""))
 }


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

```log

=== RUN   TestAccEnvironmentKubernetes_CreateAndUpdate
=== PAUSE TestAccEnvironmentKubernetes_CreateAndUpdate
=== CONT  TestAccEnvironmentKubernetes_CreateAndUpdate
--- PASS: TestAccEnvironmentKubernetes_CreateAndUpdate (125.41s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        136.016s

=== RUN   TestAccBuildDefinitionPermissions_SetPermissions
=== PAUSE TestAccBuildDefinitionPermissions_SetPermissions
=== RUN   TestAccBuildDefinitionPermissions_UpdatePermissions
=== PAUSE TestAccBuildDefinitionPermissions_UpdatePermissions
=== CONT  TestAccBuildDefinitionPermissions_SetPermissions
=== CONT  TestAccBuildDefinitionPermissions_UpdatePermissions
--- PASS: TestAccBuildDefinitionPermissions_SetPermissions (111.56s)
--- PASS: TestAccBuildDefinitionPermissions_UpdatePermissions (165.92s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        169.419s

== RUN   TestAccBuildFolderPermissions_SetPermissions
=== PAUSE TestAccBuildFolderPermissions_SetPermissions
=== RUN   TestAccBuildFolderPermissions_UpdatePermissions
=== PAUSE TestAccBuildFolderPermissions_UpdatePermissions
=== CONT  TestAccBuildFolderPermissions_SetPermissions
=== CONT  TestAccBuildFolderPermissions_UpdatePermissions
--- PASS: TestAccBuildFolderPermissions_UpdatePermissions (141.49s)
--- PASS: TestAccBuildFolderPermissions_SetPermissions (145.19s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        145.751s

=== RUN   TestAccGitPermissions_SetPermissions
=== PAUSE TestAccGitPermissions_SetPermissions
=== CONT  TestAccGitPermissions_SetPermissions
--- PASS: TestAccGitPermissions_SetPermissions (85.70s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        86.242s

=== RUN   TestAccIterationPermissions_SetPermissions
=== PAUSE TestAccIterationPermissions_SetPermissions
=== RUN   TestAccIterationPermissions_UpdatePermissions
=== PAUSE TestAccIterationPermissions_UpdatePermissions
=== CONT  TestAccIterationPermissions_SetPermissions
=== CONT  TestAccIterationPermissions_UpdatePermissions
--- PASS: TestAccIterationPermissions_SetPermissions (75.98s)
--- PASS: TestAccIterationPermissions_UpdatePermissions (109.19s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        109.650s

=== RUN   TestAccLibraryPermissions_SetPermissions
--- PASS: TestAccLibraryPermissions_SetPermissions (71.67s)
=== RUN   TestAccLibraryPermissions_UpdatePermissions
--- PASS: TestAccLibraryPermissions_UpdatePermissions (91.26s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        163.475s



=== RUN   TestAccProjectPermissions_SetPermissions
=== PAUSE TestAccProjectPermissions_SetPermissions
=== CONT  TestAccProjectPermissions_SetPermissions
--- PASS: TestAccProjectPermissions_SetPermissions (84.60s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        85.045s

=== RUN   TestAccServiceEndpointPermissions_SetPermissions
--- PASS: TestAccServiceEndpointPermissions_SetPermissions (90.66s)
=== RUN   TestAccServiceEndpointPermissions_UpdatePermissions
--- PASS: TestAccServiceEndpointPermissions_UpdatePermissions (117.25s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        208.453s

=== RUN   TestAccServiceHookPermissions_SetPermissions
=== PAUSE TestAccServiceHookPermissions_SetPermissions
=== RUN   TestAccServiceHookPermissions_UpdatePermissions
=== PAUSE TestAccServiceHookPermissions_UpdatePermissions
=== CONT  TestAccServiceHookPermissions_SetPermissions
=== CONT  TestAccServiceHookPermissions_UpdatePermissions
--- PASS: TestAccServiceHookPermissions_SetPermissions (72.63s)
--- PASS: TestAccServiceHookPermissions_UpdatePermissions (100.60s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        101.175s

=== RUN   TestAccTaggingPermissions_SetPermissions
=== PAUSE TestAccTaggingPermissions_SetPermissions
=== RUN   TestAccTaggingPermissions_UpdatePermissions
=== PAUSE TestAccTaggingPermissions_UpdatePermissions
=== CONT  TestAccTaggingPermissions_SetPermissions
=== CONT  TestAccTaggingPermissions_UpdatePermissions
--- PASS: TestAccTaggingPermissions_SetPermissions (72.52s)
--- PASS: TestAccTaggingPermissions_UpdatePermissions (100.85s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        101.427s

=== RUN   TestAccVariableGroupPermissions_SetPermissions
--- PASS: TestAccVariableGroupPermissions_SetPermissions (84.27s)
=== RUN   TestAccVariableGroupPermissions_UpdatePermissions
--- PASS: TestAccVariableGroupPermissions_UpdatePermissions (105.43s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        190.307s

=== RUN   TestAccWorkItemQueryPermissions_SetProjectPermissions
=== PAUSE TestAccWorkItemQueryPermissions_SetProjectPermissions
=== RUN   TestAccWorkItemQueryPermissions_UpdateProjectPermissions
=== PAUSE TestAccWorkItemQueryPermissions_UpdateProjectPermissions
=== RUN   TestAccWorkItemQueryPermissions_SetSharedQueriesPermissions
=== PAUSE TestAccWorkItemQueryPermissions_SetSharedQueriesPermissions
=== RUN   TestAccWorkItemQueryPermissions_SetInvalidFolderPermissions
=== PAUSE TestAccWorkItemQueryPermissions_SetInvalidFolderPermissions
=== CONT  TestAccWorkItemQueryPermissions_SetProjectPermissions
=== CONT  TestAccWorkItemQueryPermissions_SetSharedQueriesPermissions
=== CONT  TestAccWorkItemQueryPermissions_SetInvalidFolderPermissions
=== CONT  TestAccWorkItemQueryPermissions_UpdateProjectPermissions
--- PASS: TestAccWorkItemQueryPermissions_SetInvalidFolderPermissions (51.43s)
--- PASS: TestAccWorkItemQueryPermissions_SetProjectPermissions (71.93s)
--- PASS: TestAccWorkItemQueryPermissions_SetSharedQueriesPermissions (72.19s)
--- PASS: TestAccWorkItemQueryPermissions_UpdateProjectPermissions (99.54s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        100.066s

=== RUN   TestAccEnvironment_dataSource
=== PAUSE TestAccEnvironment_dataSource
=== RUN   TestAccEnvironment_dataSource_by_name
=== PAUSE TestAccEnvironment_dataSource_by_name
=== RUN   TestAccEnvironment_CreateAndUpdate
=== PAUSE TestAccEnvironment_CreateAndUpdate
=== CONT  TestAccEnvironment_dataSource
=== CONT  TestAccEnvironment_CreateAndUpdate
=== CONT  TestAccEnvironment_dataSource_by_name
--- PASS: TestAccEnvironment_dataSource_by_name (54.47s)
--- PASS: TestAccEnvironment_dataSource (54.65s)
--- PASS: TestAccEnvironment_CreateAndUpdate (73.44s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        73.991s

```