### PR TITLE
Permission utils - Filter deactivate identity

### DIFF
--- a/azuredevops/internal/service/core/resource_team_test.go
+++ b/azuredevops/internal/service/core/resource_team_test.go
@@ -126,6 +126,7 @@ func TestTeam_Create_EnsureTeamDeletedOnAddAdministratorsError(t *testing.T) {
 			{
 				Descriptor:        converter.String(adminID.String()),
 				SubjectDescriptor: &adminSubjectDescriptor,
+				IsActive:          converter.Bool(true),
 			},
 		}, nil).
 		Times(1)
@@ -227,6 +228,7 @@ func TestTeam_Create_EnsureTeamDeletedOnAddMembersError(t *testing.T) {
 				Id:                &memberID,
 				Descriptor:        converter.String(memberID.String()),
 				SubjectDescriptor: &memberSubjectDescriptor,
+				IsActive:          converter.Bool(true),
 			},
 		}, nil).
 		Times(1)

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -293,6 +293,10 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 		return nil, err
 	}
 
+	if idlist == nil || len(*idlist) <= 0 {
+		return nil, fmt.Errorf(" No identity information for defined principals [%s]", descriptors)
+	}
+
 	linq.From(*idlist).Where(func(ele interface{}) bool {
 		if val, ok := ele.(identity.Identity); ok {
 			if val.IsActive != nil && *val.IsActive {
@@ -302,7 +306,7 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 		return false
 	}).ToSlice(idlist)
 
-	if idlist == nil || len(*idlist) != len(*principal) {
+	if len(*idlist) != len(*principal) {
 		return nil, fmt.Errorf(" Failed to load identity information for defined principals [%s]", descriptors)
 	}
 	return idlist, nil

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -292,8 +292,18 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 	if err != nil {
 		return nil, err
 	}
+
+	linq.From(*idlist).Where(func(ele interface{}) bool {
+		if val, ok := ele.(identity.Identity); ok {
+			if val.IsActive != nil && *val.IsActive {
+				return true
+			}
+		}
+		return false
+	}).ToSlice(idlist)
+
 	if idlist == nil || len(*idlist) != len(*principal) {
-		return nil, fmt.Errorf("Failed to load identity information for defined principals [%s]", descriptors)
+		return nil, fmt.Errorf(" Failed to load identity information for defined principals [%s]", descriptors)
 	}
 	return idlist, nil
 }

--- a/azuredevops/internal/service/permissions/utils/namespaces_test.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces_test.go
@@ -268,30 +268,35 @@ var projectIdentityList = []identity.Identity{
 		Id:                  testhelper.ToUUID("79b8298b-7101-4a53-ad6d-1d3de0b495f1"),
 		ProviderDisplayName: converter.String("f609b046-3e4a-419a-a5d7-a0840414dc74"),
 		SubjectDescriptor:   converter.String("svc.Nzc3NGFjMDMtOGEyOS00NGFjLTg2ZjEtZmE0YmRlZDc4ZGUyOkJ1aWxkOmY2MDliMDQ2LTNlNGEtNDE5YS1hNWQ3LWEwODQwNDE0ZGM3NA"),
+		IsActive:            converter.Bool(true),
 	},
 	{
 		Descriptor:          converter.String("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-4251810032-2399672646-2899062471-1578266062-0-0-0-0-1"),
 		Id:                  testhelper.ToUUID("b555cec9-60cf-4f6e-9626-670f964945c5"),
 		ProviderDisplayName: converter.String("[dev]\\Project Collection Administrators"),
 		SubjectDescriptor:   converter.String("vssgp.Uy0xLTktMTU1MTM3NDI0NS00MjUxODEwMDMyLTIzOTk2NzI2NDYtMjg5OTA2MjQ3MS0xNTc4MjY2MDYyLTAtMC0wLTAtMQ"),
+		IsActive:            converter.Bool(true),
 	},
 	{
 		Descriptor:          converter.String("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-4251810032-2399672646-2899062471-1578266062-0-0-0-1-1"),
 		Id:                  testhelper.ToUUID("3e0ea031-f36c-4c43-ab70-34769dc5ba3a"),
 		ProviderDisplayName: converter.String("[dev]\\Project Collection Build Service Accounts"),
 		SubjectDescriptor:   converter.String("vssgp.Uy0xLTktMTU1MTM3NDI0NS00MjUxODEwMDMyLTIzOTk2NzI2NDYtMjg5OTA2MjQ3MS0xNTc4MjY2MDYyLTAtMC0wLTEtMQ"),
+		IsActive:            converter.Bool(true),
 	},
 	{
 		Descriptor:          converter.String("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-4251810032-2399672646-2899062471-1578266062-0-0-0-1-2"),
 		Id:                  testhelper.ToUUID("e1c911d1-592e-451b-84d2-6c81dbb895c0"),
 		ProviderDisplayName: converter.String("[dev]\\Project Collection Build Administrators"),
 		SubjectDescriptor:   converter.String("vssgp.Uy0xLTktMTU1MTM3NDI0NS00MjUxODEwMDMyLTIzOTk2NzI2NDYtMjg5OTA2MjQ3MS0xNTc4MjY2MDYyLTAtMC0wLTEtMg"),
+		IsActive:            converter.Bool(true),
 	},
 	{
 		Descriptor:          converter.String("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-4251810032-2399672646-2899062471-1578266062-0-0-0-4-1"),
 		Id:                  testhelper.ToUUID("b167c23a-27eb-4c59-aa7c-09794f38a556"),
 		ProviderDisplayName: converter.String("[dev]\\Project Collection Test Service Accounts"),
 		SubjectDescriptor:   converter.String("vssgp.Uy0xLTktMTU1MTM3NDI0NS00MjUxODEwMDMyLTIzOTk2NzI2NDYtMjg5OTA2MjQ3MS0xNTc4MjY2MDYyLTAtMC0wLTQtMQ"),
+		IsActive:            converter.Bool(true),
 	},
 }
 

--- a/azuredevops/internal/service/permissions/utils/securityHelper.go
+++ b/azuredevops/internal/service/permissions/utils/securityHelper.go
@@ -14,12 +14,12 @@ import (
 func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forcePermission *PermissionType, forceReplace bool) error {
 	principal, ok := d.GetOk("principal")
 	if !ok {
-		return fmt.Errorf("Failed to get 'principal' from schema")
+		return fmt.Errorf(" Failed to get 'principal' from schema")
 	}
 
 	permissions, ok := d.GetOk("permissions")
 	if !ok {
-		return fmt.Errorf("Failed to get 'permissions' from schema")
+		return fmt.Errorf(" Failed to get 'permissions' from schema")
 	}
 
 	bReplace := d.Get("replace")
@@ -56,10 +56,10 @@ func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forc
 				principal.(string),
 			})
 			if err != nil {
-				return nil, "", fmt.Errorf("Error reading permissions for principal %s: %+v", err, principal.(string))
+				return nil, "", fmt.Errorf(" Reading permissions for principal %s: %+v", err, principal.(string))
 			}
 			if len(*currentPermissions) != 1 {
-				return nil, "", fmt.Errorf("Received multiple permission sets for principal [%s] from backend. Expected single value.", principal.(string))
+				return nil, "", fmt.Errorf(" Received multiple permission sets for principal [%s] from backend. Expected single value.", principal.(string))
 			}
 
 			bInsnyc := false
