### PR TITLE
`azuredevops_serviceendpoint_sonarqube` Adding nil check to project ID of sonarqube service endpoint

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -84,6 +84,20 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
+	var projectID string
+	if serviceEndpoint != nil && serviceEndpoint.ServiceEndpointProjectReferences != nil {
+		if len(*serviceEndpoint.ServiceEndpointProjectReferences) > 0 {
+			projectReference := (*serviceEndpoint.ServiceEndpointProjectReferences)[0]
+			if projectReference.ProjectReference != nil && projectReference.ProjectReference.Id != nil {
+				projectID = projectReference.ProjectReference.Id.String()
+			}
+		}
+	}
+
+	if projectID == "" {
+		return fmt.Errorf("Project ID not found for service endpoint %v", getArgs.EndpointId)
+	}
+
 	flattenServiceEndpointSonarQube(d, serviceEndpoint, (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	return nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -84,20 +84,10 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	var projectID string
-	if serviceEndpoint != nil && serviceEndpoint.ServiceEndpointProjectReferences != nil {
-		if len(*serviceEndpoint.ServiceEndpointProjectReferences) > 0 {
-			projectReference := (*serviceEndpoint.ServiceEndpointProjectReferences)[0]
-			if projectReference.ProjectReference != nil && projectReference.ProjectReference.Id != nil {
-				projectID = projectReference.ProjectReference.Id.String()
-			}
-		}
+	if serviceEndpoint.Id == nil {
+		d.SetId("")
+		return nil
 	}
-
-	if projectID == "" {
-		return fmt.Errorf("Project ID not found for service endpoint %v", getArgs.EndpointId)
-	}
-
 	flattenServiceEndpointSonarQube(d, serviceEndpoint, (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	return nil
 }


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The SonarQube service endpoint is now checked for a valid project ID and returns an appropriate error message if one is not found. 

This solves the issue shown in the logs below which occurred when trying to import a service endpoint that had been shared between projects. As these resources are imported using their (shared) ID, the error below occurred once the original endpoint had been deleted, thus leaving no associated project ID. 

The nil check is the same as for the kubernetes service endpoint.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?

```
Stack trace from the terraform-provider-azuredevops_v1.3.0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x8 pc=0x153c063]

goroutine 53 [running]:
github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint.resourceServiceEndpointSonarQubeRead(0xc00019c900, {0x15caf20?, 0xc0000da4e0})   
        github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go:87 +0xa3
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x1945248?, {0x1945248?, 0xc000108090?}, 0xd?, {0x15caf20?, 0xc0000da4e0?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.23.0/helper/schema/resource.go:712 +0x15f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0004ac380, {0x1945248, 0xc000108090}, 0xc000592820, {0x15caf20, 0xc0000da4e0})    
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.23.0/helper/schema/resource.go:1015 +0x51d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00011a000, {0x1945248?, 0xc000703f50?}, 0xc0002566c0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.23.0/helper/schema/grpc_provider.go:613 +0x4aa
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc000176000, {0x1945248?, 0xc0007039b0?}, 0xc0002b02a0)
        github.com/hashicorp/terraform-plugin-go@v0.14.0/tfprotov5/tf5server/server.go:748 +0x488
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x1783840, 0xc000176000}, {0x1945248, 0xc0007039b0}, 0xc000210000, 0x0)     
        github.com/hashicorp/terraform-plugin-go@v0.14.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:349 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000150000, {0x1949ba0, 0xc0004b1520}, 0xc0005c4000, 0xc000702b40, 0x1f97ef0, 0x0)
        google.golang.org/grpc@v1.56.3/server.go:1335 +0xdb8
google.golang.org/grpc.(*Server).handleStream(0xc000150000, {0x1949ba0, 0xc0004b1520}, 0xc0005c4000, 0x0)
        google.golang.org/grpc@v1.56.3/server.go:1712 +0x9da
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        google.golang.org/grpc@v1.56.3/server.go:947 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 11
        google.golang.org/grpc@v1.56.3/server.go:958 +0x136

Error: The terraform-provider-azuredevops_v1.3.0 plugin crashed!
```
