### PR TITLE
`azuredevops_git_repository` - Cleanup code

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -240,7 +240,7 @@ func TestAccGitRepository_forkBranchNotEmpty(t *testing.T) {
 		CheckDestroy: checkGitRepoDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: hclGitRepositoryForkBranchNotEmpty(projectName, gitRepoName, gitForkedRepoName, "Uninitialized"),
+				Config: hclGitRepositoryForkBranchNotEmpty(projectName, gitRepoName, gitForkedRepoName),
 				Check: resource.ComposeTestCheckFunc(
 					checkGitRepoExists(gitRepoName),
 					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
@@ -437,7 +437,7 @@ resource "azuredevops_git_repository" "test" {
 `, projectName, repoName)
 }
 
-func hclGitRepositoryForkBranchNotEmpty(projectName, repoName, forkRepoName, forkInitType string) string {
+func hclGitRepositoryForkBranchNotEmpty(projectName, repoName, forkRepoName string) string {
 	repoInit := hclGitRepositoryBasic(projectName, repoName, "Clean")
 	return fmt.Sprintf(`
 %s
@@ -447,9 +447,9 @@ resource "azuredevops_git_repository" "fork" {
   parent_repository_id = azuredevops_git_repository.test.id
   name                 = "%s"
   initialization {
-    init_type = "%s"
+    init_type = "Fork"
   }
-}`, repoInit, forkRepoName, forkInitType)
+}`, repoInit, forkRepoName)
 }
 
 func hclGitRepositoryImportPrivate(projectName, repoName, importRepoName, serviceEndpointName string) string {

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -116,7 +116,7 @@ resource "azuredevops_git_repository" "example-fork" {
   name                 = "Example Fork Repository"
   parent_repository_id = azuredevops_git_repository.example.id
   initialization {
-    init_type = "Clean"
+    init_type = "Fork"
   }
 }
 ```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_import
=== PAUSE TestAccGitRepository_import
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_uninitialized
=== CONT  TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_initializationClean
=== CONT  TestAccGitRepository_import
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_update
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_DataSource_notExist
--- PASS: TestAccGitRepository_incorrectInitialization (9.16s)
--- PASS: TestAccGitRepository_DataSource_notExist (82.97s)
--- PASS: TestAccGitRepository_DataSource (89.36s)
--- PASS: TestAccGitRepository_uninitialized (95.26s)
--- PASS: TestAccGitRepository_initializationClean (95.28s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (96.57s)
--- PASS: TestAccGitRepository_import (131.34s)
--- PASS: TestAccGitRepository_update (148.84s)
--- PASS: TestAccGitRepository_disabled (148.86s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (169.94s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        176.790s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->