### PR TITLE
[Bug Fix] - `azuredevops_project` - Fix project ID was not set correctly when importing via name

### DIFF
--- a/azuredevops/internal/acceptancetests/data_project_test.go
+++ b/azuredevops/internal/acceptancetests/data_project_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-func TestAccProject_DataSource_withID(t *testing.T) {
+func TestAccProject_dataSource_withID(t *testing.T) {
 	name := testutils.GenerateResourceName()
 	tfNode := "data.azuredevops_project.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccProject_DataSource_withID(t *testing.T) {
 	})
 }
 
-func TestAccProject_DataSource_withName(t *testing.T) {
+func TestAccProject_dataSource_withName(t *testing.T) {
 	name := testutils.GenerateResourceName()
 	tfNode := "data.azuredevops_project.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -86,16 +86,4 @@ data "azuredevops_project" "test" {
   name = azuredevops_project.test.name
 }
 `, name)
-}
-
-func errorWithNameAndIdSet() string {
-	return `data "azuredevops_project" "project" {}`
-}
-
-func errorWhenDescriptionSet(projectName string) string {
-	return fmt.Sprintf(`
-data "azuredevops_project" "project" {
-  name        = "%s"
-  description = "A project description"
-}`, projectName)
 }

--- a/azuredevops/internal/acceptancetests/resource_project_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_test.go
@@ -5,25 +5,22 @@
 package acceptancetests
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/core"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
-// Verifies that the following sequence of events occurs without error:
-//
-//	(1) TF apply creates project
-//	(2) TF state values are set
-//	(3) project can be queried by ID and has expected name
-//	(4) TF apply update project with changing name
-//	(5) project can be queried by ID and has expected name
-//	(6) TF destroy deletes project
-//	(7) project can no longer be queried by ID
-func TestAccProject_CreateAndUpdate(t *testing.T) {
-	projectNameFirst := testutils.GenerateResourceName()
-	projectNameSecond := testutils.GenerateResourceName()
-	tfNode := "azuredevops_project.project"
+func TestAccProject_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_project.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testutils.PreCheck(t, nil) },
@@ -31,40 +28,110 @@ func TestAccProject_CreateAndUpdate(t *testing.T) {
 		CheckDestroy:      testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.HclProjectResource(projectNameFirst),
+				Config: hclProjectBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					checkProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
+					resource.TestCheckResourceAttr(tfNode, "name", projectName),
+					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
+					resource.TestCheckResourceAttr(tfNode, "visibility", "private"),
+					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  checkImportProject(),
+			},
+		},
+	})
+}
+
+func TestAccProject_importByName(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclProjectBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					checkProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
+					resource.TestCheckResourceAttr(tfNode, "name", projectName),
+					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
+					resource.TestCheckResourceAttr(tfNode, "visibility", "private"),
+					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return projectName, nil
+				},
+				ImportStateCheck: checkImportProject(),
+			},
+		},
+	})
+}
+
+func TestAccProject_update(t *testing.T) {
+	projectNameFirst := testutils.GenerateResourceName()
+	projectNameSecond := testutils.GenerateResourceName()
+	tfNode := "azuredevops_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclProjectBasic(projectNameFirst),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
 					resource.TestCheckResourceAttr(tfNode, "name", projectNameFirst),
 					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
 					resource.TestCheckResourceAttr(tfNode, "visibility", "private"),
 					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
-					testutils.CheckProjectExists(projectNameFirst),
+					checkProjectExists(projectNameFirst),
 				),
 			},
 			{
-				Config: testutils.HclProjectResource(projectNameSecond),
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  checkImportProject(),
+			},
+			{
+				Config: hclProjectUpdate(projectNameSecond),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
 					resource.TestCheckResourceAttr(tfNode, "name", projectNameSecond),
 					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
-					resource.TestCheckResourceAttr(tfNode, "visibility", "private"),
+					resource.TestCheckResourceAttr(tfNode, "visibility", "public"),
 					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
-					testutils.CheckProjectExists(projectNameSecond),
+					checkProjectExists(projectNameSecond),
 				),
 			},
 			{
-				// Resource Acceptance Testing https://www.terraform.io/docs/extend/resources/import.html#resource-acceptance-testing-implementation
 				ResourceName:      tfNode,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  checkImportProject(),
 			},
 		},
 	})
 }
 
-func TestAccProject_CreateAndUpdateWithFeatures(t *testing.T) {
+func TestAccProject_features(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
-	tfNode := "azuredevops_project.project"
+	tfNode := "azuredevops_project.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testutils.PreCheck(t, nil) },
@@ -72,8 +139,9 @@ func TestAccProject_CreateAndUpdateWithFeatures(t *testing.T) {
 		CheckDestroy:      testutils.CheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.HclProjectResourceWithFeature(projectName, "disabled", "disabled"),
+				Config: hclProjectFeature(projectName, "disabled", "disabled"),
 				Check: resource.ComposeTestCheckFunc(
+					checkProjectExists(projectName),
 					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
 					resource.TestCheckResourceAttr(tfNode, "name", projectName),
 					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
@@ -81,12 +149,19 @@ func TestAccProject_CreateAndUpdateWithFeatures(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
 					resource.TestCheckResourceAttr(tfNode, "features.testplans", "disabled"),
 					resource.TestCheckResourceAttr(tfNode, "features.artifacts", "disabled"),
-					testutils.CheckProjectExists(projectName),
 				),
 			},
 			{
-				Config: testutils.HclProjectResourceWithFeature(projectName, "enabled", "disabled"),
+				ResourceName:            tfNode,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"features.testplans", "features.artifacts", "features.%"},
+				ImportStateCheck:        checkImportProject(),
+			},
+			{
+				Config: hclProjectFeature(projectName, "enabled", "disabled"),
 				Check: resource.ComposeTestCheckFunc(
+					checkProjectExists(projectName),
 					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
 					resource.TestCheckResourceAttr(tfNode, "name", projectName),
 					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
@@ -94,9 +169,136 @@ func TestAccProject_CreateAndUpdateWithFeatures(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
 					resource.TestCheckResourceAttr(tfNode, "features.testplans", "enabled"),
 					resource.TestCheckResourceAttr(tfNode, "features.artifacts", "disabled"),
-					testutils.CheckProjectExists(projectName),
 				),
+			},
+			{
+				ResourceName:            tfNode,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"features.testplans", "features.artifacts", "features.%"},
+				ImportStateCheck:        checkImportProject(),
 			},
 		},
 	})
+}
+
+func TestAccProject_requireImportError(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclProjectBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					checkProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "process_template_id"),
+					resource.TestCheckResourceAttr(tfNode, "name", projectName),
+					resource.TestCheckResourceAttr(tfNode, "version_control", "Git"),
+					resource.TestCheckResourceAttr(tfNode, "visibility", "private"),
+					resource.TestCheckResourceAttr(tfNode, "work_item_template", "Agile"),
+				),
+			},
+			{
+				Config:      hclProjectImport(projectName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Error:  creating project: TF200019: The following project already exists on the Azure DevOps Server: %s. You cannot create a new project with the same name as an existing project. Provide a different name`, projectName)),
+			},
+		},
+	})
+}
+
+func checkProjectExists(expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		state, ok := s.RootModule().Resources["azuredevops_project.test"]
+		if !ok {
+			return fmt.Errorf(" Did not find a project in the TF state")
+		}
+
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+		id := state.Primary.ID
+		project, err := clients.CoreClient.GetProject(clients.Ctx, core.GetProjectArgs{
+			ProjectId:           &id,
+			IncludeCapabilities: converter.Bool(true),
+			IncludeHistory:      converter.Bool(false),
+		})
+
+		if err != nil {
+			return fmt.Errorf(" Project with ID=%s cannot be found!. Error=%v", id, err)
+		}
+
+		if *project.Name != expectedName {
+			return fmt.Errorf(" Project with ID=%s has Name=%s, but expected Name=%s", id, *project.Name, expectedName)
+		}
+
+		return nil
+	}
+}
+
+func checkImportProject() resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		if len(states) != 1 {
+			return fmt.Errorf(" Expected project imported but not found in the state.")
+		}
+		state := states[0]
+		projectId := state.ID
+		if err := uuid.Validate(projectId); err != nil {
+			return fmt.Errorf(" Project ID should be a valid UUID. Got: %s", projectId)
+		}
+		return nil
+	}
+}
+
+func hclProjectBasic(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "%[1]s-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}`, name)
+}
+
+func hclProjectUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "%[1]s-description-update"
+  visibility         = "public"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}`, name)
+}
+
+func hclProjectFeature(projectName, testPlans, stateArtifacts string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%s"
+  description        = "%s-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+
+  features = {
+    "testplans" = "%s"
+    "artifacts" = "%s"
+  }
+}`, projectName, projectName, testPlans, stateArtifacts)
+}
+
+func hclProjectImport(name string) string {
+	template := hclProjectBasic(name)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_project" "import" {
+  name               = azuredevops_project.test.name
+  description        = azuredevops_project.test.description
+  visibility         = azuredevops_project.test.visibility
+  version_control    = azuredevops_project.test.version_control
+  work_item_template = azuredevops_project.test.work_item_template
+}`, template)
 }

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -79,47 +79,6 @@ resource "azuredevops_service_principal_entitlement" "test" {
 }`, servicePrincipalObjectId)
 }
 
