### PR TITLE
`azuredevops_build_definition` and data source `azuredevops_build_definition` - Add support for other git type pipeline and agent jobs

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_test.go
@@ -100,10 +100,10 @@ func TestAccBuildDefinition_withVariables(t *testing.T) {
 		CheckDestroy: checkBuildDefinitionDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: hclBuildDefinitionVariable("foo1", "bar1", name),
+				Config: hclBuildDefinitionVariable(name, "foo1", "bar1"),
 				Check:  checkForVariableValues(tfNode, "foo1", "bar1"),
 			}, {
-				Config: hclBuildDefinitionVariable("foo2", "bar2", name),
+				Config: hclBuildDefinitionVariable(name, "foo2", "bar2"),
 				Check:  checkForVariableValues(tfNode, "foo2", "bar2"),
 			},
 		},
@@ -151,6 +151,430 @@ func TestAccBuildDefinition_buildCompletionTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "build_completion_trigger.#", "1"),
 					resource.TestCheckResourceAttr(tfNode, "name", name),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentJob_basic(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobBasic(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobMultiConfiguration(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.condition", "succeededOrFailed()"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.demands.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.multipliers", "multipliers1,multipliers2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.max_concurrency", "3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "true"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobMultiAgent(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.condition", "succeededOrFailed()"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.demands.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Agent"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.max_concurrency", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "false"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentJob_update(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobBasic(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobMultiConfiguration(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.condition", "succeededOrFailed()"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.demands.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.multipliers", "multipliers1,multipliers2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.max_concurrency", "3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "true"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobMultiAgent(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agent_job3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.condition", "succeededOrFailed()"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.demands.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Agent"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.max_concurrency", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "false"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentJob_complete(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentJobComplete(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.ref_name", "agent_job2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.dependencies.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.job_timeout_in_minutes", "60"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.job_cancel_timeout_in_minutes", "5"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.0.max_concurrency", "3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.demands.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.dependencies.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.ref_name", "agent_job3"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.condition", "succeededOrFailed()"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.job_timeout_in_minutes", "60"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.job_cancel_timeout_in_minutes", "5"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.type", "AgentJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.demands.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.execution_options.0.type", "Multi-Agent"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.execution_options.0.max_concurrency", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.2.target.0.execution_options.0.continue_on_error", "false"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentlessJobBasic(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agentless_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentlessJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "None"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfBuildDefNode := "azuredevops_build_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentlessJobMultiConfiguration(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agentless_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentlessJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.multipliers", "multiplierstest"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "true"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentlessJobBasic(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agentless_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentlessJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "None"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentlessJobMultiConfiguration(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agentless_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentlessJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.multipliers", "multiplierstest"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.continue_on_error", "true"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
+			},
+		},
+	})
+}
+
+func TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	tfBuildDefNode := "azuredevops_build_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkBuildDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclBuildDefinitionOtherGitRepositoryAgentlessJobComplete(name, `\\`),
+				Check: resource.ComposeTestCheckFunc(
+					checkBuildDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "revision"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "name", name),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "path", `\`),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.#", "2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.ref_name", "agentless_job1"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "jobs.0.target.#"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.type", "AgentlessJob"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.job_timeout_in_minutes", "60"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.job_cancel_timeout_in_minutes", "5"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.0.target.0.execution_options.0.type", "None"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.ref_name", "agentless_job2"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.job_timeout_in_minutes", "60"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.job_cancel_timeout_in_minutes", "5"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.0.type", "Multi-Configuration"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.dependencies.#", "1"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.0.multipliers", "multiplierstest"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "jobs.1.target.0.execution_options.0.continue_on_error", "true"),
+				),
+			}, {
+				ResourceName:            tfBuildDefNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfBuildDefNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_first_run"},
 			},
 		},
 	})
@@ -407,4 +831,477 @@ resource "azuredevops_build_definition" "test" {
   }
 }
 `, template, name)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentJobBasic(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  agent_specification = "windows-latest"
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  jobs {
+    name      = "Agent Job1"
+    ref_name  = "agent_job1"
+    condition = "succeeded()"
+    target {
+      type = "AgentJob"
+      execution_options {
+        type = "None"
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentJobMultiConfiguration(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name      = "Agent Job1"
+    ref_name  = "agent_job1"
+    condition = "succeededOrFailed()"
+    target {
+      type    = "AgentJob"
+      demands = ["git -equals git", "git"]
+      execution_options {
+        type              = "Multi-Configuration"
+        continue_on_error = true
+        multipliers       = "multipliers1,multipliers2"
+        max_concurrency   = 3
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentJobMultiAgent(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name      = "Agent Job3"
+    ref_name  = "agent_job3"
+    condition = "succeededOrFailed()"
+    target {
+      type    = "AgentJob"
+      demands = ["git -equals git", "git"]
+      execution_options {
+        type              = "Multi-Agent"
+        continue_on_error = false
+        max_concurrency   = 2
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentJobComplete(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name      = "Agent Job1"
+    ref_name  = "agent_job1"
+    condition = "succeeded()"
+    target {
+      type = "AgentJob"
+      execution_options {
+        type = "None"
+      }
+    }
+  }
+
+  jobs {
+    name                          = "Agent Job2"
+    ref_name                      = "agent_job2"
+    condition                     = "succeededOrFailed()"
+    job_timeout_in_minutes        = 60
+    job_cancel_timeout_in_minutes = 5
+    dependencies {
+      scope = "agent_job1"
+    }
+    target {
+      type    = "AgentJob"
+      demands = ["git -equals git", "git"]
+      execution_options {
+        type              = "Multi-Configuration"
+        continue_on_error = true
+        multipliers       = "multipliers1,multipliers2"
+        max_concurrency   = 3
+      }
+    }
+  }
+
+  jobs {
+    name      = "Agent Job3"
+    ref_name  = "agent_job3"
+    condition = "succeededOrFailed()"
+    dependencies {
+      scope = "agent_job1"
+    }
+    dependencies {
+      scope = "agent_job2"
+    }
+    job_timeout_in_minutes        = 60
+    job_cancel_timeout_in_minutes = 5
+    target {
+      type    = "AgentJob"
+      demands = ["git -equals git"]
+      execution_options {
+        type              = "Multi-Agent"
+        continue_on_error = false
+        max_concurrency   = 2
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentlessJobBasic(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name      = "Agentless Job1"
+    ref_name  = "agentless_job1"
+    condition = "succeeded()"
+    target {
+      type = "AgentlessJob"
+      execution_options {
+        type = "None"
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentlessJobMultiConfiguration(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name      = "Agentless Job1"
+    ref_name  = "agentless_job1"
+    condition = "succeeded()"
+    target {
+      type = "AgentlessJob"
+      execution_options {
+        type              = "Multi-Configuration"
+        continue_on_error = true
+        multipliers       = "multiplierstest"
+      }
+    }
+  }
+}
+`, template, name, path)
+}
+
+func hclBuildDefinitionOtherGitRepositoryAgentlessJobComplete(name, path string) string {
+	template := hclBuildDefinitionTemplate(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_serviceendpoint_generic_git" "test" {
+  project_id            = azuredevops_project.test.id
+  repository_url        = "https://dev.azure.com/org/project/_git/test"
+  username              = "username"
+  password              = "password"
+  service_endpoint_name = "Generic Git"
+}
+
+resource "azuredevops_build_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "%[3]s"
+
+  ci_trigger {
+    override {
+      batch = true
+      branch_filter {
+        include = ["master"]
+      }
+      path_filter {
+        include = ["*/**.ts"]
+      }
+      max_concurrent_builds_per_branch = 2
+      polling_interval                 = 0
+    }
+  }
+
+  repository {
+    repo_type             = "Git"
+    repo_id               = azuredevops_serviceendpoint_generic_git.test.repository_url
+    branch_name           = "refs/heads/main"
+    url                   = azuredevops_serviceendpoint_generic_git.test.repository_url
+    service_connection_id = azuredevops_serviceendpoint_generic_git.test.id
+  }
+
+  agent_specification = "windows-latest"
+
+  jobs {
+    name                          = "Agentless Job1"
+    ref_name                      = "agentless_job1"
+    condition                     = "succeeded()"
+    job_timeout_in_minutes        = 60
+    job_cancel_timeout_in_minutes = 5
+    target {
+      type = "AgentlessJob"
+      execution_options {
+        type = "None"
+      }
+    }
+  }
+
+  jobs {
+    name                          = "Agentless Job2"
+    ref_name                      = "agentless_job2"
+    condition                     = "succeeded()"
+    job_timeout_in_minutes        = 60
+    job_cancel_timeout_in_minutes = 5
+    dependencies {
+      scope = "agentless_job1"
+    }
+    target {
+      type = "AgentlessJob"
+      execution_options {
+        type              = "Multi-Configuration"
+        continue_on_error = true
+        multipliers       = "multiplierstest"
+      }
+    }
+  }
+}
+`, template, name, path)
 }

--- a/azuredevops/internal/model/model_job.go
+++ b/azuredevops/internal/model/model_job.go
@@ -1,0 +1,73 @@
+package model
+
+type PipelineJobType string
+
+type pipelineJobTypeValuesType struct {
+	AgentJob     PipelineJobType
+	AgentlessJob PipelineJobType
+}
+
+var PipelineJobTypeValues = pipelineJobTypeValuesType{
+	AgentJob:     "AgentJob",
+	AgentlessJob: "AgentlessJob",
+}
+
+var PipelineJobTypeTypeValueMap = map[string]int{
+	string(PipelineJobTypeValues.AgentJob):     1,
+	string(PipelineJobTypeValues.AgentlessJob): 2,
+}
+
+var PipelineJobTypeValueTypeMap = map[int]string{
+	1: string(PipelineJobTypeValues.AgentJob),
+	2: string(PipelineJobTypeValues.AgentlessJob),
+}
+
+type JobExecutionOptionsType string
+
+type JobExecutionOptionsTypeValuesType struct {
+	None               JobExecutionOptionsType
+	MultiConfiguration JobExecutionOptionsType
+	MultiAgent         JobExecutionOptionsType
+}
+
+var JobExecutionOptionsTypeValues = JobExecutionOptionsTypeValuesType{
+	None:               "None",                // 0
+	MultiConfiguration: "Multi-Configuration", // 1
+	MultiAgent:         "Multi-Agent",         // 2
+}
+
+var JobExecutionOptionsTypValueTypeMap = map[int]string{
+	0: string(JobExecutionOptionsTypeValues.None),
+	1: string(JobExecutionOptionsTypeValues.MultiConfiguration),
+	2: string(JobExecutionOptionsTypeValues.MultiAgent),
+}
+
+type JobExecutionOptions struct {
+	Multipliers     *[]string `json:"multipliers,omitempty"`
+	MaxConcurrency  *int      `json:"maxConcurrency,omitempty"`
+	ContinueOnError *bool     `json:"continueOnError,omitempty"`
+	Type            *int      `json:"type,omitempty"`
+}
+
+type JobDependency struct {
+	Scope *string `json:"scope,omitempty"`
+	Event *string `json:"event,omitempty"`
+}
+
+type JobTarget struct {
+	Demands                      *[]string            `json:"demands,omitempty"`
+	ExecutionOptions             *JobExecutionOptions `json:"executionOptions,omitempty"`
+	Type                         *int                 `json:"type,omitempty"`
+	AllowScriptsAuthAccessOption *bool                `json:"allowScriptsAuthAccessOption,omitempty"`
+}
+
+type PipelineJob struct {
+	Name                      *string          `json:"name,omitempty"`
+	RefName                   *string          `json:"refName,omitempty"`
+	Condition                 *string          `json:"condition,omitempty"`
+	Dependencies              *[]JobDependency `json:"dependencies,omitempty"`
+	Target                    *JobTarget       `json:"target,omitempty"`
+	JobTimeoutInMinutes       *int             `json:"jobTimeoutInMinutes,omitempty"`
+	JobCancelTimeoutInMinutes *int             `json:"jobCancelTimeoutInMinutes,omitempty"`
+	JobAuthorizationScope     *string          `json:"JobAuthorizationScope,omitempty"`
+}

--- a/azuredevops/internal/model/repo.go
+++ b/azuredevops/internal/model/repo.go
@@ -8,6 +8,7 @@ type repoTypeValuesType struct {
 	TfsGit           RepoType
 	Bitbucket        RepoType
 	GitHubEnterprise RepoType
+	OtherGit         RepoType
 }
 
 // RepoTypeValues enum of the type of the repository
@@ -16,4 +17,5 @@ var RepoTypeValues = repoTypeValuesType{
 	TfsGit:           "TfsGit",
 	Bitbucket:        "Bitbucket",
 	GitHubEnterprise: "GitHubEnterprise",
+	OtherGit:         "Git",
 }

--- a/azuredevops/internal/service/build/data_build_definition.go
+++ b/azuredevops/internal/service/build/data_build_definition.go
@@ -145,6 +145,10 @@ func DataBuildDefinition() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"report_build_status": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -235,6 +239,104 @@ func DataBuildDefinition() *schema.Resource {
 						},
 						"comment_required": {
 							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"agent_specification": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"job_authorization_scope": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ref_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"condition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dependencies": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scope": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"target": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"execution_options": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"max_concurrency": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"multipliers": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"continue_on_error": {
+													Type:     schema.TypeBool,
+													Computed: true},
+											},
+										},
+									},
+									"demands": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+						"job_timeout_in_minutes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"job_cancel_timeout_in_minutes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"job_authorization_scope": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"allow_scripts_auth_access_option": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 					},

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -715,10 +715,12 @@ func flattenBuildDefinition(d *schema.ResourceData, buildDefinition *build.Build
 		}
 
 		// set agent identifier
-		if target, ok := buildDefinition.Process.(map[string]interface{})["target"]; ok {
-			if spec, ok := target.(map[string]interface{})["agentSpecification"]; ok {
-				if agentIdentifier, ok := spec.(map[string]interface{})["identifier"]; ok {
-					d.Set("agent_specification", agentIdentifier.(string))
+		if processMap, ok := buildDefinition.Process.(map[string]interface{}); ok {
+			if target, ok := processMap["target"]; ok {
+				if spec, ok := target.(map[string]interface{})["agentSpecification"]; ok {
+					if agentIdentifier, ok := spec.(map[string]interface{})["identifier"]; ok {
+						d.Set("agent_specification", agentIdentifier.(string))
+					}
 				}
 			}
 		}

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -157,10 +158,6 @@ func ResourceBuildDefinition() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"yml_path": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
 						"repo_id": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -173,7 +170,12 @@ func ResourceBuildDefinition() *schema.Resource {
 								string(model.RepoTypeValues.TfsGit),
 								string(model.RepoTypeValues.Bitbucket),
 								string(model.RepoTypeValues.GitHubEnterprise),
+								string(model.RepoTypeValues.OtherGit),
 							}, false),
+						},
+						"yml_path": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"branch_name": {
 							Type:     schema.TypeString,
@@ -186,9 +188,16 @@ func ResourceBuildDefinition() *schema.Resource {
 							Default:  "",
 						},
 						"github_enterprise_url": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "",
+							Type:          schema.TypeString,
+							Optional:      true,
+							Default:       "",
+							ConflictsWith: []string{"repository.0.url"},
+						},
+						"url": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ConflictsWith: []string{"repository.0.github_enterprise_url"},
 						},
 						"report_build_status": {
 							Type:     schema.TypeBool,
@@ -317,6 +326,142 @@ func ResourceBuildDefinition() *schema.Resource {
 							ValidateFunc: validation.NoZeroValues,
 						},
 						"branch_filter": branchFilter,
+					},
+				},
+			},
+			"agent_specification": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"job_authorization_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(build.BuildAuthorizationScopeValues.Project),
+					string(build.BuildAuthorizationScopeValues.ProjectCollection),
+				}, false),
+				Default: string(build.BuildAuthorizationScopeValues.ProjectCollection),
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"ref_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"condition": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"dependencies": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scope": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+						"target": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(model.PipelineJobTypeValues.AgentJob),
+											string(model.PipelineJobTypeValues.AgentlessJob),
+										}, false),
+									},
+									"execution_options": {
+										Type:     schema.TypeList,
+										Required: true,
+										MinItems: 1,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"type": {
+													Type:     schema.TypeString,
+													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														string(model.JobExecutionOptionsTypeValues.None),
+														string(model.JobExecutionOptionsTypeValues.MultiConfiguration),
+														string(model.JobExecutionOptionsTypeValues.MultiAgent),
+													}, false),
+												},
+												"max_concurrency": { // needs to be set when executionOptions type is: Multi-Configuration
+													Type:         schema.TypeInt,
+													Optional:     true,
+													Computed:     true,
+													ValidateFunc: validation.IntBetween(1, 99),
+												},
+												"multipliers": { // required when executionOptions type: Multi-Configuration
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+												"continue_on_error": { // required when executionOptions is: 1, or 2
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"demands": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+						"job_timeout_in_minutes": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 1000000000),
+						},
+						"job_cancel_timeout_in_minutes": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 60),
+						},
+						"job_authorization_scope": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(build.BuildAuthorizationScopeValues.Project),
+								string(build.BuildAuthorizationScopeValues.ProjectCollection),
+							}, false),
+							Default: string(build.BuildAuthorizationScopeValues.ProjectCollection),
+						},
+						"allow_scripts_auth_access_option": { // available when job type is AgentJob(1)
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -558,14 +703,113 @@ func flattenBuildDefinition(d *schema.ResourceData, buildDefinition *build.Build
 		}
 	}
 
