### PR TITLE
[Bug Fix] `azuredevops_git_repository` - Fix branch not found bug

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -20,6 +20,32 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
+func TestAccGitRepository_withDefaultBranch(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+	tfRepoNode := "azuredevops_git_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkGitRepoDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclGitRepositoryWithDefaultBranch(projectName, gitRepoName, "Clean"),
+				Check: resource.ComposeTestCheckFunc(
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttrSet(tfRepoNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfRepoNode, "is_fork"),
+					resource.TestCheckResourceAttrSet(tfRepoNode, "url"),
+					resource.TestCheckResourceAttrSet(tfRepoNode, "web_url"),
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "default_branch", "refs/heads/main"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGitRepository_update(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	gitRepoNameFirst := testutils.GenerateResourceName()
@@ -382,6 +408,23 @@ resource "azuredevops_project" "test" {
 resource "azuredevops_git_repository" "test" {
   project_id = azuredevops_project.test.id
   name       = "%s"
+  initialization {
+    init_type = "%s"
+  }
+}
+`, projectName, repoName, initType)
+}
+
+func hclGitRepositoryWithDefaultBranch(projectName, repoName, initType string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%s"
+  default_branch = "refs/heads/main"
   initialization {
     init_type = "%s"
   }

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -422,8 +422,8 @@ resource "azuredevops_project" "test" {
 }
 
 resource "azuredevops_git_repository" "test" {
-  project_id = azuredevops_project.test.id
-  name       = "%s"
+  project_id     = azuredevops_project.test.id
+  name           = "%s"
   default_branch = "refs/heads/main"
   initialization {
     init_type = "%s"

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -275,6 +275,9 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(createdRepo.Id.String())
 
+	if repo.DefaultBranch != nil && *repo.DefaultBranch != "" {
+		createdRepo.DefaultBranch = repo.DefaultBranch
+	}
 	if err = initializeRepository(clients, initialization, createdRepo, projectID.String()); err != nil {
 		return err
 	}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

close: #1260 
```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_withDefaultBranch
=== PAUSE TestAccGitRepository_withDefaultBranch
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_import
=== PAUSE TestAccGitRepository_import
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_uninitialized
=== CONT  TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_initializationClean
=== CONT  TestAccGitRepository_withDefaultBranch
=== CONT  TestAccGitRepository_import
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_update
--- PASS: TestAccGitRepository_incorrectInitialization (4.94s)
--- PASS: TestAccGitRepository_uninitialized (44.29s)
--- PASS: TestAccGitRepository_DataSource_notExist (49.83s)
--- PASS: TestAccGitRepository_withDefaultBranch (49.92s)
--- PASS: TestAccGitRepository_DataSource (53.43s)
--- PASS: TestAccGitRepository_update (55.37s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (57.05s)
--- PASS: TestAccGitRepository_initializationClean (57.74s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (61.49s)
--- PASS: TestAccGitRepository_disabled (63.05s)
--- PASS: TestAccGitRepository_import (72.45s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        74.342s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->