### PR TITLE
Feature: `azuredevops_git_repository` - Support enabled/disable repository 

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -72,11 +72,12 @@ func TestAccGitRepo_CreateAndUpdate(t *testing.T) {
 
 // This test verifies the following:
 // 1. You can create a repo with disabled = true
-// 2. You can update a disabled repo
-// 3. You can delete a disabled repo
+// 2. You cannot update a disabled repo
+// 3. You can enable a disabled repo
 func TestAccGitRepo_CreateAndDisable(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	gitRepoName := testutils.GenerateResourceName()
+	gitRepoName2 := testutils.GenerateResourceName()
 	tfRepoNode := "azuredevops_git_repository.repository"
 	disabledTrue := "true"
 	disabledFalse := "false"
@@ -96,6 +97,16 @@ func TestAccGitRepo_CreateAndDisable(t *testing.T) {
 				),
 			},
 			{
+				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName2, disabledTrue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledTrue),
+				),
+				ExpectError: regexp.MustCompile(`A disabled repository cannot be updated, please enable the repository before attempting to update`),
+			},
+			{
 				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName, disabledFalse),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
@@ -111,6 +122,15 @@ func TestAccGitRepo_CreateAndDisable(t *testing.T) {
 					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
 					checkGitRepoExists(gitRepoName),
 					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledTrue),
+				),
+			},
+			{
+				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName, disabledFalse),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledFalse),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,6 +16,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
@@ -62,6 +64,53 @@ func TestAccGitRepo_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfRepoNode, "ssh_url"),
 					resource.TestCheckResourceAttrSet(tfRepoNode, "url"),
 					resource.TestCheckResourceAttrSet(tfRepoNode, "web_url"),
+				),
+			},
+		},
+	})
+}
+
+// This test verifies the following:
+// 1. You can create a repo with disabled = true
+// 2. You can update a disabled repo
+// 3. You can delete a disabled repo
+func TestAccGitRepo_CreateAndDisable(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+	tfRepoNode := "azuredevops_git_repository.repository"
+	disabledTrue := "true"
+	disabledFalse := "false"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkGitRepoDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName, disabledTrue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledTrue),
+				),
+			},
+			{
+				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName, disabledFalse),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledFalse),
+				),
+			},
+			{
+				Config: gitRepoDisabledResourceConfig(projectName, gitRepoName, disabledTrue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disabled", disabledTrue),
 				),
 			},
 		},