@@ -94,12 +94,12 @@ func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forc
 func GetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace) (*PrincipalPermission, error) {
 	principal, ok := d.GetOk("principal")
 	if !ok {
-		return nil, fmt.Errorf("Failed to get 'principal' from schema")
+		return nil, fmt.Errorf(" Failed to get 'principal' from schema")
 	}
 
 	permissions, ok := d.GetOk("permissions")
 	if !ok {
-		return nil, fmt.Errorf("Failed to get 'permissions' from schema")
+		return nil, fmt.Errorf(" Failed to get 'permissions' from schema")
 	}
 
 	principalList := []string{*converter.StringFromInterface(principal)}
@@ -111,7 +111,7 @@ func GetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace) (*Pr
 		return nil, nil
 	}
 	if len(*principalPermissions) != 1 {
-		return nil, fmt.Errorf("Failed to retrieve current permissions for principal [%s]", principalList[0])
+		return nil, fmt.Errorf(" Failed to retrieve current permissions for principal [%s]", principalList[0])
 	}
 	for key := range ((*principalPermissions)[0]).Permissions {
 		if _, ok := permissions.(map[string]interface{})[string(key)]; !ok {


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This PR is trying to fix the issue in #1250 . Provider will filter the principal/identity based on the status flag(**IsActivate**)
close: #1250 
```log
=== RUN   TestAccSecurityRoleAssignmentResource_basic
=== PAUSE TestAccSecurityRoleAssignmentResource_basic
=== RUN   TestAccSecurityRoleAssignmentResource_update
=== PAUSE TestAccSecurityRoleAssignmentResource_update
=== CONT  TestAccSecurityRoleAssignmentResource_basic
=== CONT  TestAccSecurityRoleAssignmentResource_update
--- PASS: TestAccSecurityRoleAssignmentResource_basic (67.97s)
--- PASS: TestAccSecurityRoleAssignmentResource_update (91.84s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        100.184s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->