+	if buildDefinition.Process != nil {
+		pipeJobs, err := flattenBuildDefinitionJobs(buildDefinition.Process)
+		if err != nil {
+			return fmt.Errorf(" Flattening pipeline jobs: %+v", err)
+		}
+
+		err = d.Set("jobs", pipeJobs)
+		if err != nil {
+			return fmt.Errorf(" Setting build definition jobs: %+v", err)
+		}
+
+		// set agent identifier
+		if target, ok := buildDefinition.Process.(map[string]interface{})["target"]; ok {
+			if spec, ok := target.(map[string]interface{})["agentSpecification"]; ok {
+				if agentIdentifier, ok := spec.(map[string]interface{})["identifier"]; ok {
+					d.Set("agent_specification", agentIdentifier.(string))
+				}
+			}
+		}
+	}
+
 	revision := 0
 	if buildDefinition.Revision != nil {
 		revision = *buildDefinition.Revision
 	}
 
+	d.Set("job_authorization_scope", buildDefinition.JobAuthorizationScope)
+
 	d.Set("revision", revision)
 	d.Set("queue_status", *buildDefinition.QueueStatus)
 	return nil
+}
+
+func flattenBuildDefinitionJobs(input interface{}) ([]interface{}, error) {
+	if input == nil {
+		return []interface{}{}, nil
+	}
+
+	result := make([]interface{}, 0)
+	if v, ok := input.(map[string]interface{}); ok {
+		if phases, ok := v["phases"]; ok {
+			var jobs []model.PipelineJob
+
+			v, err := json.Marshal(phases)
+			if err != nil {
+				return nil, fmt.Errorf(" Get pipeline jobs byte array: %+v", err)
+			}
+
+			err = json.Unmarshal(v, &jobs)
+			if err != nil {
+				return nil, fmt.Errorf(" Convert Pipelins Jobs to PipelineJob: %+v", err)
+			}
+
+			for _, job := range jobs {
+				var dependencyMap []map[string]interface{}
+				if job.Dependencies != nil {
+					for _, dependency := range *job.Dependencies {
+						dependencyMap = append(dependencyMap, map[string]interface{}{
+							"scope": dependency.Scope,
+						})
+					}
+				}
+
+				var targetMap map[string]interface{}
+				if job.Target != nil {
+					targetMap = map[string]interface{}{
+						"demands": job.Target.Demands,
+						"type":    model.PipelineJobTypeValueTypeMap[*job.Target.Type],
+						"execution_options": []interface{}{
+							map[string]interface{}{
+								"type": model.JobExecutionOptionsTypeValues.None,
+							},
+						},
+					}
+
+					if job.Target.ExecutionOptions != nil {
+						execOptionsMap := map[string]interface{}{
+							"continue_on_error": job.Target.ExecutionOptions.ContinueOnError,
+							"type":              model.JobExecutionOptionsTypValueTypeMap[*job.Target.ExecutionOptions.Type],
+							"max_concurrency":   job.Target.ExecutionOptions.MaxConcurrency,
+						}
+						if job.Target.ExecutionOptions.Multipliers != nil && len(*job.Target.ExecutionOptions.Multipliers) > 0 {
+							execOptionsMap["multipliers"] = (*job.Target.ExecutionOptions.Multipliers)[0]
+						}
+
+						targetMap["execution_options"] = []interface{}{execOptionsMap}
+					}
+				}
+
+				jobConfig := map[string]interface{}{
+					"name":                             job.Name,
+					"ref_name":                         job.RefName,
+					"condition":                        job.Condition,
+					"allow_scripts_auth_access_option": job.Target.AllowScriptsAuthAccessOption,
+					"job_timeout_in_minutes":           job.JobTimeoutInMinutes,
+					"job_cancel_timeout_in_minutes":    job.JobCancelTimeoutInMinutes,
+					"job_authorization_scope":          job.JobAuthorizationScope,
+					"dependencies":                     dependencyMap,
+					"target":                           []interface{}{targetMap},
+				}
+
+				result = append(result, jobConfig)
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func flattenBuildVariables(d *schema.ResourceData, buildDefinition *build.BuildDefinition) interface{} {
@@ -621,7 +865,9 @@ func flattenRepository(buildDefinition *build.BuildDefinition) (interface{}, err
 	// available from the compiler is `interface{}` so we can probe for known
 	// implementations
 	if processMap, ok := buildDefinition.Process.(map[string]interface{}); ok {
-		yamlFilePath = processMap["yamlFilename"].(string)
+		if v, exist := processMap["yamlFilename"].(string); exist {
+			yamlFilePath = v
+		}
 	}
 	if yamlProcess, ok := buildDefinition.Process.(*build.YamlProcess); ok {
 		yamlFilePath = *yamlProcess.YamlFilename
@@ -642,6 +888,7 @@ func flattenRepository(buildDefinition *build.BuildDefinition) (interface{}, err
 		"repo_type":             *buildDefinition.Repository.Type,
 		"branch_name":           *buildDefinition.Repository.DefaultBranch,
 		"github_enterprise_url": githubEnterpriseUrl,
+		"url":                   *buildDefinition.Repository.Url,
 	}}
 
 	if buildDefinition.Repository != nil && buildDefinition.Repository.Properties != nil {
@@ -1056,6 +1303,125 @@ func expandVariables(d *schema.ResourceData) (*map[string]build.BuildDefinitionV
 	return &expandedVars, nil
 }
 
+func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error) {
+	if len(input) == 0 {
+		return &[]model.PipelineJob{}, nil
+	}
+
+	var result []model.PipelineJob
+	for _, jobConfig := range input {
+		jobMap := jobConfig.(map[string]interface{})
+		job := model.PipelineJob{
+			Name:                      converter.String(jobMap["name"].(string)),
+			RefName:                   converter.String(jobMap["ref_name"].(string)),
+			Condition:                 converter.String(jobMap["condition"].(string)),
+			JobTimeoutInMinutes:       converter.Int(jobMap["job_timeout_in_minutes"].(int)),
+			JobCancelTimeoutInMinutes: converter.Int(jobMap["job_cancel_timeout_in_minutes"].(int)),
+			JobAuthorizationScope:     converter.String(jobMap["job_authorization_scope"].(string)),
+		}
+
+		// dependencies
+		if depConfig := jobMap["dependencies"].([]interface{}); len(depConfig) > 0 {
+			var dependencies []model.JobDependency
+			for _, dep := range depConfig {
+				depMap := dep.(map[string]interface{})
+				dependencies = append(dependencies, model.JobDependency{
+					Scope: converter.String(depMap["scope"].(string)),
+					Event: converter.String("Completed"),
+				})
+			}
+			job.Dependencies = &dependencies
+		}
+
+		// job target
+		targetConfig := jobMap["target"].([]interface{})[0]
+		targetMap := targetConfig.(map[string]interface{})
+		executionOptionsMap := targetMap["execution_options"].([]interface{})[0].(map[string]interface{})
+
+		// set task type (AgentJob or AgentlessJob) and additional options(Allow scripts to access the OAuth token)
+		jobType := model.PipelineJobTypeTypeValueMap[targetMap["type"].(string)]
+
+		// execution options
+		executionType := model.JobExecutionOptionsType(executionOptionsMap["type"].(string))
+		var executeOptions model.JobExecutionOptions
+
+		switch executionType {
+		case model.JobExecutionOptionsTypeValues.None:
+			executeOptions = model.JobExecutionOptions{
+				Type: converter.ToPtr(0),
+			}
+		case model.JobExecutionOptionsTypeValues.MultiConfiguration:
+			executeOptions = model.JobExecutionOptions{
+				Type:            converter.ToPtr(1),
+				ContinueOnError: converter.ToPtr(executionOptionsMap["continue_on_error"].(bool)),
+				Multipliers:     &[]string{executionOptionsMap["multipliers"].(string)},
+			}
+
+			if jobType == 1 { // Agent Job
+				if v, ok := executionOptionsMap["max_concurrency"]; !ok || v.(int) == 0 {
+					return nil, fmt.Errorf(" `max_concurrency` must be set when job is `AgentJob`")
+				}
+				executeOptions.MaxConcurrency = converter.ToPtr(executionOptionsMap["max_concurrency"].(int))
+			}
+
+			// TODO
+			//if jobType == 2 { // Agentless Job
+			//	if v, ok := executionOptionsMap["max_concurrency"]; ok && v.(int) > 0 {
+			//		return nil, fmt.Errorf(" `max_concurrency` must not be set when job is `AgentlessJob`")
+			//	}
+			//}
+
+			// AgentlessJob(2)
+			if jobType == 2 {
+				executeOptions.MaxConcurrency = converter.ToPtr(50) // hard coded
+			}
+		case model.JobExecutionOptionsTypeValues.MultiAgent: // multi-agent, only available when job type is AgentJob
+			if jobType == 2 {
+				return nil, fmt.Errorf(" `Multi-Agent` is not supported when job Type is `AgentlessJob`")
+			}
+			executeOptions = model.JobExecutionOptions{
+				Type:            converter.ToPtr(2),
+				ContinueOnError: converter.ToPtr(executionOptionsMap["continue_on_error"].(bool)),
+			}
+
+			if v, ok := executionOptionsMap["multipliers"]; ok {
+				if len(v.(string)) > 0 {
+					return nil, fmt.Errorf(" `multipliers` must not be set when Execution Options Type is `Multi-Agent`")
+				}
+			}
+			if jobType == 1 {
+				if v, ok := executionOptionsMap["max_concurrency"]; !ok || v.(int) == 0 {
+					return nil, fmt.Errorf(" `max_concurrency` must be set when job is `AgentJob`")
+				}
+				executeOptions.MaxConcurrency = converter.ToPtr(executionOptionsMap["max_concurrency"].(int))
+			}
+		}
+
+		target := model.JobTarget{
+			Type:             converter.ToPtr(jobType),
+			ExecutionOptions: &executeOptions,
+		}
+
+		// configurations only available when job type is AgentJob(1)
+		if *target.Type == 1 {
+			target.AllowScriptsAuthAccessOption = converter.ToPtr(jobMap["allow_scripts_auth_access_option"].(bool))
+			demands := targetMap["demands"].([]interface{})
+			if len(demands) > 0 {
+				target.Demands = converter.ToPtr(tfhelper.ExpandStringList(demands))
+			}
+		} else {
+			demands := targetMap["demands"].([]interface{})
+			if len(demands) > 0 {
+				return nil, fmt.Errorf(" `demands` must not be set when Job Type is `AgentlessJob`")
+			}
+		}
+		job.Target = &target
+
+		result = append(result, job)
+	}
+	return &result, nil
+}
+
 func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.BuildDefinition, string, error) {
 	projectID := d.Get("project_id").(string)
 	repositories := d.Get("repository").([]interface{})
@@ -1068,22 +1434,33 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 	repository := repositories[0].(map[string]interface{})
 
 	repoID := repository["repo_id"].(string)
-	repoType := model.RepoType(repository["repo_type"].(string))
+	repoType := repository["repo_type"].(string)
 	repoURL := ""
 	repoAPIURL := ""
 
-	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.GitHub)) {
+	switch repoType {
+	case string(model.RepoTypeValues.GitHub):
 		repoURL = fmt.Sprintf("https://github.com/%s.git", repoID)
 		repoAPIURL = fmt.Sprintf("https://api.github.com/repos/%s", repoID)
-	}
-	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.Bitbucket)) {
+	case string(model.RepoTypeValues.Bitbucket):
 		repoURL = fmt.Sprintf("https://bitbucket.org/%s.git", repoID)
 		repoAPIURL = fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s", repoID)
-	}
-	if strings.EqualFold(string(repoType), string(model.RepoTypeValues.GitHubEnterprise)) {
+	case string(model.RepoTypeValues.GitHubEnterprise):
 		githubEnterpriseURL := repository["github_enterprise_url"].(string)
 		repoURL = fmt.Sprintf("%s/%s.git", githubEnterpriseURL, repoID)
 		repoAPIURL = fmt.Sprintf("%s/api/v3/repos/%s", githubEnterpriseURL, repoID)
+	case string(model.RepoTypeValues.OtherGit):
+		repoURL = repository["url"].(string)
+	}
+
+	if strings.EqualFold(repoType, string(model.RepoTypeValues.OtherGit)) {
+		if _, ok := repository["service_connection_id"]; !ok {
+			return nil, "", fmt.Errorf(" `repository.service_connection_id` must be set when `repoType` is `Git`")
+		}
+
+		if _, ok := repository["url"]; !ok {
+			return nil, "", fmt.Errorf(" `repository.service_connection_id` must be set when `repoType` is `Git`")
+		}
 	}
 
 	ciTriggers, err := expandBuildDefinitionTriggerList(
@@ -1148,7 +1525,7 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 
 	variables, err := expandVariables(d)
 	if err != nil {
-		return nil, "", fmt.Errorf("Error expanding varibles: %+v", err)
+		return nil, "", fmt.Errorf(" Expanding varibles: %+v", err)
 	}
 
 	queueStatus := build.DefinitionQueueStatus(d.Get("queue_status").(string))
@@ -1163,7 +1540,7 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 			Id:            &repoID,
 			Name:          &repoID,
 			DefaultBranch: converter.String(repository["branch_name"].(string)),
-			Type:          converter.String(string(repoType)),
+			Type:          converter.String(repoType),
 			Properties: &map[string]string{
 				"connectedServiceId": repository["service_connection_id"].(string),
 				"apiUrl":             repoAPIURL,
@@ -1186,6 +1563,33 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 			Name: converter.StringFromInterface(agentPoolName),
 			Pool: &build.TaskAgentPoolReference{
 				Name: converter.StringFromInterface(agentPoolName),
+			},
+		}
+	}
+
+	// other git need clone the repository information
+	if repoType == string(model.RepoTypeValues.OtherGit) {
+		(*buildDefinition.Repository.Properties)["fullName"] = "repository"
+		(*buildDefinition.Repository.Properties)["cloneUrl"] = repoURL
+		buildDefinition.Repository.Clean = converter.String("true")
+
+		jobs, err := expandBuildDefinitionJobs(d.Get("jobs").([]interface{}))
+		if err != nil {
+			return nil, "", fmt.Errorf(" Expanding jobs: %+v", err)
+		}
+
+		agentSpecification := d.Get("agent_specification").(string)
+		if len(agentSpecification) <= 0 {
+			return nil, "", fmt.Errorf(" Expanding jobs: `agent_specification` must be set when `repo_type` is `Git`")
+		}
+
+		buildDefinition.Process = map[string]interface{}{
+			"type":   1,
+			"phases": jobs,
+			"target": map[string]interface{}{
+				"agentSpecification": map[string]interface{}{
+					"identifier": d.Get("agent_specification"),
+				},
 			},
 		}
 	}

--- a/website/docs/d/build_definition.html.markdown
+++ b/website/docs/d/build_definition.html.markdown
@@ -62,6 +62,63 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `queue_status` - The queue status of the build definition.
 
+* `agent_specification`- The Agent Specification to run the pipelines. Example: `windows-2019`, `windows-latest`, `macos-13` etc.
+
+* `job_authorization_scope`- The job authorization scope for builds queued against this definition.
+
+* `jobs`- A `jobs` blocks as documented below.
+
+---
+
+`jobs` block supports the following:
+
+* `name` - The name of the job.
+
+* `ref_name` - The reference name of the job, can be used to define the job dependencies.
+
+* `condition` - Specifies when this job should run. Can **Custom conditions** to specify more complex conditions. More details: [Pipeline conditions](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops)
+
+* `target`- A `target` blocks as documented below.
+
+* `job_timeout_in_minutes` - The job execution timeout (in minutes) for builds queued against this definition.
+
+* `job_cancel_timeout_in_minutes` - The job cancel timeout (in minutes) for builds cancelled by user for this definition.
+
+* `job_authorization_scope`- The job authorization scope for builds queued against this definition.
+
+* `allow_scripts_auth_access_option`- Enables scripts and other processes launched by tasks to access the OAuth token through the `System.AccessToken` variable.
+
+* `dependencies`- A `dependencies` blocks as documented below. Define the job dependencies.
+
+---
+
+`dependencies` block supports the following:
+
+* `scope` The job reference name that depends on. Reference to `jobs.ref_name`
+
+---
+
+`target` block supports the following:
+
+* `type`  The job type.
+
+* `execution_options`- A `execution_options` blocks as documented below.
+
+* `demands` - A list of demands that represents the agent capabilities required by this build. Example: `git`
+
+---
+
+`execution_options` block supports the following:
+
+* `type`- The execution type of the Job.
+
+* `multipliers` -  A list of comma separated configuration variables to use. These are defined on the Variables tab. For example, OperatingSystem, Browser will run the tasks for both variables.
+
+* `max_concurrency` - Limit the number of agents to be used. If job type is `AgentlessJob`, the concurrency is not configurable and is fixed to 50.
+
+* `continue_on_error` - Whether to continue the job when an error occurs.
+
+
 ---
 
 A `branch_filter` block exports the following:


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 
Issue Number: #535 
Add  support other git repository support and agent jobs
<summary>
Acc Tests
<details>

```log
=== RUN   TestAccBuildDefinition_DataSource
=== PAUSE TestAccBuildDefinition_DataSource
=== RUN   TestAccBuildDefinition_with_path_DataSource
=== PAUSE TestAccBuildDefinition_with_path_DataSource
=== RUN   TestAccBuildDefinition_basic
=== PAUSE TestAccBuildDefinition_basic
=== RUN   TestAccBuildDefinition_pathUpdate
=== PAUSE TestAccBuildDefinition_pathUpdate
=== RUN   TestAccBuildDefinition_withVariables
=== PAUSE TestAccBuildDefinition_withVariables
=== RUN   TestAccBuildDefinition_schedules
=== PAUSE TestAccBuildDefinition_schedules
=== RUN   TestAccBuildDefinition_buildCompletionTrigger
=== PAUSE TestAccBuildDefinition_buildCompletionTrigger
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== CONT  TestAccBuildDefinition_DataSource
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== CONT  TestAccBuildDefinition_withVariables
=== CONT  TestAccBuildDefinition_buildCompletionTrigger
=== CONT  TestAccBuildDefinition_schedules
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
=== CONT  TestAccBuildDefinition_basic
=== CONT  TestAccBuildDefinition_pathUpdate
=== CONT  TestAccBuildDefinition_with_path_DataSource
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
--- PASS: TestAccBuildDefinition_buildCompletionTrigger (46.70s)
--- PASS: TestAccBuildDefinition_schedules (53.97s)
--- PASS: TestAccBuildDefinition_pathUpdate (57.67s)
--- PASS: TestAccBuildDefinition_with_path_DataSource (60.30s)
--- PASS: TestAccBuildDefinition_basic (62.99s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration (64.60s)
--- PASS: TestAccBuildDefinition_DataSource (65.48s)
--- PASS: TestAccBuildDefinition_withVariables (70.75s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_complete (72.38s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete (72.59s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration (72.60s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic (95.73s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent (95.85s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update (95.99s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_basic (95.99s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_update (116.77s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        116.957s

```

</details>
</summary>

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->