### PR TITLE
`azuredevops_wiki_page` update test case

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
@@ -6,16 +6,16 @@ package acceptancetests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-func TestAccWikiPageResource_Basic(t *testing.T) {
+func TestAccWikiPageResource_basic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
-
-	tf := "azuredevops_wiki.project_wiki"
+	tf := "azuredevops_wiki.test"
 	resourceType := "azuredevops_wiki"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
@@ -23,15 +23,12 @@ func TestAccWikiPageResource_Basic(t *testing.T) {
 		CheckDestroy: checkWikiDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: hclProjectWikiPage(projectName),
+				Config: hclProjectWikiPageBasic(projectName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "project_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "type"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "name"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "project_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "wiki_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "path"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "content"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "project_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "wiki_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "path"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "content"),
 				),
 			},
 			{
@@ -43,26 +40,35 @@ func TestAccWikiPageResource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccWikiPageResource_CreateAndUpdate(t *testing.T) {
-
+func TestAccWikiPageResource_update(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
-	tf := "azuredevops_wiki.project_wiki"
-
+	tf := "azuredevops_wiki.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.GetProviders(),
 		CheckDestroy: checkWikiDestroyed("azuredevops_wiki"),
 		Steps: []resource.TestStep{
 			{
-				Config: hclProjectWikiPage(projectName),
+				Config: hclProjectWikiPageBasic(projectName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "project_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "type"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki.project_wiki", "name"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "project_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "wiki_id"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "path"),
-					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.wiki_page", "content"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "project_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "wiki_id"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "path", "/path"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "content", "content"),
+				),
+			},
+			{
+				ResourceName:      tf,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: hclProjectWikiPageUpdate(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "project_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "wiki_id"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "path", "/path"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "content", "contentupdate"),
 				),
 			},
 			{
@@ -74,22 +80,87 @@ func TestAccWikiPageResource_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func hclProjectWikiPage(projectName string) string {
-	projectResource := testutils.HclProjectResource(projectName)
+func TestAccWikiPageResource_requireImportError(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tf := "azuredevops_wiki.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkWikiDestroyed("azuredevops_wiki"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclProjectWikiPageBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "project_id"),
+					resource.TestCheckResourceAttrSet("azuredevops_wiki_page.test", "wiki_id"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "path", "/path"),
+					resource.TestCheckResourceAttr("azuredevops_wiki_page.test", "content", "content"),
+				),
+			},
+			{
+				ResourceName:      tf,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      hclProjectWikiPageImport(projectName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`The page '/path' specified in the add operation already exists in the wiki. Please specify a new page path.`)),
+			},
+		},
+	})
+}
+
+func hclProjectWikiPageBasic(projectName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_wiki" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "projectWikiRepo"
+  type       = "projectWiki"
+}
+
+resource "azuredevops_wiki_page" "test" {
+  project_id = azuredevops_project.test.id
+  wiki_id    = azuredevops_wiki.test.id
+  path       = "/path"
+  content    = "content"
+}
+`, projectName)
+}
+
+func hclProjectWikiPageUpdate(projectName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_wiki" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "projectWikiRepo"
+  type       = "projectWiki"
+}
+
+resource "azuredevops_wiki_page" "test" {
+  project_id = azuredevops_project.test.id
+  wiki_id    = azuredevops_wiki.test.id
+  path       = "/path"
+  content    = "contentupdate"
+}
+`, projectName)
+}
+
+func hclProjectWikiPageImport(projectName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azuredevops_wiki" "project_wiki" {
-	name = "projectWikiRepo"
-	project_id = azuredevops_project.project.id
-	type = "projectWiki"
+resource "azuredevops_wiki_page" "import" {
+  project_id = azuredevops_wiki_page.test.project_id
+  wiki_id    = azuredevops_wiki_page.test.wiki_id
+  path       = azuredevops_wiki_page.test.path
+  content    = azuredevops_wiki_page.test.content
 }
-
-resource "azuredevops_wiki_page" "wiki_page" {
-  project_id = azuredevops_project.project.id
-  wiki_id = azuredevops_wiki.project_wiki.id
-  path = "/path"
-  content = "content"
-}
-`, projectResource)
+`, hclProjectWikiPageBasic(projectName))
 }

