### PR TITLE
[Enhancement] `azuredevops_identity_groups` - Add support for `descriptor`

### DIFF
--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -32,7 +32,7 @@ func TestAccIdentityGroupDataSource(t *testing.T) {
 }
 
 func hclIdentityGroupConfig(groupName string, projectName string) string {
-	combinedgroupName := fmt.Sprintf("[%s]\\\\%s", projectName, groupName)
+	combinedGroupName := fmt.Sprintf("[%s]\\\\%s", projectName, groupName)
 	return fmt.Sprintf(`
 resource "azuredevops_project" "project" {
   name               = "%s"
@@ -45,5 +45,5 @@ resource "azuredevops_project" "project" {
 data "azuredevops_identity_group" "test" {
   name       = "%s"
   project_id = azuredevops_project.project.id
-}`, projectName, combinedgroupName)
+}`, projectName, combinedGroupName)
 }

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -24,6 +24,7 @@ func TestAccIdentityGroupsDataSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
 					resource.TestCheckResourceAttrSet(tfNode, "groups.#"),
+					resource.TestCheckResourceAttrSet(tfNode, "groups.0.descriptor"),
 				),
 			},
 		},

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -55,8 +55,7 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Set ID and descriptor for group data resource based on targetGroup output.
-	targetGroupID := targetGroup.Id.String()
-	d.SetId(targetGroupID)
+	d.SetId(targetGroup.Id.String())
 	d.Set("descriptor", targetGroup.Descriptor)
 	return nil
 }

--- a/azuredevops/internal/service/identity/data_identity_group_test.go
+++ b/azuredevops/internal/service/identity/data_identity_group_test.go
@@ -55,7 +55,7 @@ func TestIdentityGroupDataSource_ProjectDescriptorLookupErrorNotFound(t *testing
 		})
 
 	err := dataSourceIdentityGroupRead(resourceData, clients)
-	require.Contains(t, err.Error(), "Error getting groups")
+	require.Contains(t, err.Error(), " Getting groups")
 }
 
 func createIdentityGroupDataSource(t *testing.T, projectID string, groupName string) *schema.ResourceData {

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -39,6 +39,10 @@ func DataIdentityGroups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"descriptor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -53,13 +57,13 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 	// Get groups in specified project id
 	groups, err := getIdentityGroupsWithProjectID(clients, projectID)
 	if err != nil {
-		return fmt.Errorf(" failed to get groups for project with ID %s. Error: %v", projectID, err)
+		return fmt.Errorf(" Failed to get groups for project with ID %s. Error: %v", projectID, err)
 	}
 
 	// With project groups flatten results
 	flattenedGroups, err := flattenIdentityGroups(&groups)
 	if err != nil {
-		return fmt.Errorf("Error flattening groups. Error: %w", err)
+		return fmt.Errorf(" Flattening groups. Error: %w", err)
 	}
 
 	// Set id and group list for groups data resource
@@ -74,7 +78,7 @@ func getIdentityGroupsWithProjectID(clients *client.AggregatedClient, projectID 
 		ScopeIds: &projectID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Error getting groups: %v", err)
+		return nil, fmt.Errorf(" Getting groups: %v", err)
 	}
 	return *response, nil
 }
@@ -91,12 +95,16 @@ func flattenIdentityGroups(groups *[]identity.Identity) ([]interface{}, error) {
 		if group.Id != nil {
 			groupID := *group.Id
 			groupMap["id"] = groupID.String()
-		} else {
-			return nil, fmt.Errorf(" Group Object does not contain an id")
 		}
+
 		if group.ProviderDisplayName != nil {
 			groupMap["name"] = *group.ProviderDisplayName
 		}
+
+		if group.Descriptor != nil {
+			groupMap["descriptor"] = *group.Descriptor
+		}
+
 		results[i] = groupMap
 	}
 	return results, nil

--- a/azuredevops/internal/service/identity/data_identity_groups_test.go
+++ b/azuredevops/internal/service/identity/data_identity_groups_test.go
@@ -55,7 +55,7 @@ func TestIdentityGroupsDataSource_DoesNotSwallowProjectDescriptorLookupError_Not
 		})
 
 	err := dataSourceIdentityGroupsRead(resourceData, clients)
-	require.Contains(t, err.Error(), "Error getting group")
+	require.Contains(t, err.Error(), " Getting group")
 }
 
 func createIdentityGroupsDataSource(t *testing.T, projectID string) *schema.ResourceData {

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -24,15 +24,15 @@ func DataIdentityUser() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
-			"descriptor": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"search_filter": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "General",
 				ValidateFunc: validation.StringInSlice([]string{"AccountName", "DisplayName", "MailAddress", "General"}, false),
+			},
+			"descriptor": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -57,7 +57,7 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	// Filter for the desired user in the FilterUsers results
 	targetUser := validateIdentityUser(flattenUser, userName, searchFilter)
 	if targetUser == nil {
-		return fmt.Errorf(" Could not find user with name: %s with filter: %s", userName, searchFilter)
+		return fmt.Errorf(" Could not find user with name: %s, with filter: %s", userName, searchFilter)
 	}
 
 	// Set id and user list for users data resource

--- a/website/docs/d/identity_groups.html.markdown
+++ b/website/docs/d/identity_groups.html.markdown
@@ -44,7 +44,9 @@ A `groups` block supports the following:
 
 * `id` - The ID of the Identity Group.
 
-* `name` - This is the non-unique display name of the identity subject. To change this field, you must alter its value in the source provider.
+* `descriptor` - The descriptor of the Identity Group.
+
+* `name` - This is the non-unique display name of the identity subject.
 
 ## Relevant Links
 

--- a/website/docs/d/identity_user.html.markdown
+++ b/website/docs/d/identity_user.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `name` - (required) The PrincipalName of this identity member from the source provider.
 
+---
+
 * `search_filter` - (Optional) The type of search to perform. Possible values are: `AccountName`, `DisplayName`, and `MailAddress`. Default is `General`.
 
 ## Attributes Reference


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```log
=== RUN   TestAccIdentityGroupDataSource
=== PAUSE TestAccIdentityGroupDataSource
=== CONT  TestAccIdentityGroupDataSource
--- PASS: TestAccIdentityGroupDataSource (42.94s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        47.154s

=== RUN   TestAccIdentityGroupsDataSource
=== PAUSE TestAccIdentityGroupsDataSource
=== CONT  TestAccIdentityGroupsDataSource
--- PASS: TestAccIdentityGroupsDataSource (40.75s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        41.636s

=== RUN   TestAccIdentityUsersDataSource
=== PAUSE TestAccIdentityUsersDataSource
=== CONT  TestAccIdentityUsersDataSource
--- PASS: TestAccIdentityUsersDataSource (9.20s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        13.030s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->