### PR TITLE
[Bug Fix]`azuredevops_group_entitlement` - Detect group deleted

### DIFF
--- a/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
@@ -156,7 +156,8 @@ func resourceGroupEntitlementRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf(" reading group entitlement: %v", err)
 	}
 
-	if groupEntitlement == nil || groupEntitlement.Id == nil {
+	if groupEntitlement == nil || groupEntitlement.Id == nil ||
+		(groupEntitlement.Group != nil && groupEntitlement.Group.IsDeleted != nil && *groupEntitlement.Group.IsDeleted) {
 		log.Println(" Group has been deleted")
 		d.SetId("")
 		return nil


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 
Fixes: #932 
```log
=== RUN   TestAccGroupEntitlement_Create
=== PAUSE TestAccGroupEntitlement_Create
=== RUN   TestAccGroupEntitlement_AAD_Create
=== PAUSE TestAccGroupEntitlement_AAD_Create
=== CONT  TestAccGroupEntitlement_Create
=== CONT  TestAccGroupEntitlement_AAD_Create
--- PASS: TestAccGroupEntitlement_AAD_Create (26.06s)
--- PASS: TestAccGroupEntitlement_Create (26.82s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        29.001s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->