### PR TITLE
`azuredevops_git_repository` Update git repository test case

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -110,7 +110,7 @@ func TestGitRepo_FlattenExpand_RoundTrip(t *testing.T) {
 	project := core.TeamProjectReference{Id: &projectID}
 
 	repoID := uuid.New()
-	repoName := "name"
+	repoName := "repoName"
 	gitRepo := git.GitRepository{Id: &repoID, Name: &repoName, Project: &project}
 
 	resourceData := schema.TestResourceDataRaw(t, ResourceGitRepository().Schema, nil)
@@ -122,8 +122,6 @@ func TestGitRepo_FlattenExpand_RoundTrip(t *testing.T) {
 
 	require.Nil(t, err)
 	require.NotNil(t, expandedGitRepo)
-	require.NotNil(t, expandedGitRepo.Id)
-	require.Equal(t, *expandedGitRepo.Id, repoID)
 	require.NotNil(t, expandedProjectID)
 	require.Equal(t, *expandedProjectID, projectID)
 	require.NotNil(t, repoInitialization)
@@ -252,7 +250,7 @@ func TestGitRepo_Delete_ChecksForValidUUID(t *testing.T) {
 
 	err := resourceGitRepositoryDelete(resourceData, &client.AggregatedClient{})
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid repositoryId UUID")
+	require.Contains(t, err.Error(), "invalid repositoryId UUID")
 }
 
 func TestGitRepo_Delete_DoesNotSwallowErrorFromFailedDeleteCall(t *testing.T) {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_import
=== PAUSE TestAccGitRepository_import
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_uninitialized
=== CONT  TestAccGitRepository_initializationClean
=== CONT  TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_update
=== CONT  TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_import
--- PASS: TestAccGitRepository_incorrectInitialization (3.66s)
--- PASS: TestAccGitRepository_DataSource_notExist (38.63s)
--- PASS: TestAccGitRepository_DataSource (40.86s)
--- PASS: TestAccGitRepository_uninitialized (41.41s)
--- PASS: TestAccGitRepository_initializationClean (43.72s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (49.23s)
--- PASS: TestAccGitRepository_disabled (50.70s)
--- PASS: TestAccGitRepository_update (52.66s)
--- PASS: TestAccGitRepository_import (56.51s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (60.14s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        66.439s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->