### PR TITLE
Add `use_oidc` property to `azuredevops_serviceendpoint_aws` resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
@@ -31,6 +31,7 @@ func TestAccServiceEndpointAws_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "access_key_id", "0000"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "secret_access_key", "secretkey"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "use_oidc", "false"),
 				),
 			},
 		},
@@ -66,6 +67,7 @@ func TestAccServiceEndpointAws_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfSvcEpNode, "role_to_assume", rta),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "role_session_name", rsn),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "external_id", externalId),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "use_oidc", "false"),
 				),
 			},
 		},
@@ -148,6 +150,7 @@ resource "azuredevops_serviceendpoint_aws" "test" {
   secret_access_key     = "secretkey"
   service_endpoint_name = "%s"
   description           = "%s"
+  use_oidc              = false
 }`, projectName, serviceEndpointName, description)
 }
 
@@ -167,6 +170,7 @@ resource "azuredevops_serviceendpoint_aws" "test" {
   role_to_assume    = "%s"
   role_session_name = "%s"
   external_id       = "%s"
+  use_oidc          = false
 }`, projectName, serviceEndpointName, description, sessionToken, rta, rsn, externalId)
 
 }
@@ -182,6 +186,7 @@ resource "azuredevops_serviceendpoint_aws" "import" {
   secret_access_key     = "secretkey"
   service_endpoint_name = azuredevops_serviceendpoint_aws.test.service_endpoint_name
   description           = azuredevops_serviceendpoint_aws.test.description
+  use_oidc              = azuredevops_serviceendpoint_aws.test.use_oidc
 }
 `, template)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
@@ -34,23 +33,20 @@ func ResourceServiceEndpointAws() *schema.Resource {
 
 	maps.Copy(r.Schema, map[string]*schema.Schema{
 		"access_key_id": {
-			Type:          schema.TypeString,
-			Required:      false,
-			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_ACCESS_KEY_ID", nil),
-			Description:   "The AWS access key ID for signing programmatic requests.",
-			ConflictsWith: []string{"use_oidc"},
-			RequiredWith:  []string{"secret_access_key"},
-			AtLeastOneOf:  []string{"access_key_id", "secret_access_key", "use_oidc"},
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_ACCESS_KEY_ID", nil),
+			Description:  "The AWS access key ID for signing programmatic requests.",
+			RequiredWith: []string{"secret_access_key"},
 		},
 
 		"secret_access_key": {
-			Type:          schema.TypeString,
-			Required:      false,
-			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_SECRET_ACCESS_KEY", nil),
-			Description:   "The AWS secret access key for signing programmatic requests.",
-			Sensitive:     true,
-			ConflictsWith: []string{"use_oidc"},
-			RequiredWith:  []string{"access_key_id"},
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_SECRET_ACCESS_KEY", nil),
+			Description:  "The AWS secret access key for signing programmatic requests.",
+			Sensitive:    true,
+			RequiredWith: []string{"access_key_id"},
 		},
 
 		"session_token": {
@@ -61,12 +57,10 @@ func ResourceServiceEndpointAws() *schema.Resource {
 			Sensitive:   true,
 		},
 		"role_to_assume": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			DefaultFunc:  schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_RTA", nil),
-			Description:  "The Amazon Resource Name (ARN) of the role to assume.",
-			RequiredWith: []string{"use_oidc"},
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_RTA", nil),
+			Description: "The Amazon Resource Name (ARN) of the role to assume.",
 		},
 
 		"role_session_name": {
@@ -83,12 +77,11 @@ func ResourceServiceEndpointAws() *schema.Resource {
 		},
 
 		"use_oidc": {
-			Type:          schema.TypeBool,
-			Optional:      true,
-			Default:       false,
-			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_USE_OIDC", nil),
-			Description:   "Enable this to attempt getting credentials with OIDC token from Azure Devops",
-			ConflictsWith: []string{"access_key_id", "secret_access_key"},
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_USE_OIDC", nil),
+			Description: "Enable this to attempt getting credentials with OIDC token from Azure Devops.",
 		},
 	})
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -3,9 +3,11 @@ package serviceendpoint
 import (
 	"fmt"
 	"maps"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
@@ -32,18 +34,23 @@ func ResourceServiceEndpointAws() *schema.Resource {
 
 	maps.Copy(r.Schema, map[string]*schema.Schema{
 		"access_key_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_ACCESS_KEY_ID", nil),
-			Description: "The AWS access key ID for signing programmatic requests.",
+			Type:          schema.TypeString,
+			Required:      false,
+			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_ACCESS_KEY_ID", nil),
+			Description:   "The AWS access key ID for signing programmatic requests.",
+			ConflictsWith: []string{"use_oidc"},
+			RequiredWith:  []string{"secret_access_key"},
+			AtLeastOneOf:  []string{"access_key_id", "secret_access_key", "use_oidc"},
 		},
 
 		"secret_access_key": {
-			Type:        schema.TypeString,
-			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_SECRET_ACCESS_KEY", nil),
-			Description: "The AWS secret access key for signing programmatic requests.",
-			Sensitive:   true,
+			Type:          schema.TypeString,
+			Required:      false,
+			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_SECRET_ACCESS_KEY", nil),
+			Description:   "The AWS secret access key for signing programmatic requests.",
+			Sensitive:     true,
+			ConflictsWith: []string{"use_oidc"},
+			RequiredWith:  []string{"access_key_id"},
 		},
 
 		"session_token": {
@@ -54,10 +61,12 @@ func ResourceServiceEndpointAws() *schema.Resource {
 			Sensitive:   true,
 		},
 		"role_to_assume": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_RTA", nil),
-			Description: "The Amazon Resource Name (ARN) of the role to assume.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_RTA", nil),
+			Description:  "The Amazon Resource Name (ARN) of the role to assume.",
+			RequiredWith: []string{"use_oidc"},
 		},
 
 		"role_session_name": {
@@ -71,6 +80,15 @@ func ResourceServiceEndpointAws() *schema.Resource {
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_EXTERNAL_ID", nil),
 			Description: "A unique identifier that is used by third parties when assuming roles in their customers' accounts, aka cross-account role access.",
+		},
+
+		"use_oidc": {
+			Type:          schema.TypeBool,
+			Optional:      true,
+			Default:       false,
+			DefaultFunc:   schema.EnvDefaultFunc("AZDO_AWS_SERVICE_CONNECTION_USE_OIDC", nil),
+			Description:   "Enable this to attempt getting credentials with OIDC token from Azure Devops",
+			ConflictsWith: []string{"access_key_id", "secret_access_key"},
 		},
 	})
 
@@ -151,6 +169,7 @@ func expandServiceEndpointAws(d *schema.ResourceData) (*serviceendpoint.ServiceE
 			"assumeRoleArn":   d.Get("role_to_assume").(string),
 			"roleSessionName": d.Get("role_session_name").(string),
 			"externalId":      d.Get("external_id").(string),
+			"useOIDC":         strconv.FormatBool(d.Get("use_oidc").(bool)),
 		},
 		Scheme: converter.String("UsernamePassword"),
 	}
@@ -163,8 +182,15 @@ func expandServiceEndpointAws(d *schema.ResourceData) (*serviceendpoint.ServiceE
 func flattenServiceEndpointAws(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint) {
 	doBaseFlattening(d, serviceEndpoint)
 
+	useOIDC, err := strconv.ParseBool((*serviceEndpoint.Authorization.Parameters)["useOIDC"])
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	d.Set("access_key_id", (*serviceEndpoint.Authorization.Parameters)["username"])
 	d.Set("role_to_assume", (*serviceEndpoint.Authorization.Parameters)["assumeRoleArn"])
 	d.Set("role_session_name", (*serviceEndpoint.Authorization.Parameters)["roleSessionName"])
 	d.Set("external_id", (*serviceEndpoint.Authorization.Parameters)["externalId"])
+	d.Set("use_oidc", useOIDC)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
@@ -32,6 +32,7 @@ var awsTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 			"assumeRoleArn":   "AWS_TEST_assumeRoleArn",
 			"roleSessionName": "ARS_TEST_roleSessionName",
 			"externalId":      "AWS_TEST_externalId",
+			"useOIDC":         "false",
 		},
 		Scheme: converter.String("UsernamePassword"),
 	},

--- a/website/docs/r/serviceendpoint_aws.html.markdown
+++ b/website/docs/r/serviceendpoint_aws.html.markdown
@@ -34,13 +34,14 @@ The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project.
 * `service_endpoint_name` - (Required) The Service Endpoint name.
-* `access_key_id` - (Required) The AWS access key ID for signing programmatic requests.
-* `secret_access_key` - (Required) The AWS secret access key for signing programmatic requests.
+* `access_key_id` - (Optional) The AWS access key ID for signing programmatic requests.
+* `secret_access_key` - (Optional) The AWS secret access key for signing programmatic requests.
 * `session_token` - (Optional) The AWS session token for signing programmatic requests.
 * `role_to_assume` - (Optional) The Amazon Resource Name (ARN) of the role to assume.
 * `role_session_name` - (Optional) Optional identifier for the assumed role session.
 * `external_id` - (Optional) A unique identifier that is used by third parties when assuming roles in their customers' accounts, aka cross-account role access.
 * `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
+* `use_oidc` - (Optional) Enable this to attempt getting credentials with OIDC token from Azure Devops.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR adds the `useOIDC` inputDescriptor from the Azure Devops service endpoint for AWS. Since the v1.15.0 release the AWS Toolkit for Azure DevOps, an AWS service endpoint connection allows OIDC authentication instead of AWS access keys.

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

N/A

## Other information
Relevant PR in AWS Toolkit repo: [Use OIDC Token directly when options in Service Connections is enabled](https://github.com/aws/aws-toolkit-azure-devops/pull/558)

<img width="547" alt="serviceendpointaws" src="https://github.com/user-attachments/assets/0ad7c9f5-abf0-45f7-ab7a-f61f83f37173">