### PR TITLE
[Bug Fix] - `azuredevops_agent_queue` - Fix name get/set bug

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
+++ b/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
@@ -5,23 +5,49 @@
 package acceptancetests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-func TestAccResourceAgentQueue_CreateAndUpdate(t *testing.T) {
+func TestAccResourceAgentQueue_basic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	poolName := testutils.GenerateResourceName()
-	tfNode := "azuredevops_agent_queue.q"
+	tfNode := "azuredevops_agent_queue.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testutils.PreCheck(t, nil) },
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.HclAgentQueueResource(projectName, poolName),
+				Config: hclAgentQueueBasic(projectName, poolName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+				),
+			}, {
+				ResourceName:      tfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceAgentQueue_basedOnPool(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	poolName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_agent_queue.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAgentQueueBasedObnPool(projectName, poolName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
 					resource.TestCheckResourceAttrSet(tfNode, "agent_pool_id"),
@@ -35,4 +61,37 @@ func TestAccResourceAgentQueue_CreateAndUpdate(t *testing.T) {
 			},
 		},
 	})
+}
+
+func hclAgentQueueBasic(projectName, queueName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_agent_queue" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%s"
+}
+`, projectName, queueName)
+}
+
+func hclAgentQueueBasedObnPool(projectName, poolName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_agent_pool" "test" {
+  name           = "%s"
+  auto_provision = false
+  auto_update    = false
+  pool_type      = "automation"
+}
+
+resource "azuredevops_agent_queue" "test" {
+  project_id    = azuredevops_project.test.id
+  agent_pool_id = azuredevops_agent_pool.test.id
+}
+`, projectName, poolName)
 }

--- a/azuredevops/internal/service/taskagent/resource_agent_queue.go
+++ b/azuredevops/internal/service/taskagent/resource_agent_queue.go
@@ -70,7 +70,7 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 		}
 		queue.Name = referencedPool.Name
 	} else {
-		queue.Name = converter.String(d.Get("agentQueueName").(string))
+		queue.Name = converter.String(d.Get("name").(string))
 	}
 
 	createdQueue, err := clients.TaskAgentClient.AddAgentQueue(clients.Ctx, taskagent.AddAgentQueueArgs{
@@ -85,26 +85,6 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(strconv.Itoa(*createdQueue.Id))
 	return resourceAgentQueueRead(d, m)
-}
-
-func expandAgentQueue(d *schema.ResourceData) (*taskagent.TaskAgentQueue, string, error) {
-	queue := &taskagent.TaskAgentQueue{}
-
-	if v, ok := d.GetOk("agent_pool_id"); ok {
-		queue.Pool = &taskagent.TaskAgentPoolReference{
-			Id: converter.Int(v.(int)),
-		}
-	}
-
-	if d.Id() != "" {
-		id, err := converter.ASCIIToIntPtr(d.Id())
-		if err != nil {
-			return nil, "", fmt.Errorf(" Queue ID was unexpectedly not a valid integer: %+v", err)
-		}
-		queue.Id = id
-	}
-
-	return queue, d.Get("project_id").(string), nil
 }
 
 func resourceAgentQueueRead(d *schema.ResourceData, m interface{}) error {
@@ -132,6 +112,10 @@ func resourceAgentQueueRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("agent_pool_id", *queue.Pool.Id)
 	}
 
+	if queue.Name != nil {
+		d.Set("name", *queue.Name)
+	}
+
 	return nil
 }
 
@@ -152,4 +136,24 @@ func resourceAgentQueueDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return nil
+}
+
+func expandAgentQueue(d *schema.ResourceData) (*taskagent.TaskAgentQueue, string, error) {
+	queue := &taskagent.TaskAgentQueue{}
+
+	if v, ok := d.GetOk("agent_pool_id"); ok {
+		queue.Pool = &taskagent.TaskAgentPoolReference{
+			Id: converter.Int(v.(int)),
+		}
+	}
+
+	if d.Id() != "" {
+		id, err := converter.ASCIIToIntPtr(d.Id())
+		if err != nil {
+			return nil, "", fmt.Errorf(" Queue ID was unexpectedly not a valid integer: %+v", err)
+		}
+		queue.Id = id
+	}
+
+	return queue, d.Get("project_id").(string), nil
 }


### PR DESCRIPTION
1. Fix `name` get/set bug
2.  Update test case

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1153 

```log
=== RUN   TestAccResourceAgentQueue_basic
=== PAUSE TestAccResourceAgentQueue_basic
=== RUN   TestAccResourceAgentQueue_basedOnPool
=== PAUSE TestAccResourceAgentQueue_basedOnPool
=== CONT  TestAccResourceAgentQueue_basic
=== CONT  TestAccResourceAgentQueue_basedOnPool
--- PASS: TestAccResourceAgentQueue_basic (48.91s)
--- PASS: TestAccResourceAgentQueue_basedOnPool (50.97s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        56.320s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->