### PR TITLE
[Bug Fix] - `azuredevops_group_entitlement` - Fix provider crash bug

### DIFF
--- a/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
@@ -262,14 +262,18 @@ func importGroupEntitlement(d *schema.ResourceData, m interface{}) ([]*schema.Re
 	}
 
 	clients := m.(*client.AggregatedClient)
-	result, err := clients.MemberEntitleManagementClient.GetGroupEntitlement(clients.Ctx, memberentitlementmanagement.GetGroupEntitlementArgs{
+	resp, err := clients.MemberEntitleManagementClient.GetGroupEntitlement(clients.Ctx, memberentitlementmanagement.GetGroupEntitlementArgs{
 		GroupId: &id,
 	})
 	if err != nil {
 		return nil, fmt.Errorf(" Getting the group entitlement with supplied id %s: %s", upn, err)
 	}
 
-	d.SetId((*result).Id.String())
+	if resp == nil || resp.Id == nil {
+		return nil, fmt.Errorf(" Group entitlement with ID: %s not found", upn)
+	}
+
+	d.SetId((*resp).Id.String())
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd_test.go
@@ -106,6 +106,7 @@ func testServiceEndpointArgoCD_Create_DoesNotSwallowError(t *testing.T, ep *serv
 
 	r := ResourceServiceEndpointArgoCD()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArgoCD(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -135,6 +136,7 @@ func testServiceEndpointArgoCD_Read_DoesNotSwallowError(t *testing.T, ep *servic
 
 	r := ResourceServiceEndpointArgoCD()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArgoCD(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -167,6 +169,7 @@ func testServiceEndpointArgoCD_Delete_DoesNotSwallowError(t *testing.T, ep *serv
 
 	r := ResourceServiceEndpointArgoCD()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArgoCD(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -203,6 +206,7 @@ func testServiceEndpointArgoCD_Update_DoesNotSwallowError(t *testing.T, ep *serv
 
 	r := ResourceServiceEndpointArgoCD()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArgoCD(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory_test.go
@@ -81,6 +81,7 @@ func testServiceEndpointArtifactory_ExpandFlatten_Roundtrip(t *testing.T, ep *se
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointArtifactory().Schema, nil)
+		resourceData.Set("project_id", id.String())
 		flattenServiceEndpointArtifactory(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointArtifactory(resourceData)
@@ -105,6 +106,7 @@ func testServiceEndpointArtifactory_Create_DoesNotSwallowError(t *testing.T, ep 
 
 	r := ResourceServiceEndpointArtifactory()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -134,6 +136,7 @@ func testServiceEndpointArtifactory_Read_DoesNotSwallowError(t *testing.T, ep *s
 
 	r := ResourceServiceEndpointArtifactory()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -166,6 +169,7 @@ func testServiceEndpointArtifactory_Delete_DoesNotSwallowError(t *testing.T, ep 
 
 	r := ResourceServiceEndpointArtifactory()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws_test.go
@@ -55,6 +55,7 @@ var awsTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointAws_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointAws().Schema, nil)
+	resourceData.Set("project_id", (*awsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAws(resourceData, &awsTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointAws(resourceData)
@@ -71,6 +72,7 @@ func TestServiceEndpointAws_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAws()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*awsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAws(resourceData, &awsTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -94,6 +96,7 @@ func TestServiceEndpointAws_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAws()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*awsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAws(resourceData, &awsTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -120,6 +123,7 @@ func TestServiceEndpointAws_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAws()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*awsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAws(resourceData, &awsTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -148,6 +152,7 @@ func TestServiceEndpointAws_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAws()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*awsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAws(resourceData, &awsTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr_test.go
@@ -70,6 +70,7 @@ var azureCRTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointAzureCR_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointAzureCR().Schema, nil)
+	resourceData.Set("project_id", (*azureCRTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointAzureCR(resourceData)
@@ -86,6 +87,7 @@ func TestServiceEndpointAzureCR_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAzureCR()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*azureCRTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -109,6 +111,7 @@ func TestServiceEndpointAzureCR_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAzureCR()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*azureCRTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -135,6 +138,7 @@ func TestServiceEndpointAzureCR_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAzureCR()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*azureCRTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -163,6 +167,7 @@ func TestServiceEndpointAzureCR_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointAzureCR()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*azureCRTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointAzureCR(resourceData, &azureCRTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -257,6 +257,7 @@ var azurermTestServiceEndpointsAzureRM = []serviceendpoint.ServiceEndpoint{
 func TestServiceEndpointAzureRM_ExpandFlatten_Roundtrip(t *testing.T) {
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 		serviceEndpointAfterRoundTrip, _ := expandServiceEndpointAzureRM(resourceData)
 
@@ -273,6 +274,7 @@ func TestServiceEndpointAzureRM_Create_DoesNotSwallowError(t *testing.T) {
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -299,6 +301,7 @@ func TestServiceEndpointAzureRM_CreateWithValidate_DoesNotSwallowError(t *testin
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		features := initializeFeaturesWithValidate(true)
@@ -354,6 +357,7 @@ func TestServiceEndpointAzureRM_Read_DoesNotSwallowError(t *testing.T) {
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -383,6 +387,7 @@ func TestServiceEndpointAzureRM_Delete_DoesNotSwallowError(t *testing.T) {
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -414,6 +419,7 @@ func TestServiceEndpointAzureRM_Update_DoesNotSwallowError(t *testing.T) {
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -442,6 +448,7 @@ func TestServiceEndpointAzureRM_UpdateWithValidate_DoesNotSwallowError(t *testin
 	r := ResourceServiceEndpointAzureRM()
 	for _, resource := range azurermTestServiceEndpointsAzureRM {
 		resourceData := getResourceData(t, resource)
+		resourceData.Set("project_id", (*resource.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointAzureRM(resourceData, &resource)
 
 		features := initializeFeaturesWithValidate(true)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry_test.go
@@ -56,6 +56,7 @@ var dockerRegistryTestServiceEndpoint = serviceendpoint.ServiceEndpoint{ //todo 
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointDockerRegistry_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointDockerRegistry().Schema, nil)
+	resourceData.Set("project_id", (*dockerRegistryTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointDockerRegistry(resourceData, &dockerRegistryTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointDockerRegistry(resourceData)
@@ -72,6 +73,7 @@ func TestServiceEndpointDockerRegistry_Create_DoesNotSwallowError(t *testing.T) 
 
 	r := ResourceServiceEndpointDockerRegistry()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*dockerRegistryTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointDockerRegistry(resourceData, &dockerRegistryTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -95,6 +97,7 @@ func TestServiceEndpointDockerRegistry_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointDockerRegistry()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*dockerRegistryTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointDockerRegistry(resourceData, &dockerRegistryTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -122,6 +125,7 @@ func TestServiceEndpointDockerRegistry_Delete_DoesNotSwallowError(t *testing.T) 
 
 	r := ResourceServiceEndpointDockerRegistry()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*dockerRegistryTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointDockerRegistry(resourceData, &dockerRegistryTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -151,6 +155,7 @@ func TestServiceEndpointDockerRegistry_Update_DoesNotSwallowError(t *testing.T) 
 
 	r := ResourceServiceEndpointDockerRegistry()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*dockerRegistryTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointDockerRegistry(resourceData, &dockerRegistryTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
@@ -51,6 +51,7 @@ var externalTfsTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 
 func TestServiceEndpointExternalTFS_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointExternalTFS().Schema, nil)
+	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,
@@ -69,6 +70,7 @@ func TestServiceEndpointExternalTFS_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointExternalTFS()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,
@@ -94,6 +96,7 @@ func TestServiceEndpointExternalTFS_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointExternalTFS()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointExternalTFS(
 		resourceData,
 		&externalTfsTestServiceEndpoint)
@@ -121,6 +124,7 @@ func TestServiceEndpointExternalTFS_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointExternalTFS()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointExternalTFS(
 		resourceData,
 		&externalTfsTestServiceEndpoint)
@@ -151,6 +155,7 @@ func TestServiceEndpointExternalTFS_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointExternalTFS()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform_test.go
@@ -56,6 +56,7 @@ var gcpForTerraformTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointGcp_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointGcp().Schema, nil)
+	resourceData.Set("project_id", (*gcpForTerraformTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGcp(resourceData, &gcpForTerraformTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointGcp(resourceData)
@@ -72,6 +73,7 @@ func TestServiceEndpointGcp_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGcp()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*gcpForTerraformTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGcp(resourceData, &gcpForTerraformTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -95,6 +97,7 @@ func TestServiceEndpointGcp_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGcp()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*gcpForTerraformTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGcp(resourceData, &gcpForTerraformTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -121,6 +124,7 @@ func TestServiceEndpointGcp_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGcp()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*gcpForTerraformTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGcp(resourceData, &gcpForTerraformTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -149,6 +153,7 @@ func TestServiceEndpointGcp_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGcp()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*gcpForTerraformTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGcp(resourceData, &gcpForTerraformTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise_test.go
@@ -50,6 +50,7 @@ var ghesTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointGitHubEnterprise_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointGitHubEnterprise().Schema, nil)
+	resourceData.Set("project_id", (*ghesTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureGhesAuthPersonal(resourceData)
 	flattenServiceEndpointGitHubEnterprise(resourceData, &ghesTestServiceEndpoint)
 
@@ -67,6 +68,7 @@ func TestServiceEndpointGitHubEnterprise_Create_DoesNotSwallowError(t *testing.T
 
 	r := ResourceServiceEndpointGitHubEnterprise()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghesTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureGhesAuthPersonal(resourceData)
 	flattenServiceEndpointGitHubEnterprise(resourceData, &ghesTestServiceEndpoint)
 
@@ -91,6 +93,7 @@ func TestServiceEndpointGitHubEnterprise_Read_DoesNotSwallowError(t *testing.T) 
 
 	r := ResourceServiceEndpointGitHubEnterprise()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghesTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGitHubEnterprise(resourceData, &ghesTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -117,6 +120,7 @@ func TestServiceEndpointGitHubEnterprise_Delete_DoesNotSwallowError(t *testing.T
 
 	r := ResourceServiceEndpointGitHubEnterprise()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghesTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGitHubEnterprise(resourceData, &ghesTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -146,6 +150,7 @@ func TestServiceEndpointGitHubEnterprise_Update_DoesNotSwallowError(t *testing.T
 
 	r := ResourceServiceEndpointGitHubEnterprise()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghesTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureGhesAuthPersonal(resourceData)
 	flattenServiceEndpointGitHubEnterprise(resourceData, &ghesTestServiceEndpoint)
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_test.go
@@ -50,6 +50,7 @@ var ghTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointGitHub_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointGitHub().Schema, nil)
+	resourceData.Set("project_id", (*ghTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthPersonal(resourceData)
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint)
 
@@ -67,6 +68,7 @@ func TestServiceEndpointGitHub_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGitHub()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthPersonal(resourceData)
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint)
 
@@ -91,6 +93,7 @@ func TestServiceEndpointGitHub_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGitHub()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -117,6 +120,7 @@ func TestServiceEndpointGitHub_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGitHub()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -145,6 +149,7 @@ func TestServiceEndpointGitHub_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointGitHub()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ghTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthPersonal(resourceData)
 	flattenServiceEndpointGitHub(resourceData, &ghTestServiceEndpoint)
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook_test.go
@@ -52,6 +52,7 @@ var incomingWebhookTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointIncomingWebhook_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointIncomingWebhook().Schema, nil)
+	resourceData.Set("project_id", (*incomingWebhookTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointIncomingWebhook(resourceData, &incomingWebhookTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointIncomingWebhook(resourceData)
@@ -68,6 +69,7 @@ func TestServiceEndpointIncomingWebhook_Create_DoesNotSwallowError(t *testing.T)
 
 	r := ResourceServiceEndpointIncomingWebhook()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*incomingWebhookTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointIncomingWebhook(resourceData, &incomingWebhookTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -91,6 +93,7 @@ func TestServiceEndpointIncomingWebhook_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointIncomingWebhook()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*incomingWebhookTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointIncomingWebhook(resourceData, &incomingWebhookTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -117,6 +120,7 @@ func TestServiceEndpointIncomingWebhook_Delete_DoesNotSwallowError(t *testing.T)
 
 	r := ResourceServiceEndpointIncomingWebhook()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*incomingWebhookTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointIncomingWebhook(resourceData, &incomingWebhookTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -145,6 +149,7 @@ func TestServiceEndpointIncomingWebhook_Update_DoesNotSwallowError(t *testing.T)
 
 	r := ResourceServiceEndpointIncomingWebhook()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*incomingWebhookTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointIncomingWebhook(resourceData, &incomingWebhookTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins_test.go
@@ -53,14 +53,15 @@ var jenkinsTestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 
 // verifies that the flatten/expand round trip yields the same service endpoint
 func testServiceEndpointJenkins_ExpandFlatten_Roundtrip(t *testing.T, ep *serviceendpoint.ServiceEndpoint, id *uuid.UUID) {
-	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
+	for _, se := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointJenkins().Schema, nil)
-		flattenServiceEndpointJenkins(resourceData, ep)
+		resourceData.Set("project_id", (*se.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
+		flattenServiceEndpointJenkins(resourceData, se)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointJenkins(resourceData)
 
 		require.Nil(t, err)
-		require.Equal(t, *ep, *serviceEndpointAfterRoundTrip)
+		require.Equal(t, *se, *serviceEndpointAfterRoundTrip)
 		require.Equal(t, id, (*serviceEndpointAfterRoundTrip.ServiceEndpointProjectReferences)[0].ProjectReference.Id)
 	}
 }
@@ -74,6 +75,7 @@ func TestServiceEndpointJenkins_Create_DoesNotSwallowErrorPassword(t *testing.T)
 
 	r := ResourceServiceEndpointJenkins()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*jenkinsTestServiceEndpointPassword.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointJenkins(resourceData, &jenkinsTestServiceEndpointPassword)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -98,6 +100,7 @@ func testServiceEndpointJenkins_Read_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointJenkins()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointJenkins(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -128,6 +131,7 @@ func testServiceEndpointJenkins_Delete_DoesNotSwallowError(t *testing.T, ep *ser
 
 	r := ResourceServiceEndpointJenkins()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointJenkins(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2_test.go
@@ -49,7 +49,6 @@ var artifactoryV2TestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 }
 
 var artifactoryV2TestServiceEndpointID = uuid.New()
-var artifactoryV2RandomServiceEndpointProjectID = uuid.New()
 var artifactoryV2TestServiceEndpointProjectID = &artifactoryRandomServiceEndpointProjectID
 
 var artifactoryV2TestServiceEndpoint = serviceendpoint.ServiceEndpoint{
@@ -81,6 +80,7 @@ func testServiceEndpointArtifactoryV2_ExpandFlatten_Roundtrip(t *testing.T, ep *
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointJFrogArtifactoryV2().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointArtifactory(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointJFrogArtifactoryV2(resourceData)
@@ -105,6 +105,7 @@ func testServiceEndpointArtifactoryV2_Create_DoesNotSwallowError(t *testing.T, e
 
 	r := ResourceServiceEndpointJFrogArtifactoryV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -136,6 +137,7 @@ func testServiceEndpointArtifactoryV2_Read_DoesNotSwallowError(t *testing.T, ep 
 
 	r := ResourceServiceEndpointJFrogArtifactoryV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -170,6 +172,7 @@ func testServiceEndpointArtifactoryV2_Delete_DoesNotSwallowError(t *testing.T, e
 
 	r := ResourceServiceEndpointJFrogArtifactoryV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2_test.go
@@ -81,6 +81,7 @@ func testServiceEndpointdistributionV2_ExpandFlatten_Roundtrip(t *testing.T, ep 
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointJFrogDistributionV2().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointArtifactory(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointJFrogDistributionV2(resourceData)
@@ -105,6 +106,7 @@ func testServiceEndpointdistributionV2_Create_DoesNotSwallowError(t *testing.T, 
 
 	r := ResourceServiceEndpointJFrogDistributionV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -134,6 +136,7 @@ func testServiceEndpointdistributionV2_Read_DoesNotSwallowError(t *testing.T, ep
 
 	r := ResourceServiceEndpointJFrogDistributionV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -166,6 +169,7 @@ func testServiceEndpointdistributionV2_Delete_DoesNotSwallowError(t *testing.T, 
 
 	r := ResourceServiceEndpointJFrogDistributionV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2_test.go
@@ -81,6 +81,7 @@ func testServiceEndpointplatformV2_ExpandFlatten_Roundtrip(t *testing.T, ep *ser
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointJFrogPlatformV2().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointArtifactory(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointJFrogPlatformV2(resourceData)
@@ -105,6 +106,7 @@ func testServiceEndpointplatformV2_Create_DoesNotSwallowError(t *testing.T, ep *
 
 	r := ResourceServiceEndpointJFrogPlatformV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -134,6 +136,7 @@ func testServiceEndpointplatformV2_Read_DoesNotSwallowError(t *testing.T, ep *se
 
 	r := ResourceServiceEndpointJFrogPlatformV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -166,6 +169,7 @@ func testServiceEndpointplatformV2_Delete_DoesNotSwallowError(t *testing.T, ep *
 
 	r := ResourceServiceEndpointJFrogPlatformV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2_test.go
@@ -81,6 +81,7 @@ func testServiceEndpointxrayV2_ExpandFlatten_Roundtrip(t *testing.T, ep *service
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointJFrogXRayV2().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointArtifactory(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointJFrogXRayV2(resourceData)
@@ -105,6 +106,7 @@ func testServiceEndpointxrayV2_Create_DoesNotSwallowError(t *testing.T, ep *serv
 
 	r := ResourceServiceEndpointJFrogXRayV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -134,6 +136,7 @@ func testServiceEndpointxrayV2_Read_DoesNotSwallowError(t *testing.T, ep *servic
 
 	r := ResourceServiceEndpointJFrogXRayV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -166,6 +169,7 @@ func testServiceEndpointxrayV2_Delete_DoesNotSwallowError(t *testing.T, ep *serv
 
 	r := ResourceServiceEndpointJFrogXRayV2()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointArtifactory(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes_test.go
@@ -7,18 +7,16 @@ package serviceendpoint
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/stretchr/testify/require"
-
-	"github.com/google/uuid"
-
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 )
 
 const errMsgCreateServiceEndpoint = "CreateServiceEndpoint() Failed"
@@ -122,6 +120,7 @@ func createkubernetesTestServiceEndpointForServiceAccount() *serviceendpoint.Ser
 func TestServiceEndpointKubernetesForAzureSubscriptionExpandFlattenRoundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointKubernetes().Schema, nil)
 	kubernetesTestServiceEndpointForAzureSubscription := createkubernetesTestServiceEndpointForAzureSubscription()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForAzureSubscription.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 
@@ -140,6 +139,7 @@ func TestServiceEndpointKubernetesForAzureSubscriptionCreateDoesNotSwallowError(
 	r := ResourceServiceEndpointKubernetes()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	kubernetesTestServiceEndpointForAzureSubscription := createkubernetesTestServiceEndpointForAzureSubscription()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForAzureSubscription.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 
@@ -165,6 +165,7 @@ func TestServiceEndpointKubernetesForAzureSubscriptionReadDoesNotSwallowError(t 
 	r := ResourceServiceEndpointKubernetes()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	kubernetesTestServiceEndpointForAzureSubscription := createkubernetesTestServiceEndpointForAzureSubscription()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForAzureSubscription.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 
@@ -193,6 +194,7 @@ func TestServiceEndpointKubernetesForAzureSubscriptionDeleteDoesNotSwallowError(
 	r := ResourceServiceEndpointKubernetes()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	kubernetesTestServiceEndpointForAzureSubscription := createkubernetesTestServiceEndpointForAzureSubscription()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForAzureSubscription.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 
@@ -224,6 +226,7 @@ func TestServiceEndpointKubernetesForAzureSubscriptionUpdateDoesNotSwallowError(
 	r := ResourceServiceEndpointKubernetes()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	kubernetesTestServiceEndpointForAzureSubscription := createkubernetesTestServiceEndpointForAzureSubscription()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForAzureSubscription.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForAzureSubscription)
 
@@ -250,6 +253,7 @@ func TestServiceEndpointKubernetesForKubeconfigExpandFlattenRoundtrip(t *testing
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointKubernetes().Schema, nil)
 	configureKubeconfig(resourceData)
 	kubernetesTestServiceEndpointForKubeconfig := createkubernetesTestServiceEndpointForKubeconfig()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForKubeconfig.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 
@@ -268,6 +272,7 @@ func TestServiceEndpointKubernetesForKubeconfigCreateDoesNotSwallowError(t *test
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureKubeconfig(resourceData)
 	kubernetesTestServiceEndpointForKubeconfig := createkubernetesTestServiceEndpointForKubeconfig()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForKubeconfig.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 
@@ -294,6 +299,7 @@ func TestServiceEndpointKubernetesForKubeconfigReadDoesNotSwallowError(t *testin
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureKubeconfig(resourceData)
 	kubernetesTestServiceEndpointForKubeconfig := createkubernetesTestServiceEndpointForKubeconfig()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForKubeconfig.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 
@@ -323,6 +329,7 @@ func TestServiceEndpointKubernetesForKubeconfigDeleteDoesNotSwallowError(t *test
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureKubeconfig(resourceData)
 	kubernetesTestServiceEndpointForKubeconfig := createkubernetesTestServiceEndpointForKubeconfig()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForKubeconfig.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 
@@ -354,6 +361,7 @@ func TestServiceEndpointKubernetesForKubeconfigUpdateDoesNotSwallowError(t *test
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureKubeconfig(resourceData)
 	kubernetesTestServiceEndpointForKubeconfig := createkubernetesTestServiceEndpointForKubeconfig()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForKubeconfig.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForKubeconfig)
 
@@ -380,6 +388,7 @@ func TestServiceEndpointKubernetesForServiceAccountExpandFlattenRoundtrip(t *tes
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointKubernetes().Schema, nil)
 	configureServiceAccount(resourceData)
 	kubernetesTestServiceEndpointForServiceAccount := createkubernetesTestServiceEndpointForServiceAccount()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForServiceAccount.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 
@@ -399,6 +408,7 @@ func TestServiceEndpointKubernetesForServiceAccountCreateDoesNotSwallowError(t *
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureServiceAccount(resourceData)
 	kubernetesTestServiceEndpointForServiceAccount := createkubernetesTestServiceEndpointForServiceAccount()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForServiceAccount.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 
@@ -425,6 +435,7 @@ func TestServiceEndpointKubernetesForServiceAccountReadDoesNotSwallowError(t *te
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureServiceAccount(resourceData)
 	kubernetesTestServiceEndpointForServiceAccount := createkubernetesTestServiceEndpointForServiceAccount()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForServiceAccount.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 
@@ -454,6 +465,7 @@ func TestServiceEndpointKubernetesForServiceAccountDeleteDoesNotSwallowError(t *
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureServiceAccount(resourceData)
 	kubernetesTestServiceEndpointForServiceAccount := createkubernetesTestServiceEndpointForServiceAccount()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForServiceAccount.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 
@@ -485,6 +497,7 @@ func TestServiceEndpointKubernetesForServiceAccountUpdateDoesNotSwallowError(t *
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
 	configureServiceAccount(resourceData)
 	kubernetesTestServiceEndpointForServiceAccount := createkubernetesTestServiceEndpointForServiceAccount()
+	resourceData.Set("project_id", (*kubernetesTestServiceEndpointForServiceAccount.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	doBaseFlattening(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 	flattenServiceEndpointKubernetes(resourceData, kubernetesTestServiceEndpointForServiceAccount)
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven_test.go
@@ -87,6 +87,7 @@ var mavenTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 func testServiceEndpointMaven_ExpandFlatten_Roundtrip(t *testing.T, ep *serviceendpoint.ServiceEndpoint, id *uuid.UUID) {
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointMaven().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointMaven(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointMaven(resourceData)
@@ -111,6 +112,7 @@ func testServiceEndpointMaven_Create_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointMaven()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointMaven(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -140,6 +142,7 @@ func testServiceEndpointMaven_Read_DoesNotSwallowError(t *testing.T, ep *service
 
 	r := ResourceServiceEndpointMaven()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointMaven(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -172,6 +175,7 @@ func testServiceEndpointMaven_Delete_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointMaven()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointMaven(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -206,6 +210,7 @@ func testServiceEndpointMaven_Update_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointMaven()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointMaven(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus_test.go
@@ -52,6 +52,7 @@ var nexusTestServiceEndpointPassword = serviceendpoint.ServiceEndpoint{
 func testServiceEndpointNexus_ExpandFlatten_Roundtrip(t *testing.T, ep *serviceendpoint.ServiceEndpoint, id *uuid.UUID) {
 	for _, ep := range []*serviceendpoint.ServiceEndpoint{ep, ep} {
 		resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointNexus().Schema, nil)
+		resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 		flattenServiceEndpointNexus(resourceData, ep)
 
 		serviceEndpointAfterRoundTrip, err := expandServiceEndpointNexus(resourceData)
@@ -72,6 +73,7 @@ func testServiceEndpointNexus_Create_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointNexus()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNexus(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -98,6 +100,7 @@ func testServiceEndpointNexus_Read_DoesNotSwallowError(t *testing.T, ep *service
 
 	r := ResourceServiceEndpointNexus()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNexus(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -127,6 +130,7 @@ func testServiceEndpointNexus_Delete_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointNexus()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNexus(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -158,6 +162,7 @@ func testServiceEndpointNexus_Update_DoesNotSwallowError(t *testing.T, ep *servi
 
 	r := ResourceServiceEndpointNexus()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*ep.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNexus(resourceData, ep)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm_test.go
@@ -50,6 +50,7 @@ var npmTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointNpm_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointNpm().Schema, nil)
+	resourceData.Set("project_id", (*npmTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNpm(resourceData, &npmTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointNpm(resourceData)
@@ -66,6 +67,7 @@ func TestServiceEndpointNpm_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointNpm()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*npmTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNpm(resourceData, &npmTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -89,6 +91,7 @@ func TestServiceEndpointNpm_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointNpm()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*npmTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNpm(resourceData, &npmTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -115,6 +118,7 @@ func TestServiceEndpointNpm_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointNpm()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*npmTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNpm(resourceData, &npmTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -143,6 +147,7 @@ func TestServiceEndpointNpm_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointNpm()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*npmTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointNpm(resourceData, &npmTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline_test.go
@@ -54,6 +54,7 @@ var rpTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointRunPipeline_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointRunPipeline().Schema, nil)
+	resourceData.Set("project_id", (*rpTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	rpConfigureExtraFields(resourceData)
 	flattenServiceEndpointRunPipeline(resourceData, &rpTestServiceEndpoint)
 
@@ -71,6 +72,7 @@ func TestServiceEndpointRunPipeline_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointRunPipeline()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*rpTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	rpConfigureExtraFields(resourceData)
 	flattenServiceEndpointRunPipeline(resourceData, &rpTestServiceEndpoint)
 
@@ -95,6 +97,7 @@ func TestServiceEndpointRunPipeline_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointRunPipeline()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*rpTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointRunPipeline(resourceData, &rpTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -121,6 +124,7 @@ func TestServiceEndpointRunPipeline_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointRunPipeline()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*rpTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointRunPipeline(resourceData, &rpTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -149,6 +153,7 @@ func TestServiceEndpointRunPipeline_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointRunPipeline()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*rpTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	rpConfigureExtraFields(resourceData)
 	flattenServiceEndpointRunPipeline(resourceData, &rpTestServiceEndpoint)
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric_test.go
@@ -53,6 +53,7 @@ var serviceFabricTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointServiceFabric_FlattenExpand_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointServiceFabric().Schema, nil)
+	resourceData.Set("project_id", (*serviceFabricTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthServiceFabricCertificate(resourceData)
 	flattenServiceEndpointServiceFabric(resourceData, &serviceFabricTestServiceEndpoint)
 
@@ -70,6 +71,7 @@ func TestServiceEndpointServiceFabric_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointServiceFabric()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*serviceFabricTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthServiceFabricCertificate(resourceData)
 	flattenServiceEndpointServiceFabric(resourceData, &serviceFabricTestServiceEndpoint)
 
@@ -94,6 +96,7 @@ func TestServiceEndpointServiceFabric_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointServiceFabric()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*serviceFabricTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthServiceFabricCertificate(resourceData)
 	flattenServiceEndpointServiceFabric(resourceData, &serviceFabricTestServiceEndpoint)
 
@@ -121,6 +124,7 @@ func TestServiceEndpointServiceFabric_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointServiceFabric()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*serviceFabricTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthServiceFabricCertificate(resourceData)
 	flattenServiceEndpointServiceFabric(resourceData, &serviceFabricTestServiceEndpoint)
 
@@ -150,6 +154,7 @@ func TestServiceEndpointServiceFabric_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointServiceFabric()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*serviceFabricTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	configureAuthServiceFabricCertificate(resourceData)
 	flattenServiceEndpointServiceFabric(resourceData, &serviceFabricTestServiceEndpoint)
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube_test.go
@@ -50,6 +50,7 @@ var sonarQubeTestServiceEndpoint = serviceendpoint.ServiceEndpoint{
 // verifies that the flatten/expand round trip yields the same service endpoint
 func TestServiceEndpointSonarQube_ExpandFlatten_Roundtrip(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, ResourceServiceEndpointSonarQube().Schema, nil)
+	resourceData.Set("project_id", (*sonarQubeTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointSonarQube(resourceData, &sonarQubeTestServiceEndpoint)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointSonarQube(resourceData)
@@ -66,6 +67,7 @@ func TestServiceEndpointSonarQube_Create_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointSonarQube()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*sonarQubeTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointSonarQube(resourceData, &sonarQubeTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -89,6 +91,7 @@ func TestServiceEndpointSonarQube_Read_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointSonarQube()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*sonarQubeTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointSonarQube(resourceData, &sonarQubeTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -115,6 +118,7 @@ func TestServiceEndpointSonarQube_Delete_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointSonarQube()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*sonarQubeTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointSonarQube(resourceData, &sonarQubeTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
@@ -143,6 +147,7 @@ func TestServiceEndpointSonarQube_Update_DoesNotSwallowError(t *testing.T) {
 
 	r := ResourceServiceEndpointSonarQube()
 	resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+	resourceData.Set("project_id", (*sonarQubeTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointSonarQube(resourceData, &sonarQubeTestServiceEndpoint)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #924 
```log
=== RUN   TestAccGroupEntitlement_Create
=== PAUSE TestAccGroupEntitlement_Create
=== RUN   TestAccGroupEntitlement_AAD_Create
=== PAUSE TestAccGroupEntitlement_AAD_Create
=== CONT  TestAccGroupEntitlement_Create
=== CONT  TestAccGroupEntitlement_AAD_Create
--- PASS: TestAccGroupEntitlement_AAD_Create (25.24s)
--- PASS: TestAccGroupEntitlement_Create (25.35s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        26.114s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->