--- a/azuredevops/internal/service/graph/data_group_test.go
+++ b/azuredevops/internal/service/graph/data_group_test.go
@@ -124,6 +124,15 @@ func TestGroupDataSource_HandlesContinuationToken_And_SelectsCorrectGroup(t *tes
 		GetDescriptor(clients.Ctx, expectedProjectDescriptorLookupArgs).
 		Return(&projectDescriptorResponse, nil)
 
+	graphClient.
+		EXPECT().
+		GetStorageKey(clients.Ctx, gomock.Any()).
+		Return(&graph.GraphStorageKeyResult{
+			Links: "",
+			Value: &id,
+		}, nil).
+		Times(1)
+
 	firstListGroupCallArgs := graph.ListGroupsArgs{ScopeDescriptor: projectDescriptor}
 	continuationToken := "continuation-token"
 	firstListGroupCallResponse := createPaginatedResponse(continuationToken, groupMeta{name: "name1", descriptor: "descriptor1", origin: "vsts", originId: originID.String()})

--- a/azuredevops/internal/service/graph/data_group_test.go
+++ b/azuredevops/internal/service/graph/data_group_test.go
@@ -183,6 +183,13 @@ func testGroupDataSource_HandlesCollectionGroups(t *testing.T, resourceData *sch
 
 	graphClient := azdosdkmocks.NewMockGraphClient(ctrl)
 	clients := &client.AggregatedClient{GraphClient: graphClient, Ctx: context.Background()}
+	graphClient.
+		EXPECT().
+		GetStorageKey(clients.Ctx, gomock.Any()).
+		Return(&graph.GraphStorageKeyResult{
+			Links: "",
+			Value: &id,
+		}, nil)
 
 	firstListGroupCallArgs := graph.ListGroupsArgs{}
 	continuationToken := "continuation-token"

--- a/azuredevops/internal/service/wiki/resource_wiki_page.go
+++ b/azuredevops/internal/service/wiki/resource_wiki_page.go
@@ -2,7 +2,6 @@ package wiki
 
 import (
 	"fmt"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"strconv"
 	"strings"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/wiki"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
 /*

--- a/azuredevops/internal/service/wiki/resource_wiki_page.go
+++ b/azuredevops/internal/service/wiki/resource_wiki_page.go
@@ -1,6 +1,8 @@
 package wiki
 
 import (
+	"fmt"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,8 +41,9 @@ func ResourceWikiPage() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 			"path": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"content": {
 				Type:     schema.TypeString,
@@ -58,21 +61,16 @@ func ResourceWikiPage() *schema.Resource {
 func resourceWikiPageCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	projectID := d.Get("project_id").(string)
-	wikiID := d.Get("wiki_id").(string)
-	path := d.Get("path").(string)
-	content := d.Get("content").(string)
-
 	pageLock.Lock()
 	defer pageLock.Unlock()
 
 	resp, err := clients.WikiClient.CreateOrUpdatePage(clients.Ctx, wiki.CreateOrUpdatePageArgs{
 		Parameters: &wiki.WikiPageCreateOrUpdateParameters{
-			Content: &content,
+			Content: converter.String(d.Get("content").(string)),
 		},
-		Project:        &projectID,
-		WikiIdentifier: &wikiID,
-		Path:           &path,
+		Project:        converter.String(d.Get("project_id").(string)),
+		WikiIdentifier: converter.String(d.Get("wiki_id").(string)),
+		Path:           converter.String(d.Get("path").(string)),
 	})
 
 	if err != nil {
@@ -84,51 +82,48 @@ func resourceWikiPageCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceWikiPageRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
-	projectID := d.Get("project_id").(string)
-	wikiID := d.Get("wiki_id").(string)
-	path := d.Get("path").(string)
-	includeContent := true
 
 	resp, err := clients.WikiClient.GetPage(clients.Ctx, wiki.GetPageArgs{
-		Project:        &projectID,
-		WikiIdentifier: &wikiID,
-		Path:           &path,
-		IncludeContent: &includeContent,
+		Project:        converter.String(d.Get("project_id").(string)),
+		WikiIdentifier: converter.String(d.Get("wiki_id").(string)),
+		Path:           converter.String(d.Get("path").(string)),
+		IncludeContent: converter.Bool(true),
 	})
 
 	if err != nil {
 		return err
 	}
-	etagValue := strings.Trim(strings.Join(*resp.ETag, " "), `\"`)
-	d.Set("etag", etagValue)
-	d.Set("content", *resp.Page.Content)
-	d.Set("path", *resp.Page.Path)
+
+	if resp.ETag != nil && len(*resp.ETag) > 0 {
+		etagValue := strings.Trim(strings.Join(*resp.ETag, " "), `\"`)
+		d.Set("etag", etagValue)
+	}
+
+	if resp.Page != nil {
+		d.Set("content", resp.Page.Content)
+		d.Set("path", resp.Page.Path)
+	}
 	return nil
 }
 
 func resourceWikiPageUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
-	projectID := d.Get("project_id").(string)
-	wikiID := d.Get("wiki_id").(string)
-
-	etag := d.Get("etag").(string)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf(" Parse wiki page ID: %s. Error: %+v", d.Id(), err)
 	}
-	content := d.Get("content").(string)
 
 	pageLock.Lock()
 	defer pageLock.Unlock()
 
 	_, err = clients.WikiClient.UpdatePageById(clients.Ctx, wiki.UpdatePageByIdArgs{
 		Parameters: &wiki.WikiPageCreateOrUpdateParameters{
-			Content: &content,
+			Content: converter.String(d.Get("content").(string)),
 		},
-		Project:        &projectID,
-		WikiIdentifier: &wikiID,
 		Id:             &id,
-		Version:        &etag,
+		Project:        converter.String(d.Get("project_id").(string)),
+		WikiIdentifier: converter.String(d.Get("wiki_id").(string)),
+		Version:        converter.String(d.Get("etag").(string)),
 	})
 
 	if err != nil {
@@ -141,19 +136,17 @@ func resourceWikiPageUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceWikiPageDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 
-	projectID := d.Get("project_id").(string)
-	wikiID := d.Get("wiki_id").(string)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf(" Parse wiki page ID: %s. Error: %+v", d.Id(), err)
 	}
 
 	pageLock.Lock()
 	defer pageLock.Unlock()
 
 	_, err = clients.WikiClient.DeletePageById(clients.Ctx, wiki.DeletePageByIdArgs{
-		Project:        &projectID,
-		WikiIdentifier: &wikiID,
+		Project:        converter.String(d.Get("project_id").(string)),
+		WikiIdentifier: converter.String(d.Get("wiki_id").(string)),
 		Id:             &id,
 	})
 	if err != nil {

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -108,6 +108,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_iteration_permissions",
 		"azuredevops_team",
 		"azuredevops_wiki",
+		"azuredevops_wiki_page",
 		"azuredevops_team_members",
 		"azuredevops_team_administrators",
 		"azuredevops_serviceendpoint_permissions",


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
```log
=== RUN   TestAccWikiPageResource_basic
=== PAUSE TestAccWikiPageResource_basic
=== RUN   TestAccWikiPageResource_update
=== PAUSE TestAccWikiPageResource_update
=== RUN   TestAccWikiPageResource_requireImportError
=== PAUSE TestAccWikiPageResource_requireImportError
=== CONT  TestAccWikiPageResource_basic
=== CONT  TestAccWikiPageResource_requireImportError
=== CONT  TestAccWikiPageResource_update
--- PASS: TestAccWikiPageResource_requireImportError (72.63s)
--- PASS: TestAccWikiPageResource_basic (309.22s)
--- PASS: TestAccWikiPageResource_update (325.56s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        327.659s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->