### PR TITLE
Adding new resource azuredevops_repository_policy_searchable_branches

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_searchable_branches_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_searchable_branches_test.go
@@ -1,0 +1,117 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccRepositoryPolicySearchableBranches(t *testing.T) {
+	testutils.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"RepositoryPolicies": {
+			"basic":  testAccRepositoryPolicySearchableBranchesBasic,
+			"update": testAccRepositoryPolicySearchableBranchesUpdate,
+		},
+	})
+}
+
+func testAccRepositoryPolicySearchableBranchesBasic(t *testing.T) {
+	searchableBranchesTfNode := "azuredevops_repository_searchable_branches.test"
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclRepoPolicySearchableBranchesResourceBasic(projectName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(searchableBranchesTfNode, "searchable_branches.#", "1"),
+				),
+			}, {
+				ResourceName:      searchableBranchesTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(searchableBranchesTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRepositoryPolicySearchableBranchesUpdate(t *testing.T) {
+	searchableBranchesTfNode := "azuredevops_repository_searchable_branches.test"
+	projectName := testutils.GenerateResourceName()
+	repoName := testutils.GenerateResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclRepoPolicySearchableBranchesResourceBasic(projectName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(searchableBranchesTfNode, "searchable_branches.#", "1"),
+				),
+			}, {
+				Config: hclRepoPolicySearchableBranchesResourceUpdate(projectName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(searchableBranchesTfNode, "searchable_branches.#", "2"),
+				),
+			}, {
+				ResourceName:      searchableBranchesTfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(searchableBranchesTfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func hclRepoPolicySearchableBranchesResourceTemplate(projectName string, repoName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%s"
+  description        = "Test Project Description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%s"
+  initialization {
+    init_type = "Clean"
+  }
+}
+`, projectName, repoName)
+}
+
+func hclRepoPolicySearchableBranchesResourceBasic(projectName string, repoName string) string {
+	projectAndRepo := hclRepoPolicySearchableBranchesResourceTemplate(projectName, repoName)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_repository_policy_searchable_branches" "test" {
+  project_id = azuredevops_project.test.id
+
+  searchable_branches     = ["testbranch"]
+  repository_ids          = [azuredevops_git_repository.test.id]
+}`, projectAndRepo)
+}
+
+func hclRepoPolicySearchableBranchesResourceUpdate(projectName string, repoName string) string {
+	projectAndRepo := hclRepoPolicySearchableBranchesResourceTemplate(projectName, repoName)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_repository_policy_searchable_branches" "test" {
+  project_id = azuredevops_project.test.id
+
+  searchable_branches     = ["testbranch2"]
+  repository_ids          = [azuredevops_git_repository.test.id]
+}`, projectAndRepo)
+}

--- a/azuredevops/internal/service/policy/repository/common.go
+++ b/azuredevops/internal/service/policy/repository/common.go
@@ -27,6 +27,7 @@ var (
 	PathLength         = uuid.MustParse("001a79cf-fda1-4c4e-9e7c-bac40ee5ead8")
 	FileSize           = uuid.MustParse("2e26e725-8201-4edd-8bf5-978563c34a80")
 	CheckCredentials   = uuid.MustParse("e67ae10f-cf9a-40bc-8e66-6b3a8216956e")
+	SearchableBranches = uuid.MustParse("0517f88d-4ec5-4343-9d26-9930ebd53069")
 )
 
 // policyCrudArgs arguments for genBasePolicyResource

--- a/azuredevops/internal/service/policy/repository/resource_repositorypolicy_searchable_branches.go
+++ b/azuredevops/internal/service/policy/repository/resource_repositorypolicy_searchable_branches.go
@@ -1,0 +1,81 @@
+package repository
+
+import (
+	"maps"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/policy"
+)
+
+type searchbranchesPolicySettings struct {
+	SearchBranches []string `json:"searchBranches"`
+}
+
+func ResourceRepositorySearchableBranches() *schema.Resource {
+	resource := genBasePolicyResource(&policyCrudArgs{
+		FlattenFunc: searchableBranchesFlattenFunc,
+		ExpandFunc:  searchableBranchesExpandFunc,
+		PolicyType:  SearchableBranches,
+	})
+
+	maps.Copy(resource.Schema, map[string]*schema.Schema{
+		"searchable_branches": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+		"enabled": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"blocking": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		// API only accepts a single repository as scope.
+		"repository_ids": {
+			Type:     schema.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsUUID,
+			},
+		},
+	})
+
+	return resource
+}
+
+func searchableBranchesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfiguration, projectID *string) error {
+	err := baseFlattenFunc(d, policyConfig, projectID)
+	if err != nil {
+		return err
+	}
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+	_ = d.Set("searchable_branches", policySettings["searchBranches"].([]interface{}))
+	return nil
+}
+
+func searchableBranchesExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyConfiguration, *string, error) {
+	policyConfig, projectID, err := baseExpandFunc(d, typeID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policySettings := policyConfig.Settings.(map[string]interface{})
+	policySettings["searchBranches"] = d.Get("searchable_branches")
+
+	// Overriding blocking and enabled as it has no use for this policy setting
+	policySettings["blocking"] = false
+	policySettings["enabled"] = false
+
+	return policyConfig, projectID, nil
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -83,6 +83,7 @@ func Provider() *schema.Provider {
 			"azuredevops_repository_policy_max_file_size":             repository.ResourceRepositoryMaxFileSize(),
 			"azuredevops_repository_policy_max_path_length":           repository.ResourceRepositoryMaxPathLength(),
 			"azuredevops_repository_policy_reserved_names":            repository.ResourceRepositoryReservedNames(),
+			"azuredevops_repository_policy_searchable_branches":       repository.ResourceRepositorySearchableBranches(),
 			"azuredevops_resource_authorization":                      build.ResourceResourceAuthorization(),
 			"azuredevops_securityrole_assignment":                     securityroles.ResourceSecurityRoleAssignment(),
 			"azuredevops_serviceendpoint_argocd":                      serviceendpoint.ResourceServiceEndpointArgoCD(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -79,6 +79,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_repository_policy_max_file_size",
 		"azuredevops_repository_policy_max_path_length",
 		"azuredevops_repository_policy_reserved_names",
+		"azuredevops_repository_policy_searchable_branches",
 		"azuredevops_resource_authorization",
 		"azuredevops_securityrole_assignment",
 		"azuredevops_serviceendpoint_argocd",

--- a/website/docs/r/repository_policy_searchable_branches.html.markdown
+++ b/website/docs/r/repository_policy_searchable_branches.html.markdown
@@ -1,0 +1,64 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_repository_policy_searchable_branches"
+description: |- Manages searchable branches repository policy within Azure DevOps project.
+---
+
+# azuredevops_repository_policy_searchable_branches
+
+Manage searchable branches repository policy within Azure DevOps project.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_git_repository" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Repository"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_repository_policy_searchable_branches" "example" {
+  project_id          = data.azuredevops_project.example.id
+  searchable_branches = ["examplebranch"]
+  repository_ids      = [data.azuredevops_git_repository.example.id]
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project_id` - (Required) The ID of the project in which the policy will be created.
+- `enabled` - (Computed) This is set to false by the provider and is not used.
+- `blocking` - (Computed) This is set to false by the provider and is not used.
+- `searchable_branches` - (Required) A list of branch names to be added as searchable branches for the repository. Branches do not have to exist.
+- `repository_ids` (Required) ID of repository for which the policy is enabled. Note: Due to the API implementation of this policy, this only accepts 1 repository id.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the repository policy.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Policy Configurations](https://docs.microsoft.com/en-us/rest/api/azure/devops/policy/configurations?view=azure-devops-rest-7.0)
+
+## Import
+
+Azure DevOps repository policies can be imported using the projectID/policyID or projectName/policyID:
+
+```sh
+terraform import azuredevops_repository_policy_searchable_branches.example 00000000-0000-0000-0000-000000000000/0
+```


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR adds the resource azuredevops_repository_policy_searchable_branches which have been missing so far.
This will help improve the overall automation capabilities around ADO.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/891

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

@microsoft-github-policy-service agree