### PR TITLE
`azuredevops_repository_policy_max_file_size` Add max file size 50M

### DIFF
--- a/azuredevops/internal/service/policy/repository/resource_repositorypolicy_max_file_size.go
+++ b/azuredevops/internal/service/policy/repository/resource_repositorypolicy_max_file_size.go
@@ -19,7 +19,7 @@ func ResourceRepositoryMaxFileSize() *schema.Resource {
 	resource.Schema["max_file_size"] = &schema.Schema{
 		Type:         schema.TypeInt,
 		Required:     true,
-		ValidateFunc: validation.IntInSlice([]int{1, 2, 5, 10, 100, 200}),
+		ValidateFunc: validation.IntInSlice([]int{1, 2, 5, 10, 50, 100, 200}),
 	}
 	return resource
 }

--- a/website/docs/r/repository_policy_max_file_size.html.markdown
+++ b/website/docs/r/repository_policy_max_file_size.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 - `project_id` - (Required) The ID of the project in which the policy will be created.
 - `enabled` - (Optional) A flag indicating if the policy should be enabled. Defaults to `true`.
 - `blocking` - (Optional) A flag indicating if the policy should be blocking. Defaults to `true`.
-- `max_file_size` - (Required) Block pushes that contain new or updated files larger than this limit. Available values is: `1, 2, 5, 10, 100, 200` (MB).
+- `max_file_size` - (Required) Block pushes that contain new or updated files larger than this limit. Available values is: `1, 2, 5, 10, 50, 100, 200` (MB).
 - `repository_ids` (Optional) Control whether the policy is enabled for the repository or the project. If `repository_ids` not configured, the policy will be set to the project.
 
 ## Attributes Reference


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1162 

```log
=== RUN   TestAccRepositoryPolicyFileSize
=== RUN   TestAccRepositoryPolicyFileSize/RepositoryPolicies
=== RUN   TestAccRepositoryPolicyFileSize/RepositoryPolicies/basic
=== RUN   TestAccRepositoryPolicyFileSize/RepositoryPolicies/update
=== PAUSE TestAccRepositoryPolicyFileSize/RepositoryPolicies/update
=== CONT  TestAccRepositoryPolicyFileSize/RepositoryPolicies/update
=== RUN   TestAccRepositoryPolicyFileSize/ProjectPolicies
=== RUN   TestAccRepositoryPolicyFileSize/ProjectPolicies/basic
=== RUN   TestAccRepositoryPolicyFileSize/ProjectPolicies/update
=== PAUSE TestAccRepositoryPolicyFileSize/ProjectPolicies/update
=== CONT  TestAccRepositoryPolicyFileSize/ProjectPolicies/update
--- PASS: TestAccRepositoryPolicyFileSize (251.83s)
    --- PASS: TestAccRepositoryPolicyFileSize/RepositoryPolicies (60.52s)
        --- PASS: TestAccRepositoryPolicyFileSize/RepositoryPolicies/basic (60.52s)
        --- PASS: TestAccRepositoryPolicyFileSize/RepositoryPolicies/update (67.17s)
    --- PASS: TestAccRepositoryPolicyFileSize/ProjectPolicies (55.07s)
        --- PASS: TestAccRepositoryPolicyFileSize/ProjectPolicies/basic (55.07s)
        --- PASS: TestAccRepositoryPolicyFileSize/ProjectPolicies/update (69.07s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        257.416s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->