@@ -287,8 +336,47 @@ func checkGitRepoDestroyed(s *terraform.State) error {
 
 // Lookup an Azure Git Repository using the ID, or name if the ID is not set.
 func readGitRepo(clients *client.AggregatedClient, repoID string, projectID string) (*git.GitRepository, error) {
-	return clients.GitReposClient.GetRepository(clients.Ctx, git.GetRepositoryArgs{
+	repo, err := clients.GitReposClient.GetRepository(clients.Ctx, git.GetRepositoryArgs{
 		RepositoryId: converter.String(repoID),
 		Project:      converter.String(projectID),
 	})
+
+	// If the repository is disabled, the repository cannot be obtained through the GET API
+	if utils.ResponseWasNotFound(err) {
+		var allRepo *[]git.GitRepository
+		allRepo, err = clients.GitReposClient.GetRepositories(clients.Ctx, git.GetRepositoriesArgs{
+			Project: converter.String(projectID),
+			// This flag is used to include disabled repos
+			IncludeHidden: converter.Bool(true),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, gitRepo := range *allRepo {
+			if strings.EqualFold((*gitRepo.Id).String(), repoID) ||
+				strings.EqualFold(*gitRepo.Name, repoID) {
+				repo = &gitRepo
+				break
+			}
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
+func gitRepoDisabledResourceConfig(projectName string, gitRepoName string, disabled string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	azureGitRepoResource := fmt.Sprintf(`
+	resource "azuredevops_git_repository" "repository" {
+		project_id      = azuredevops_project.project.id
+		name            = "%s"
+		disabled = %s
+		initialization {
+			init_type = "Clean"
+		}
+	}`, gitRepoName, disabled)
+	return fmt.Sprintf("%s\n%s", projectResource, azureGitRepoResource)
 }

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -340,7 +340,7 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Invalid repositoryId UUID: %s", repoID)
 	}
 
-	// you cannot delete a disabled repo. We must enable in order to delete
+	// you cannot delete a disabled repo
 	repoActual, err := gitRepositoryRead(clients, repoID, repoName, projectID)
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -329,6 +329,11 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 	projectID := d.Get("project_id").(string)
 	clients := m.(*client.AggregatedClient)
 
+	uuid, err := uuid.Parse(repoID)
+	if err != nil {
+		return fmt.Errorf("Invalid repositoryId UUID: %s", repoID)
+	}
+
 	// you cannot delete a disabled repo. We must enable in order to delete
 	repoActual, err := gitRepositoryRead(clients, repoID, repoName, projectID)
 	if err != nil {
@@ -346,7 +351,7 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	err = deleteGitRepository(clients, repoID)
+	err = deleteGitRepository(clients, uuid)
 	if err != nil {
 		return err
 	}
@@ -465,11 +470,7 @@ func updateGitRepository(clients *client.AggregatedClient, repository *git.GitRe
 		})
 }
 
-func deleteGitRepository(clients *client.AggregatedClient, repoID string) error {
-	uuid, err := uuid.Parse(repoID)
-	if err != nil {
-		return fmt.Errorf("Invalid repositoryId UUID: %s", repoID)
-	}
+func deleteGitRepository(clients *client.AggregatedClient, uuid uuid.UUID) error {
 	return clients.GitReposClient.DeleteRepository(clients.Ctx, git.DeleteRepositoryArgs{
 		RepositoryId: &uuid,
 	})

--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -86,12 +86,12 @@ func TestGitRepo_Update_DoesNotSwallowErrorFromFailedCreateCall(t *testing.T) {
 
 	reposClient.
 		EXPECT().
-		UpdateRepository(clients.Ctx, gomock.Any()).
-		Return(nil, errors.New("UpdateGitRepository() Failed")).
+		GetRepository(clients.Ctx, gomock.Any()).
+		Return(nil, fmt.Errorf("GetRepository() Failed")).
 		Times(1)
 
 	err := resourceGitRepositoryUpdate(resourceData, clients)
-	require.Regexp(t, ".*UpdateGitRepository\\(\\) Failed$", err.Error())
+	require.Regexp(t, ".*GetRepository\\(\\) Failed$", err.Error())
 }
 
 func configureCleanInitialization(d *schema.ResourceData) {
@@ -269,15 +269,14 @@ func TestGitRepo_Delete_DoesNotSwallowErrorFromFailedDeleteCall(t *testing.T) {
 	id := uuid.New()
 	resourceData.SetId(id.String())
 
-	expectedArgs := git.DeleteRepositoryArgs{RepositoryId: &id}
 	reposClient.
 		EXPECT().
-		DeleteRepository(clients.Ctx, expectedArgs).
-		Return(fmt.Errorf("DeleteRepository() Failed")).
+		GetRepository(clients.Ctx, gomock.Any()).
+		Return(nil, fmt.Errorf("GetRepository() Failed")).
 		Times(1)
 
 	err := resourceGitRepositoryDelete(resourceData, clients)
-	require.Contains(t, err.Error(), "DeleteRepository() Failed")
+	require.Contains(t, err.Error(), "GetRepository() Failed")
 }
 
 // verifies that the name is used for reads if the ID is not set

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -157,6 +157,26 @@ resource "azuredevops_git_repository" "example-import" {
 }
 ```
 
+### Disable a Git repository
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Empty Git Repository"
+  disabled   = true
+  initialization {
+    init_type = "Clean"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -164,6 +184,7 @@ The following arguments are supported:
 - `project_id` - (Required) The project ID or project name.
 - `name` - (Required) The name of the git repository.
 - `parent_repository_id` - (Optional) The ID of a Git project from which a fork is to be created.
+- `disabled` - (Optional) The ability to disable or enable the repository. Defaults to `false`.
 - `initialization` - (Required) An `initialization` block as documented below.
 
 `initialization` - (Required) block supports the following:
@@ -186,7 +207,6 @@ In addition to all arguments above, except `initialization`, the following attri
 - `ssh_url` - Git SSH URL of the repository.
 - `url` - REST API URL of the repository.
 - `web_url` - Web link to the repository.
-- `disabled` - Is the repository disabled?
 
 ## Relevant Links
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR updates the "disabled" field to be `Optional` and defaults to `false`. Users can now use this field to `enable` or `disable` a repository. Acceptance tests have been added to validate the CRUD behavior.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
Closes: #1138

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Unit test output

```
➜ git (feature/git_repo_disable) ✗ go test -tags "all" ./...
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/git    0.737s
```

## Acceptance Test output of added tests

```
➜ terraform-provider-azuredevops (feature/git_repo_disable) ✗  make testacc TESTARGS='-run=TestAccGitRepo_CreateAndDisable' 
==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if available
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
        TF_ACC=1 go test -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v -run=TestAccGitRepo_CreateAndDisable -timeout 120m
=== RUN   TestAccGitRepo_CreateAndDisable
=== PAUSE TestAccGitRepo_CreateAndDisable
=== CONT  TestAccGitRepo_CreateAndDisable
--- PASS: TestAccGitRepo_CreateAndDisable (45.51s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        46.310s
```

## All Git Repository Acceptance Tests output

```
➜ terraform-provider-azuredevops (feature/git_repo_disable) ✔  make testacc TESTARGS='-run=TestAccGitRepo_'                 
==> Checking that code complies with gofmt requirements...
==> Sourcing .env file if available
if [ -f .env ]; then set -o allexport; . ./.env; set +o allexport; fi; \
        TF_ACC=1 go test -tags "all" $(go list ./azuredevops/internal/acceptancetests |grep -v 'vendor') -v -run=TestAccGitRepo_ -timeout 120m
=== RUN   TestAccGitRepo_CreateAndUpdate
=== PAUSE TestAccGitRepo_CreateAndUpdate
=== RUN   TestAccGitRepo_CreateAndDisable
=== PAUSE TestAccGitRepo_CreateAndDisable
=== RUN   TestAccGitRepo_Create_IncorrectInitialization
=== PAUSE TestAccGitRepo_Create_IncorrectInitialization
=== RUN   TestAccGitRepo_Create_Import
=== PAUSE TestAccGitRepo_Create_Import
=== RUN   TestAccGitRepo_RepoInitialization_Clean
=== PAUSE TestAccGitRepo_RepoInitialization_Clean
=== RUN   TestAccGitRepo_RepoInitialization_Uninitialized
=== PAUSE TestAccGitRepo_RepoInitialization_Uninitialized
=== RUN   TestAccGitRepo_RepoFork_BranchNotEmpty
=== PAUSE TestAccGitRepo_RepoFork_BranchNotEmpty
=== RUN   TestAccGitRepo_PrivateImport_BranchNotEmpty
    resource_git_repository_test.go:254: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepo_PrivateImport_BranchNotEmpty (0.00s)
=== CONT  TestAccGitRepo_CreateAndUpdate
=== CONT  TestAccGitRepo_RepoInitialization_Clean
=== CONT  TestAccGitRepo_RepoFork_BranchNotEmpty
=== CONT  TestAccGitRepo_RepoInitialization_Uninitialized
=== CONT  TestAccGitRepo_Create_IncorrectInitialization
=== CONT  TestAccGitRepo_CreateAndDisable
=== CONT  TestAccGitRepo_Create_Import
--- PASS: TestAccGitRepo_Create_IncorrectInitialization (0.26s)
--- PASS: TestAccGitRepo_RepoInitialization_Uninitialized (25.24s)
--- PASS: TestAccGitRepo_CreateAndUpdate (27.50s)
--- PASS: TestAccGitRepo_RepoInitialization_Clean (27.51s)
--- PASS: TestAccGitRepo_CreateAndDisable (34.71s)
--- PASS: TestAccGitRepo_RepoFork_BranchNotEmpty (40.17s)
--- PASS: TestAccGitRepo_Create_Import (50.40s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        50.879s
```