### PR TITLE
docs: update serviceendpoint_azurecr attribute reference

### DIFF
--- a/website/docs/r/serviceendpoint_azurecr.html.markdown
+++ b/website/docs/r/serviceendpoint_azurecr.html.markdown
@@ -119,7 +119,9 @@ The following attributes are exported:
 * `id` - The ID of the service endpoint.
 * `project_id` - The ID of the project.
 * `service_endpoint_name` - The Service Endpoint name.
-* `service_principal_id` - The service principal ID.
+* `service_principal_id` - The Application(Client) ID of the Service Principal.
+* `workload_identity_federation_issuer` - The issuer if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. This looks like `https://vstoken.dev.azure.com/00000000-0000-0000-0000-000000000000`, where the GUID is the Organization ID of your Azure DevOps Organisation.
+* `workload_identity_federation_subject` - The subject if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. This looks like `sc://<organisation>/<project>/<service-connection-name>`.
 
 ## Relevant Links
 


### PR DESCRIPTION
This updates the docs for the `serviceendpoint_azurecr` resource.

#1105 introduced WorkloadIdentityFederation to the acr service endpoint, but the attribute definition was not updated in the docs.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] ~I have added tests to cover my changes.~
* [ ] ~All new and existing tests passed.~
* [ ] ~My code follows the code style of this project.~
* [ ] ~I ran lint checks locally prior to submission.~
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

n/a

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->