-// HclProjectResourceWithFeature HCL describing an AzDO project including internal feature setup
-func HclProjectResourceWithFeature(projectName string, featureStateTestplans string, featureStateArtifacts string) string {
-	if projectName == "" {
-		panic("Parameter: projectName cannot be empty")
-	}
-	if featureStateTestplans == "" {
-		panic("Parameter: featureStateTestplans cannot be empty")
-	}
-	if featureStateArtifacts == "" {
-		panic("Parameter: featureStateArtifacts cannot be empty")
-	}
-	return fmt.Sprintf(`
-resource "azuredevops_project" "project" {
-	name       = "%s"
-	description        = "%s-description"
-	visibility         = "private"
-	version_control    = "Git"
-	work_item_template = "Agile"
-
-	features = {
-		"testplans" = "%s"
-		"artifacts" = "%s"
-	}
-}`, projectName, projectName, featureStateTestplans, featureStateArtifacts)
-}
-
-func HclProjectGitRepositoryImport(gitRepoName string, projectName string) string {
-	azureGitRepoResource := fmt.Sprintf(`
-	resource "azuredevops_git_repository" "repository" {
-		project_id      = azuredevops_project.project.id
-		name            = "%s"
-		initialization {
-		   init_type = "Import"
-		   source_type = "Git"
-		   source_url = "https://github.com/microsoft/terraform-provider-azuredevops.git"
-		 }
-	}`, gitRepoName)
-	projectResource := HclProjectResource(projectName)
-	return fmt.Sprintf("%s\n%s", projectResource, azureGitRepoResource)
-}
-
 // HclSecurityroleDefinitionsDataSource HCL describing a data source for securityrole definitions
 func HclSecurityroleDefinitionsDataSource() string {
 	return `

--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -164,6 +164,8 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(fmt.Errorf(" looking up project with (ID: %s or Name: %s). Error: %+v", projectID, name, err))
 	}
 
+	// Set ID to the project UUID in case the project is imported by name
+	d.SetId(project.Id.String())
 	err = flattenProject(clients, d, project)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(" flattening project: %v", err))


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1313 
Test `TestAccProject_features` test failed as expected
```log
=== RUN   TestAccProject_dataSource_withID
=== PAUSE TestAccProject_dataSource_withID
=== RUN   TestAccProject_dataSource_withName
=== PAUSE TestAccProject_dataSource_withName
=== RUN   TestAccProject_basic
=== PAUSE TestAccProject_basic
=== RUN   TestAccProject_importByName
=== PAUSE TestAccProject_importByName
=== RUN   TestAccProject_update
=== PAUSE TestAccProject_update
=== RUN   TestAccProject_features
=== PAUSE TestAccProject_features
=== RUN   TestAccProject_requireImportError
=== PAUSE TestAccProject_requireImportError
=== CONT  TestAccProject_dataSource_withID
=== CONT  TestAccProject_update
=== CONT  TestAccProject_dataSource_withName
=== CONT  TestAccProject_basic
=== CONT  TestAccProject_requireImportError
=== CONT  TestAccProject_features
=== CONT  TestAccProject_importByName
=== NAME  TestAccProject_features
    resource_project_test.go:136: Step 1/4 error: Check failed: Check 7/8 error: azuredevops_project.test: Attribute 'features.testplans' expected "disabled", got "enabled"
--- FAIL: TestAccProject_features (51.10s)
--- PASS: TestAccProject_dataSource_withID (51.65s)
--- PASS: TestAccProject_dataSource_withName (51.84s)
--- PASS: TestAccProject_importByName (51.85s)
--- PASS: TestAccProject_update (67.84s)
--- PASS: TestAccProject_basic (203.34s)
--- PASS: TestAccProject_requireImportError (204.13s)
FAIL
FAIL    github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        204.324s
FAIL

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->