### PR TITLE
[New Resource] - `azuredevops_serviceendpoint_checkmarx_one`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
@@ -1,0 +1,204 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccServiceEndpointCheckMarxOne_apiKey(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+
+	tfSvcEpNode := "azuredevops_serviceendpoint_checkmarx_one.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_checkmarx_one"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceApiKey(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "server_url", "https://server.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceEndpointCheckMarxOne_apiKeyUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+
+	tfSvcEpNode := "azuredevops_serviceendpoint_checkmarx_one.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_checkmarx_one"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceApiKeyUpdate(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "api_key"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "server_url", "https://server.com/update"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceEndpointCheckMarxOne_clientIdSecret(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+
+	tfSvcEpNode := "azuredevops_serviceendpoint_checkmarx_one.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_checkmarx_one"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceClientIdSecret(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "server_url", "https://server.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceEndpointCheckMarxOne_clientIdSecretUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+
+	tfSvcEpNode := "azuredevops_serviceendpoint_checkmarx_one.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_checkmarx_one"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceClientIdSecret(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "server_url", "https://server.com"),
+				),
+			},
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceClientIdSecretUpdate(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "server_url", "https://server.com/update"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "client_id", "clientidupdate"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "authorization_url", "https://authurl.com/update"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "description", "descriptionupdate"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceEndpointCheckMarxOne_requiresImportErrorStep(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+	tfSvcEpNode := "azuredevops_serviceendpoint_checkmarx_one.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_checkmarx_one"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointCheckMarxOneServiceResourceApiKey(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+				),
+			},
+			{
+				Config:      hclSvcEndpointCheckMarxOneServiceResourceRequiresImport(projectName, serviceEndpointName),
+				ExpectError: testutils.RequiresImportError(serviceEndpointName),
+			},
+		},
+	})
+}
+
+func hclSvcEndpointCheckMarxOneServiceResourceApiKey(projectName, serviceEndpointName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%s"
+  server_url            = "https://server.com"
+  api_key               = "apikey"
+}`, projectName, serviceEndpointName)
+}
+
+func hclSvcEndpointCheckMarxOneServiceResourceApiKeyUpdate(projectName, serviceEndpointName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%s"
+  server_url            = "https://server.com/update"
+  api_key               = "apikeyupdate"
+}`, projectName, serviceEndpointName)
+}
+
+func hclSvcEndpointCheckMarxOneServiceResourceClientIdSecret(projectName, serviceEndpointName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%s"
+  server_url            = "https://server.com"
+  client_id             = "clientid"
+  client_secret         = "secret"
+  authorization_url     = "https://authurl.com"
+}`, projectName, serviceEndpointName)
+}
+
+func hclSvcEndpointCheckMarxOneServiceResourceClientIdSecretUpdate(projectName, serviceEndpointName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%s"
+  server_url            = "https://server.com/update"
+  client_id             = "clientidupdate"
+  client_secret         = "secretupdate"
+  authorization_url     = "https://authurl.com/update"
+  description           = "descriptionupdate"
+}`, projectName, serviceEndpointName)
+}
+
+func hclSvcEndpointCheckMarxOneServiceResourceRequiresImport(projectName, serviceEndpointName string) string {
+	template := hclSvcEndpointCheckMarxOneServiceResourceApiKey(projectName, serviceEndpointName)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "import" {
+  project_id            = azuredevops_serviceendpoint_checkmarx_one.test.project_id
+  service_endpoint_name = azuredevops_serviceendpoint_checkmarx_one.test.service_endpoint_name
+  description           = azuredevops_serviceendpoint_checkmarx_one.test.description
+  server_url            = azuredevops_serviceendpoint_checkmarx_one.test.server_url
+  api_key               = azuredevops_serviceendpoint_checkmarx_one.test.api_key
+}
+`, template)
+}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -146,7 +146,6 @@ func expandServiceEndpointCheckMarxOneService(d *schema.ResourceData) (*servicee
 			},
 			Scheme: converter.String("Token"),
 		}
-
 	} else if _, ok := d.GetOk("client_id"); ok {
 		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
 			Parameters: &map[string]string{

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -1,0 +1,182 @@
+package serviceendpoint
+
+import (
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+func ResourceServiceEndpointCheckMarxOneService() *schema.Resource {
+	r := &schema.Resource{
+		Create: resourceServiceEndpointCheckMarxOneServiceCreate,
+		Read:   resourceServiceEndpointCheckMarxOneServiceRead,
+		Update: resourceServiceEndpointCheckMarxOneServiceUpdate,
+		Delete: resourceServiceEndpointCheckMarxOneServiceDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Read:   schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+		Importer: tfhelper.ImportProjectQualifiedResourceUUID(),
+		Schema:   baseSchema(),
+	}
+
+	maps.Copy(r.Schema, map[string]*schema.Schema{
+		"server_url": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+
+		"api_key": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Sensitive:     true,
+			ValidateFunc:  validation.StringIsNotWhiteSpace,
+			ConflictsWith: []string{"client_id", "client_secret", "authorization_url"},
+			AtLeastOneOf:  []string{"client_id", "api_key"},
+		},
+
+		"client_id": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.StringIsNotWhiteSpace,
+			ConflictsWith: []string{"api_key"},
+			RequiredWith:  []string{"client_secret"},
+		},
+
+		"client_secret": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Sensitive:     true,
+			ValidateFunc:  validation.StringIsNotWhiteSpace,
+			ConflictsWith: []string{"api_key"},
+			RequiredWith:  []string{"client_id"},
+		},
+
+		"authorization_url": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.IsURLWithHTTPorHTTPS,
+			ConflictsWith: []string{"api_key"},
+		},
+	})
+	return r
+}
+
+func resourceServiceEndpointCheckMarxOneServiceCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	serviceEndpoint, err := expandServiceEndpointCheckMarxOneService(d)
+	if err != nil {
+		return fmt.Errorf(errMsgTfConfigRead, err)
+	}
+
+	serviceEndPoint, err := createServiceEndpoint(d, clients, serviceEndpoint)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(serviceEndPoint.Id.String())
+	return resourceServiceEndpointCheckMarxOneServiceRead(d, m)
+}
+
+func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	getArgs, err := serviceEndpointGetArgs(d)
+	if err != nil {
+		return err
+	}
+
+	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
+	}
+	flattenServiceEndpointCheckMarxOneService(d, serviceEndpoint)
+	return nil
+}
+
+func resourceServiceEndpointCheckMarxOneServiceUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	serviceEndpoint, err := expandServiceEndpointCheckMarxOneService(d)
+	if err != nil {
+		return fmt.Errorf(errMsgTfConfigRead, err)
+	}
+
+	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
+		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+	}
+	return resourceServiceEndpointCheckMarxOneServiceRead(d, m)
+}
+
+func resourceServiceEndpointCheckMarxOneServiceDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	serviceEndpoint, err := expandServiceEndpointCheckMarxOneService(d)
+	if err != nil {
+		return fmt.Errorf(errMsgTfConfigRead, err)
+	}
+
+	return deleteServiceEndpoint(clients, serviceEndpoint, d.Timeout(schema.TimeoutDelete))
+}
+
+func expandServiceEndpointCheckMarxOneService(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, error) {
+	serviceEndpoint := doBaseExpansion(d)
+
+	if v, ok := d.GetOk("api_key"); ok {
+		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+			Parameters: &map[string]string{
+				"apitoken": v.(string),
+			},
+			Scheme: converter.String("Token"),
+		}
+
+	} else if _, ok := d.GetOk("client_id"); ok {
+		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+			Parameters: &map[string]string{
+				"authURL":  d.Get("authorization_url").(string),
+				"username": d.Get("client_id").(string),
+				"password": d.Get("client_secret").(string),
+			},
+			Scheme: converter.String("UsernamePassword"),
+		}
+	}
+	serviceEndpoint.Type = converter.String("CheckmarxASTService")
+	serviceEndpoint.Url = converter.String(d.Get("server_url").(string))
+	return serviceEndpoint, nil
+}
+
+func flattenServiceEndpointCheckMarxOneService(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint) {
+	doBaseFlattening(d, serviceEndpoint)
+	d.Set("server_url", *serviceEndpoint.Url)
+
+	if serviceEndpoint.Authorization != nil && serviceEndpoint.Authorization.Parameters != nil {
+		if *serviceEndpoint.Authorization.Scheme == "" {
+			// TOKEN will not return
+		} else if *serviceEndpoint.Authorization.Scheme == "UsernamePassword" {
+			if v, ok := (*serviceEndpoint.Authorization.Parameters)["authURL"]; ok {
+				d.Set("authorization_url", v)
+			}
+
+			if v, ok := (*serviceEndpoint.Authorization.Parameters)["username"]; ok {
+				d.Set("client_id", v)
+			}
+		}
+	}
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -93,6 +93,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_azuredevops":                 serviceendpoint.ResourceServiceEndpointAzureDevOps(),
 			"azuredevops_serviceendpoint_azurerm":                     serviceendpoint.ResourceServiceEndpointAzureRM(),
 			"azuredevops_serviceendpoint_bitbucket":                   serviceendpoint.ResourceServiceEndpointBitBucket(),
+			"azuredevops_serviceendpoint_checkmarx_one":               serviceendpoint.ResourceServiceEndpointCheckMarxOneService(),
 			"azuredevops_serviceendpoint_checkmarx_sca":               serviceendpoint.ResourceServiceEndpointCheckMarxSCA(),
 			"azuredevops_serviceendpoint_checkmarx_sast":              serviceendpoint.ResourceServiceEndpointCheckMarxSAST(),
 			"azuredevops_serviceendpoint_dockerregistry":              serviceendpoint.ResourceServiceEndpointDockerRegistry(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -89,6 +89,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_azuredevops",
 		"azuredevops_serviceendpoint_azurerm",
 		"azuredevops_serviceendpoint_bitbucket",
+		"azuredevops_serviceendpoint_checkmarx_one",
 		"azuredevops_serviceendpoint_checkmarx_sca",
 		"azuredevops_serviceendpoint_checkmarx_sast",
 		"azuredevops_serviceendpoint_dockerregistry",

--- a/website/docs/r/serviceendpoint_checkmarx_one.html.markdown
+++ b/website/docs/r/serviceendpoint_checkmarx_one.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_serviceendpoint_checkmarx_one"
+description: |-
+  Manages a Checkmarx One service endpoint within Azure DevOps organization.
+---
+
+# azuredevops_serviceendpoint_checkmarx_one
+
+Manages a Checkmarx One service endpoint within Azure DevOps. Using this service endpoint requires you to install: [Checkmarx AST](https://marketplace.visualstudio.com/items?itemName=checkmarx.checkmarx-ast-azure-plugin)
+
+## Example Usage - API Key
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "example" {
+  project_id            = azuredevops_project.example.id
+  service_endpoint_name = "Example Checkmarx One"
+  server_url            = "https://server.com"
+  api_key               = "apikey"
+}
+```
+
+## Example Usage - Client ID and Secret
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_serviceendpoint_checkmarx_one" "example" {
+  project_id            = azuredevops_project.example.id
+  service_endpoint_name = "Example Checkmarx One"
+  server_url            = "https://server.com"
+  client_id             = "clientid"
+  client_secret         = "secret"
+  authorization_url     = "https://authurl.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project.
+
+* `service_endpoint_name` - (Required) The Service Endpoint name.
+
+* `server_url` - (Required) The Server URL of the Checkmarx One Service.
+
+* `authorization_url` - (Optional) The URL of Checkmarx Authorization. Used when using `client_id` and `client_secret` authorization.
+
+* `api_key` - (Optional) The account of the Checkmarx One. Conflict with `client_id` and `client_secret`.
+
+* `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
+
+* `client_id` - (Optional) The Client ID of the Checkmarx One. Conflict with `api_key`
+
+* `client_secret` - (Optional) The Client Secret of the Checkmarx One. Conflict with `api_key`
+
+~> **Note** At least one of `api_key` and `client_id`, `client_secret` must be set
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the service endpoint.
+* `project_id` - The ID of the project.
+* `service_endpoint_name` - The Service Endpoint name.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Service Endpoints](https://docs.microsoft.com/en-us/rest/api/azure/devops/serviceendpoint/endpoints?view=azure-devops-rest-7.0)
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 2 minutes) Used when creating the Checkmarx One Service.
+* `read` - (Defaults to 1 minute) Used when retrieving the Checkmarx One Service.
+* `update` - (Defaults to 2 minutes) Used when updating the Checkmarx One Service.
+* `delete` - (Defaults to 2 minutes) Used when deleting the Checkmarx One Service.
+
+## Import
+
+Azure DevOps Service Endpoint Check Marx One can be imported using **projectID/serviceEndpointID** or **projectName/serviceEndpointID**
+
+```sh
+terraform import azuredevops_serviceendpoint_checkmarx_one.example 00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/serviceendpoint_checkmarx_sast.html.markdown
+++ b/website/docs/r/serviceendpoint_checkmarx_sast.html.markdown
@@ -64,6 +64,15 @@ The following attributes are exported:
 
 - [Azure DevOps Service REST API 7.0 - Service Endpoints](https://docs.microsoft.com/en-us/rest/api/azure/devops/serviceendpoint/endpoints?view=azure-devops-rest-7.0)
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 2 minutes) Used when creating the Checkmarx SAST.
+* `read` - (Defaults to 1 minute) Used when retrieving the Checkmarx SAST.
+* `update` - (Defaults to 2 minutes) Used when updating the Checkmarx SAST.
+* `delete` - (Defaults to 2 minutes) Used when deleting the Checkmarx SAST.
+
 ## Import
 
 Azure DevOps Service Endpoint Check Marx SAST can be imported using **projectID/serviceEndpointID** or **projectName/serviceEndpointID**

--- a/website/docs/r/serviceendpoint_checkmarx_sca.html.markdown
+++ b/website/docs/r/serviceendpoint_checkmarx_sca.html.markdown
@@ -69,6 +69,15 @@ The following attributes are exported:
 
 - [Azure DevOps Service REST API 7.0 - Service Endpoints](https://docs.microsoft.com/en-us/rest/api/azure/devops/serviceendpoint/endpoints?view=azure-devops-rest-7.0)
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 2 minutes) Used when creating the Checkmarx SCA.
+* `read` - (Defaults to 1 minute) Used when retrieving the Checkmarx SCA.
+* `update` - (Defaults to 2 minutes) Used when updating the Checkmarx SCA.
+* `delete` - (Defaults to 2 minutes) Used when deleting the Checkmarx SCA.
+
 ## Import
 
 Azure DevOps Service Endpoint Check Marx SCA can be imported using **projectID/serviceEndpointID** or **projectName/serviceEndpointID**


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

close: #762 
```log
=== RUN   TestAccServiceEndpointCheckMarxOne_apiKey
=== PAUSE TestAccServiceEndpointCheckMarxOne_apiKey
=== RUN   TestAccServiceEndpointCheckMarxOne_apiKeyUpdate
=== PAUSE TestAccServiceEndpointCheckMarxOne_apiKeyUpdate
=== RUN   TestAccServiceEndpointCheckMarxOne_clientIdSecret
=== PAUSE TestAccServiceEndpointCheckMarxOne_clientIdSecret
=== RUN   TestAccServiceEndpointCheckMarxOne_clientIdSecretUpdate
=== PAUSE TestAccServiceEndpointCheckMarxOne_clientIdSecretUpdate
=== RUN   TestAccServiceEndpointCheckMarxOne_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointCheckMarxOne_requiresImportErrorStep
=== CONT  TestAccServiceEndpointCheckMarxOne_apiKey
=== CONT  TestAccServiceEndpointCheckMarxOne_clientIdSecretUpdate
=== CONT  TestAccServiceEndpointCheckMarxOne_requiresImportErrorStep
=== CONT  TestAccServiceEndpointCheckMarxOne_clientIdSecret
=== CONT  TestAccServiceEndpointCheckMarxOne_apiKeyUpdate
--- PASS: TestAccServiceEndpointCheckMarxOne_apiKeyUpdate (81.77s)
--- PASS: TestAccServiceEndpointCheckMarxOne_requiresImportErrorStep (89.10s)
--- PASS: TestAccServiceEndpointCheckMarxOne_clientIdSecretUpdate (96.34s)
--- PASS: TestAccServiceEndpointCheckMarxOne_clientIdSecret (221.98s)
--- PASS: TestAccServiceEndpointCheckMarxOne_apiKey (222.41s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        230.185s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->