### PR TITLE
[Bug Fix ] `azuredevops_feed_permission` - Add resource status check

### DIFF
--- a/azuredevops/internal/service/feed/resource_feed_permission.go
+++ b/azuredevops/internal/service/feed/resource_feed_permission.go
@@ -299,7 +299,7 @@ func pollPermissions(d *schema.ResourceData, m interface{}) resource.StateRefres
 			if utils.ResponseWasNotFound(err) {
 				return nil, syncing, nil
 			}
-			return nil, failed, nil
+			return nil, failed, err
 		}
 		return "", succeed, nil
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1161
```log
=== RUN   TestAccFeedPermission_basic
=== PAUSE TestAccFeedPermission_basic
=== CONT  TestAccFeedPermission_basic
--- PASS: TestAccFeedPermission_basic (70.23s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        71.988s
```
## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->