### PR TITLE
Fixed typo mappedpath to mapped_path in azuredevops_wiki

### DIFF
--- a/website/docs/r/wiki.html.markdown
+++ b/website/docs/r/wiki.html.markdown
@@ -37,7 +37,7 @@ resource "azuredevops_wiki" "example2" {
   repository_id = azuredevops_git_repository.example.id
   version       = "main"
   type          = "codeWiki"
-  mappedpath    = "/"
+  mapped_path   = "/"
 }
 ```
 
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `version` - (Optional) Version of the wiki.
 
-* `mappedpath` - (Optional) Folder path inside repository which is shown as Wiki.
+* `mapped_path` - (Optional) Folder path inside repository which is shown as Wiki.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Nothing, just fixed a typo in Documentation.

I noticed that one Example and the relevant Argument Reference in the provider [Documentation](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/wiki) is wrong. The Provider expects `mapped_path` and not `mappedpath`.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

NA

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->