### PR TITLE
All service connections - Change `authorization` to compute only, not configurable

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -52,10 +52,8 @@ func baseSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringLenBetween(0, 1024),
 		},
 		"authorization": {
-			Type:         schema.TypeMap,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			Type:     schema.TypeMap,
+			Computed: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1291 

<details>
<summary>Acc Logs:</summary>

```log
=== RUN   TestAccServiceEndpointNpm_dataSource
=== PAUSE TestAccServiceEndpointNpm_dataSource
=== RUN   TestAccServiceEndpointNpm_basic
=== PAUSE TestAccServiceEndpointNpm_basic
=== RUN   TestAccServiceEndpointNpm_complete
=== PAUSE TestAccServiceEndpointNpm_complete
=== RUN   TestAccServiceEndpointNpm_update
=== PAUSE TestAccServiceEndpointNpm_update
=== RUN   TestAccServiceEndpointNpm_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointNpm_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointNpm_dataSource
=== CONT  TestAccServiceEndpointNpm_update
=== CONT  TestAccServiceEndpointNpm_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointNpm_complete
=== CONT  TestAccServiceEndpointNpm_basic
--- PASS: TestAccServiceEndpointNpm_basic (65.33s)
--- PASS: TestAccServiceEndpointNpm_dataSource (65.44s)
--- PASS: TestAccServiceEndpointNpm_complete (66.07s)
--- PASS: TestAccServiceEndpointNpm_RequiresImportErrorStep (66.94s)
--- PASS: TestAccServiceEndpointNpm_update (68.58s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        69.006s

=== RUN   TestAccServiceEndpointGeneric_basic
=== PAUSE TestAccServiceEndpointGeneric_basic
=== RUN   TestAccServiceEndpointGeneric_complete
=== PAUSE TestAccServiceEndpointGeneric_complete
=== RUN   TestAccServiceEndpointGeneric_update
=== PAUSE TestAccServiceEndpointGeneric_update
=== RUN   TestAccServiceEndpointGeneric_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointGeneric_requiresImportErrorStep
=== CONT  TestAccServiceEndpointGeneric_basic
=== CONT  TestAccServiceEndpointGeneric_update
=== CONT  TestAccServiceEndpointGeneric_requiresImportErrorStep
=== CONT  TestAccServiceEndpointGeneric_complete
--- PASS: TestAccServiceEndpointGeneric_complete (64.90s)
--- PASS: TestAccServiceEndpointGeneric_basic (65.13s)
--- PASS: TestAccServiceEndpointGeneric_requiresImportErrorStep (66.81s)
--- PASS: TestAccServiceEndpointGeneric_update (75.22s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        76.231s


=== RUN   TestAccServiceEndpointSSH_basic
=== PAUSE TestAccServiceEndpointSSH_basic
=== RUN   TestAccServiceEndpointSSH_complete
=== PAUSE TestAccServiceEndpointSSH_complete
=== RUN   TestAccServiceEndpointSSH_update
=== PAUSE TestAccServiceEndpointSSH_update
=== RUN   TestAccServiceEndpointSSH_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointSSH_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSSH_basic
=== CONT  TestAccServiceEndpointSSH_update
=== CONT  TestAccServiceEndpointSSH_complete
=== CONT  TestAccServiceEndpointSSH_RequiresImportErrorStep
--- PASS: TestAccServiceEndpointSSH_complete (81.62s)
--- PASS: TestAccServiceEndpointSSH_basic (82.87s)
--- PASS: TestAccServiceEndpointSSH_update (87.49s)
--- PASS: TestAccServiceEndpointSSH_RequiresImportErrorStep (87.52s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        88.116s  


=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_basic
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_basic
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_complete_token
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_complete_token
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_update
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_update
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep (73.48s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_basic (77.19s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_complete_token (78.65s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_update (81.26s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword (81.57s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword (82.81s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword (89.46s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword (89.76s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        90.268s    

=== RUN   TestAccServiceEndpointNuGet_ApiKey
=== PAUSE TestAccServiceEndpointNuGet_ApiKey
=== RUN   TestAccServiceEndpointNuGet_PersonalAccessToken
=== PAUSE TestAccServiceEndpointNuGet_PersonalAccessToken
=== RUN   TestAccServiceEndpointNuGet_UnamePwd
=== PAUSE TestAccServiceEndpointNuGet_UnamePwd
=== RUN   TestAccServiceEndpointNuGet_Update
=== PAUSE TestAccServiceEndpointNuGet_Update
=== PAUSE TestAccServiceEndpointNuGet_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointNuGet_ApiKey
=== CONT  TestAccServiceEndpointNuGet_Update
=== CONT  TestAccServiceEndpointNuGet_PersonalAccessToken
=== CONT  TestAccServiceEndpointNuGet_UnamePwd
=== CONT  TestAccServiceEndpointNuGet_RequiresImportErrorStep
--- PASS: TestAccServiceEndpointNuGet_UnamePwd (80.18s)
--- PASS: TestAccServiceEndpointNuGet_ApiKey (82.91s)
--- PASS: TestAccServiceEndpointNuGet_PersonalAccessToken (83.75s)
--- PASS: TestAccServiceEndpointNuGet_RequiresImportErrorStep (84.01s)
--- PASS: TestAccServiceEndpointNuGet_Update (246.42s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        247.010s
```
</details>

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->