### PR TITLE
Data source `azuredevops_team` - Use GetTeam instead of GetTeams

### DIFF
--- a/azuredevops/internal/acceptancetests/data_team_test.go
+++ b/azuredevops/internal/acceptancetests/data_team_test.go
@@ -1,7 +1,3 @@
-//go:build (all || core || data_sources || data_team) && (!exclude_data_sources || !exclude_data_team)
-// +build all core data_sources data_team
-// +build !exclude_data_sources !exclude_data_team
-
 package acceptancetests
 
 import (
@@ -29,7 +25,6 @@ func TestAccTeam_DataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfNode, "description"),
 					resource.TestCheckResourceAttrSet(tfNode, "administrators.#"),
 					resource.TestCheckResourceAttrSet(tfNode, "members.#"),
-					resource.TestCheckResourceAttrSet(tfNode, "descriptor"),
 				),
 			},
 		},
@@ -39,7 +34,7 @@ func TestAccTeam_DataSource_Basic(t *testing.T) {
 func hclTeamDataSourceBasic(name string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "test" {
-  name               = "%[1]s"
+  name               = "AccTest %[1]s"
   description        = "description"
   visibility         = "private"
   version_control    = "Git"

--- a/website/docs/d/data_team.html.markdown
+++ b/website/docs/d/data_team.html.markdown
@@ -30,9 +30,11 @@ data "azuredevops_team" "example" {
 
 The following arguments are supported:
 
-- `project_id` - (Required) The Project ID.
-- `name` - (Required) The name of the Team.
-- `top` - (Optional) The maximum number of teams to return. Defaults to `100`.
+* `project_id` - (Required) The Project ID.
+
+*`name` - (Required) The name of the Team.
+
+*`top` - (Optional) The maximum number of teams to return. Defaults to `100`. This property is deprecated and will be removed in the feature
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

close: #890 
```log
=== RUN   TestAccTeam_DataSource_Basic
--- PASS: TestAccTeam_DataSource_Basic (103.14s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        110.277s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->