### PR TITLE
`azuredevops_git_repository` - Optimize repo datasource

### DIFF
--- a/azuredevops/internal/service/git/data_git_repository.go
+++ b/azuredevops/internal/service/git/data_git_repository.go
@@ -88,7 +88,9 @@ func dataSourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf(" Multiple Repositories with name %s found in project %s", name, projectID)
 	}
 
-	err = flattenGitRepository(d, &(*projectRepos)[0])
+	repo := (*projectRepos)[0]
+	d.SetId(repo.Id.String())
+	err = flattenGitRepository(d, &repo)
 	if err != nil {
 		return fmt.Errorf(" flattening Git repository: %w", err)
 	}

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -286,7 +286,7 @@ func resourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
+		return fmt.Errorf(" Looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
 	}
 
 	if repo == nil {
@@ -535,7 +535,6 @@ func gitRepositoryRead(clients *client.AggregatedClient, repoID string, repoName
 }
 
 func flattenGitRepository(d *schema.ResourceData, repository *git.GitRepository) error {
-	d.SetId(repository.Id.String())
 	d.Set("name", repository.Name)
 	if repository.Project == nil || repository.Project.Id == nil {
 		return fmt.Errorf(" Unable to flatten Git repository without a valid projectID")


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


```log
=== RUN   TestAccTfsGitRepositories_DataSource_Basic
=== PAUSE TestAccTfsGitRepositories_DataSource_Basic
=== RUN   TestAccTfsGitRepositories_DataSource_all
=== PAUSE TestAccTfsGitRepositories_DataSource_all
=== CONT  TestAccTfsGitRepositories_DataSource_Basic
=== CONT  TestAccTfsGitRepositories_DataSource_all
--- PASS: TestAccTfsGitRepositories_DataSource_Basic (59.73s)
--- PASS: TestAccTfsGitRepositories_DataSource_all (59.74s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        61.566s

=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_import
=== PAUSE TestAccGitRepository_import
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_uninitialized
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_import
=== CONT  TestAccGitRepository_update
=== CONT  TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_initializationClean
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_forkBranchNotEmpty
--- PASS: TestAccGitRepository_incorrectInitialization (6.28s)
--- PASS: TestAccGitRepository_initializationClean (62.40s)
--- PASS: TestAccGitRepository_DataSource (68.58s)
--- PASS: TestAccGitRepository_disabled (80.05s)
--- PASS: TestAccGitRepository_import (83.50s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (87.05s)
--- PASS: TestAccGitRepository_uninitialized (180.81s)
--- PASS: TestAccGitRepository_update (193.65s)
--- PASS: TestAccGitRepository_DataSource_notExist (378.69s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (398.88s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        399.667s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->