### PR TITLE
[Bug Fix] `azuredevops_securityrole_assignment` - Fix inconsistent result after apply

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
@@ -21,7 +21,7 @@ func TestAccSecurityRoleAssignmentResource_basic(t *testing.T) {
 		Providers: testutils.GetProviders(),
 		Steps: []resource.TestStep{
 			{
-				Config: hclSecurityroleAssignmentBasic(projectName, groupName),
+				Config: hclSecurityRoleAssignmentBasic(projectName, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("azuredevops_securityrole_assignment.test", "scope"),
 					resource.TestCheckResourceAttr("azuredevops_securityrole_assignment.test", "role_name", "Administrator"),
@@ -31,8 +31,33 @@ func TestAccSecurityRoleAssignmentResource_basic(t *testing.T) {
 	})
 }
 
-func hclSecurityroleAssignmentBasic(projectName, groupName string) string {
+func TestAccSecurityRoleAssignmentResource_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	groupName := testutils.GenerateResourceName()
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSecurityRoleAssignmentBasic(projectName, groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("azuredevops_securityrole_assignment.test", "scope"),
+					resource.TestCheckResourceAttr("azuredevops_securityrole_assignment.test", "role_name", "Administrator"),
+				),
+			},
+			{
+				Config: hclSecurityRoleAssignmentUpdate(projectName, groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("azuredevops_securityrole_assignment.test", "scope"),
+					resource.TestCheckResourceAttr("azuredevops_securityrole_assignment.test", "role_name", "User"),
+				),
+			},
+		},
+	})
+}
+
+func hclSecurityRoleAssignmentBasic(projectName, groupName string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "test" {
   name               = "%[1]s"
@@ -58,6 +83,36 @@ resource "azuredevops_securityrole_assignment" "test" {
   resource_id = "${azuredevops_project.test.id}_${azuredevops_environment.test.id}"
   identity_id = azuredevops_group.test.origin_id
   role_name   = "Administrator"
+}
+`, projectName, groupName)
+}
+
+func hclSecurityRoleAssignmentUpdate(projectName, groupName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "%[1]s-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_group" "test" {
+  scope        = azuredevops_project.test.id
+  display_name = "%[2]s"
+}
+
+resource "azuredevops_environment" "test" {
+  project_id  = azuredevops_project.test.id
+  name        = "Example Environment"
+  description = "Example pipeline deployment environment"
+}
+
+resource "azuredevops_securityrole_assignment" "test" {
+  scope       = "distributedtask.environmentreferencerole"
+  resource_id = "${azuredevops_project.test.id}_${azuredevops_environment.test.id}"
+  identity_id = azuredevops_group.test.origin_id
+  role_name   = "User"
 }
 `, projectName, groupName)
 }

--- a/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
+++ b/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
@@ -163,6 +163,9 @@ func getSecurityRoleAssignment(clients client.AggregatedClient, scope, roleName,
 		})
 
 		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				return "", "syncing", nil
+			}
 			return "", "failed", nil
 		}
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

close: #1251 

```log
=== RUN   TestAccSecurityRoleAssignmentResource_basic
=== PAUSE TestAccSecurityRoleAssignmentResource_basic
=== RUN   TestAccSecurityRoleAssignmentResource_update
=== PAUSE TestAccSecurityRoleAssignmentResource_update
=== CONT  TestAccSecurityRoleAssignmentResource_basic
=== CONT  TestAccSecurityRoleAssignmentResource_update
--- PASS: TestAccSecurityRoleAssignmentResource_basic (67.97s)
--- PASS: TestAccSecurityRoleAssignmentResource_update (91.84s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        100.184s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->