### PR TITLE
All service connection resources - Check if service connection has been deleted

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
@@ -19,9 +19,9 @@ func TestAccServiceEndpointArgoCD_basic(t *testing.T) {
 	resourceType := "azuredevops_serviceendpoint_argocd"
 	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
 				Config: hclSvcEndpointArgoCDResourceBasic(projectName, serviceEndpointName, t.Name()),
@@ -36,19 +36,19 @@ func TestAccServiceEndpointArgoCD_basic(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointArgoCD_basic_usernamepassword(t *testing.T) {
+func TestAccServiceEndpointArgoCD_usernamePassword(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 
 	resourceType := "azuredevops_serviceendpoint_argocd"
 	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: hclSvcEndpointArgoCDResourceBasicUsernamePassword(projectName, serviceEndpointName, t.Name()),
+				Config: hclSvcEndpointArgoCDResourceUsernamePassword(projectName, serviceEndpointName, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
@@ -60,7 +60,7 @@ func TestAccServiceEndpointArgoCD_basic_usernamepassword(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointArgoCD_complete_token(t *testing.T) {
+func TestAccServiceEndpointArgoCD_token(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 	description := t.Name()
@@ -68,43 +68,16 @@ func TestAccServiceEndpointArgoCD_complete_token(t *testing.T) {
 	resourceType := "azuredevops_serviceendpoint_argocd"
 	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: hclSvcEndpointArgoCDResourceComplete(projectName, serviceEndpointName, description),
+				Config: hclSvcEndpointArgoCDResourceToken(projectName, serviceEndpointName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "authentication_token.#", "1"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "url", "https://url.com/1"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
-				),
-			},
-		},
-	})
-}
-
-func TestAccServiceEndpointArgoCD_complete_usernamepassword(t *testing.T) {
-	projectName := testutils.GenerateResourceName()
-	serviceEndpointName := testutils.GenerateResourceName()
-	description := t.Name()
-
-	resourceType := "azuredevops_serviceendpoint_argocd"
-	tfSvcEpNode := resourceType + ".test"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: hclSvcEndpointArgoCDResourceCompleteUsernamePassword(projectName, serviceEndpointName, description),
-				Check: resource.ComposeTestCheckFunc(
-					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "authentication_basic.#", "1"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "url", "https://url.com/1"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
@@ -124,9 +97,9 @@ func TestAccServiceEndpointArgoCD_update(t *testing.T) {
 	resourceType := "azuredevops_serviceendpoint_argocd"
 	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
 				Config: hclSvcEndpointArgoCDResourceBasic(projectName, serviceEndpointNameFirst, t.Name()),
@@ -165,7 +138,7 @@ func TestAccServiceEndpointArgoCD_update_usernamepassword(t *testing.T) {
 		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: hclSvcEndpointArgoCDResourceBasicUsernamePassword(projectName, serviceEndpointNameFirst, t.Name()),
+				Config: hclSvcEndpointArgoCDResourceUsernamePassword(projectName, serviceEndpointNameFirst, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst), resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameFirst),
@@ -186,7 +159,7 @@ func TestAccServiceEndpointArgoCD_update_usernamepassword(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointArgoCD_RequiresImportErrorStep(t *testing.T) {
+func TestAccServiceEndpointArgoCD_requiresImportErrorStep(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 	resourceType := "azuredevops_serviceendpoint_argocd"
@@ -211,7 +184,7 @@ func TestAccServiceEndpointArgoCD_RequiresImportErrorStep(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointArgoCD_RequiresImportErrorStepUsernamePassword(t *testing.T) {
+func TestAccServiceEndpointArgoCD_requiresImportErrorStepUsernamePassword(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 	resourceType := "azuredevops_serviceendpoint_argocd"
@@ -223,7 +196,7 @@ func TestAccServiceEndpointArgoCD_RequiresImportErrorStepUsernamePassword(t *tes
 		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: hclSvcEndpointArgoCDResourceBasicUsernamePassword(projectName, serviceEndpointName, t.Name()),
+				Config: hclSvcEndpointArgoCDResourceUsernamePassword(projectName, serviceEndpointName, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
 				),
@@ -239,63 +212,46 @@ func TestAccServiceEndpointArgoCD_RequiresImportErrorStepUsernamePassword(t *tes
 func hclSvcEndpointArgoCDResourceBasic(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	authentication_token {
-		token			   	   = "redacted"
-	}
-	url			   		   = "http://url.com/1"
-	description 		   = "%s"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  authentication_token {
+    token = "redacted"
+  }
+  url         = "http://url.com/1"
+  description = "%s"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
-func hclSvcEndpointArgoCDResourceBasicUsernamePassword(projectName string, serviceEndpointName string, description string) string {
+func hclSvcEndpointArgoCDResourceUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	authentication_basic {
-		username			   = "u"
-		password			   = "redacted"
-	}
-	url			   		   = "http://url.com/1"
-	description 		   = "%s"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  authentication_basic {
+    username = "u"
+    password = "redacted"
+  }
+  url         = "http://url.com/1"
+  description = "%s"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
-func hclSvcEndpointArgoCDResourceCompleteUsernamePassword(projectName string, serviceEndpointName string, description string) string {
+func hclSvcEndpointArgoCDResourceToken(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_basic {
-		username			   = "u"
-		password			   = "redacted"
-	}
-	url			   		   = "https://url.com/1"
-}`, serviceEndpointName, description)
-
-	projectResource := testutils.HclProjectResource(projectName)
-	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
-}
-
-func hclSvcEndpointArgoCDResourceComplete(projectName string, serviceEndpointName string, description string) string {
-	serviceEndpointResource := fmt.Sprintf(`
-resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_token {
-		token          = "redacted"
-	}
-	  url			   		   = "https://url.com/1"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_token {
+    token = "redacted"
+  }
+  url = "https://url.com/1"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -305,13 +261,13 @@ resource "azuredevops_serviceendpoint_argocd" "test" {
 func hclSvcEndpointArgoCDResourceUpdate(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_token {
-		token          = "redacted2"
-	}
-	  url			   		   = "https://url.com/2"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_token {
+    token = "redacted2"
+  }
+  url = "https://url.com/2"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -321,14 +277,14 @@ resource "azuredevops_serviceendpoint_argocd" "test" {
 func hclSvcEndpointArgoCDResourceUpdateUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_argocd" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_basic {
-		username			   = "u2"
-		password			   = "redacted2"
-	}
-	url			   		   = "https://url.com/2"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_basic {
+    username = "u2"
+    password = "redacted2"
+  }
+  url = "https://url.com/2"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -340,28 +296,12 @@ func hclSvcEndpointArgoCDResourceRequiresImport(projectName string, serviceEndpo
 	return fmt.Sprintf(`
 %s
 resource "azuredevops_serviceendpoint_argocd" "import" {
-  project_id                = azuredevops_serviceendpoint_argocd.test.project_id
+  project_id            = azuredevops_serviceendpoint_argocd.test.project_id
   service_endpoint_name = azuredevops_serviceendpoint_argocd.test.service_endpoint_name
-  description            = azuredevops_serviceendpoint_argocd.test.description
-  url          = azuredevops_serviceendpoint_argocd.test.url
+  description           = azuredevops_serviceendpoint_argocd.test.description
+  url                   = azuredevops_serviceendpoint_argocd.test.url
   authentication_token {
-	  token          = "redacted"
-  }
-}
-`, template)
-}
-func hclSvcEndpointArgoCDResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointArgoCDResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_argocd" "import" {
-  project_id                = azuredevops_serviceendpoint_argocd.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_argocd.test.service_endpoint_name
-  description            = azuredevops_serviceendpoint_argocd.test.description
-  url          	= azuredevops_serviceendpoint_argocd.test.url
-  authentication_basic {
-	username			   = "u"
-	password			   = "redacted"
+    token = "redacted"
   }
 }
 `, template)

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
@@ -239,13 +239,13 @@ func TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword(t
 func hclSvcEndpointArtifactoryResourceBasic(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	authentication_token {
-		token			   	   = "redacted"
-	}
-	url			   		   = "http://url.com/1"
-	description 		   = "%s"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  authentication_token {
+    token = "redacted"
+  }
+  url         = "http://url.com/1"
+  description = "%s"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -255,14 +255,14 @@ resource "azuredevops_serviceendpoint_artifactory" "test" {
 func hclSvcEndpointArtifactoryResourceBasicUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	authentication_basic {
-		username			   = "u"
-		password			   = "redacted"
-	}
-	url			   		   = "http://url.com/1"
-	description 		   = "%s"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  authentication_basic {
+    username = "u"
+    password = "redacted"
+  }
+  url         = "http://url.com/1"
+  description = "%s"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -272,14 +272,14 @@ resource "azuredevops_serviceendpoint_artifactory" "test" {
 func hclSvcEndpointArtifactoryResourceCompleteUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_basic {
-		username			   = "u"
-		password			   = "redacted"
-	}
-	url			   		   = "https://url.com/1"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_basic {
+    username = "u"
+    password = "redacted"
+  }
+  url = "https://url.com/1"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -289,13 +289,13 @@ resource "azuredevops_serviceendpoint_artifactory" "test" {
 func hclSvcEndpointArtifactoryResourceComplete(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_token {
-		token          = "redacted"
-	}
-	  url			   		   = "https://url.com/1"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_token {
+    token = "redacted"
+  }
+  url = "https://url.com/1"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -305,13 +305,13 @@ resource "azuredevops_serviceendpoint_artifactory" "test" {
 func hclSvcEndpointArtifactoryResourceUpdate(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_token {
-		token          = "redacted2"
-	}
-	  url			   		   = "https://url.com/2"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_token {
+    token = "redacted2"
+  }
+  url = "https://url.com/2"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -321,14 +321,14 @@ resource "azuredevops_serviceendpoint_artifactory" "test" {
 func hclSvcEndpointArtifactoryResourceUpdateUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_artifactory" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	authentication_basic {
-		username			   = "u2"
-		password			   = "redacted2"
-	}
-	url			   		   = "https://url.com/2"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  authentication_basic {
+    username = "u2"
+    password = "redacted2"
+  }
+  url = "https://url.com/2"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -340,28 +340,12 @@ func hclSvcEndpointArtifactoryResourceRequiresImport(projectName string, service
 	return fmt.Sprintf(`
 %s
 resource "azuredevops_serviceendpoint_artifactory" "import" {
-  project_id                = azuredevops_serviceendpoint_artifactory.test.project_id
+  project_id            = azuredevops_serviceendpoint_artifactory.test.project_id
   service_endpoint_name = azuredevops_serviceendpoint_artifactory.test.service_endpoint_name
-  description            = azuredevops_serviceendpoint_artifactory.test.description
-  url          = azuredevops_serviceendpoint_artifactory.test.url
+  description           = azuredevops_serviceendpoint_artifactory.test.description
+  url                   = azuredevops_serviceendpoint_artifactory.test.url
   authentication_token {
-	  token          = "redacted"
-  }
-}
-`, template)
-}
-func hclSvcEndpointArtifactoryResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointArtifactoryResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_artifactory" "import" {
-  project_id                = azuredevops_serviceendpoint_artifactory.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_artifactory.test.service_endpoint_name
-  description            = azuredevops_serviceendpoint_artifactory.test.description
-  url          	= azuredevops_serviceendpoint_artifactory.test.url
-  authentication_basic {
-	username			   = "u"
-	password			   = "redacted"
+    token = "redacted"
   }
 }
 `, template)

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
@@ -128,9 +128,9 @@ func TestAccServiceEndpointAzureDevOps_RequiresImportErrorStep(t *testing.T) {
 func hclSvcEndpointAzureDevOpsResourceBasic(projectName string, serviceEndpointName string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_azuredevops" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	personal_access_token  = "0000000000000000000000000000000000000000000000000000"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  personal_access_token = "0000000000000000000000000000000000000000000000000000"
 }`, serviceEndpointName)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -140,12 +140,12 @@ resource "azuredevops_serviceendpoint_azuredevops" "test" {
 func hclSvcEndpointAzureDevOpsResourceComplete(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_azuredevops" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	org_url			   	   = "https://dev.azure.com/myorganization"
-	release_api_url		   = "https://vsrm.dev.azure.com/myorganization"
-	personal_access_token  = "0000000000000000000000000000000000000000000000000000"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  org_url               = "https://dev.azure.com/myorganization"
+  release_api_url       = "https://vsrm.dev.azure.com/myorganization"
+  personal_access_token = "0000000000000000000000000000000000000000000000000000"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -155,12 +155,12 @@ resource "azuredevops_serviceendpoint_azuredevops" "test" {
 func hclSvcEndpointAzureDevOpsResourceUpdate(projectName string, serviceEndpointName string, orgUrl string, releaseApiUrl string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_azuredevops" "test" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%s"
-	description            = "%s"
-	org_url			   	   = "%s"
-	release_api_url		   = "%s"
-	personal_access_token  = "0000000000000000000000000000000000000000000000000000"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  org_url               = "%s"
+  release_api_url       = "%s"
+  personal_access_token = "0000000000000000000000000000000000000000000000000000"
 }`, serviceEndpointName, description, orgUrl, releaseApiUrl)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -172,12 +172,12 @@ func hclSvcEndpointAzureDevOpsResourceRequiresImport(projectName string, service
 	return fmt.Sprintf(`
 %s
 resource "azuredevops_serviceendpoint_azuredevops" "import" {
-	project_id             = azuredevops_serviceendpoint_azuredevops.test.project_id
-	service_endpoint_name  = azuredevops_serviceendpoint_azuredevops.test.service_endpoint_name
-	description            = azuredevops_serviceendpoint_azuredevops.test.description
-	org_url			   	   = azuredevops_serviceendpoint_azuredevops.test.org_url
-	release_api_url		   = azuredevops_serviceendpoint_azuredevops.test.release_api_url
-	personal_access_token  = azuredevops_serviceendpoint_azuredevops.test.personal_access_token
+  project_id            = azuredevops_serviceendpoint_azuredevops.test.project_id
+  service_endpoint_name = azuredevops_serviceendpoint_azuredevops.test.service_endpoint_name
+  description           = azuredevops_serviceendpoint_azuredevops.test.description
+  org_url               = azuredevops_serviceendpoint_azuredevops.test.org_url
+  release_api_url       = azuredevops_serviceendpoint_azuredevops.test.release_api_url
+  personal_access_token = azuredevops_serviceendpoint_azuredevops.test.personal_access_token
 }
 `, template)
 }

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -397,21 +397,21 @@ func TestAccServiceEndpointAzureRm_azureStack(t *testing.T) {
 func hclAzureRMServiceEndpointEnvironmentAzureStack(projectName, serviceEndpointName string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "test" {
-	name       = "%s"
+  name = "%s"
 }
 
 resource "azuredevops_serviceendpoint_azurerm" "test" {
-  project_id                             = azuredevops_project.test.id
-  service_endpoint_name                  = "%s"
-  environment = "AzureStack"
-  server_url = "https://www.azuredevops.com"
-  azurerm_spn_tenantid                   = "00000000-0000-0000-0000-000000000000"
-  azurerm_subscription_id                = "00000000-0000-0000-0000-000000000000"
-  azurerm_subscription_name              = "Test Sub"
+  project_id                = azuredevops_project.test.id
+  service_endpoint_name     = "%s"
+  environment               = "AzureStack"
+  server_url                = "https://www.azuredevops.com"
+  azurerm_spn_tenantid      = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_id   = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_name = "Test Sub"
   credentials {
-     serviceprincipalid  = "00000000-0000-0000-0000-000000000000"
-     serviceprincipalkey = "00000000-0000-0000-0000-000000000000"
-   }
+    serviceprincipalid  = "00000000-0000-0000-0000-000000000000"
+    serviceprincipalkey = "00000000-0000-0000-0000-000000000000"
+  }
 }
 `, projectName, serviceEndpointName)
 }

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
@@ -123,12 +123,12 @@ func personTokenConfigBasicGithubEnterprise(projectName string, serviceEndpointN
 
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%[1]s"
-	url                    = "https://github.contoso.com"
-	auth_personal {
-		personal_access_token= "test_token_basic"
-	}
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%[1]s"
+  url                   = "https://github.contoso.com"
+  auth_personal {
+    personal_access_token = "test_token_basic"
+  }
 }`, serviceEndpointName)
 
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
@@ -139,13 +139,13 @@ func personTokenConfigUpdateGithubEnterprise(projectName string, serviceEndpoint
 
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {
-	project_id             = azuredevops_project.project.id
-	service_endpoint_name  = "%[1]s"
-	url                    = "https://github.contoso.com"
-	auth_personal {
-		personal_access_token= "test_token_update"
-	}
-	description = "%[2]s"
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%[1]s"
+  url                   = "https://github.contoso.com"
+  auth_personal {
+    personal_access_token = "test_token_update"
+  }
+  description = "%[2]s"
 }`, serviceEndpointName, description)
 
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurecr.go
@@ -76,7 +76,7 @@ func dataSourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return err
 	}
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
@@ -86,7 +86,7 @@ func dataSourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return err
 	}
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_bitbucket.go
@@ -25,7 +25,7 @@ func dataSourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{
 		return err
 	}
 
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
@@ -22,7 +22,7 @@ func dataSourceServiceEndpointGithubRead(d *schema.ResourceData, m interface{}) 
 	if err != nil {
 		return err
 	}
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_npm.go
@@ -34,7 +34,7 @@ func dataSourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) err
 		return err
 	}
 
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_sonarcloud.go
@@ -23,7 +23,7 @@ func dataSourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface
 		return err
 	}
 
-	if serviceEndpoint != nil {
+	if serviceEndpoint != nil && serviceEndpoint.Id != nil {
 		if err = checkServiceConnection(serviceEndpoint); err != nil {
 			return err
 		}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -110,12 +109,11 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -110,12 +109,11 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" Looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -112,12 +111,11 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -159,12 +158,11 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -83,12 +82,11 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/migration"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -232,12 +231,11 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if serviceEndpoint == nil || serviceEndpoint.Id == nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -9,7 +9,6 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/model"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -74,12 +73,11 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -97,12 +96,11 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -89,12 +88,11 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -101,12 +100,11 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -92,12 +91,11 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -85,12 +84,11 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -91,12 +90,11 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -81,12 +80,11 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -86,12 +85,11 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -96,12 +95,11 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -84,12 +83,11 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -79,12 +78,11 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -87,12 +86,11 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -110,12 +109,11 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -108,12 +107,11 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -109,12 +108,11 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -109,12 +108,11 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"gopkg.in/yaml.v3"
@@ -197,12 +196,12 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -117,12 +116,11 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -78,12 +77,11 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -75,12 +74,11 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -98,12 +97,11 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -78,12 +77,11 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -85,12 +84,11 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -183,12 +182,11 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -71,12 +70,11 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -67,12 +66,11 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -75,12 +74,11 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if serviceEndpoint.Id == nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -93,12 +92,11 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
 	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {


### PR DESCRIPTION

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixed: #1314 
Check if service connection has been deleted since the API behavior has been changed.

Not all resources have been tested, some of them were selected for testing.
<summary>
AccTest log:
<details>

```log
=== RUN   TestAccServiceEndpointArgoCD_basic
=== PAUSE TestAccServiceEndpointArgoCD_basic
=== RUN   TestAccServiceEndpointArgoCD_usernamePassword
=== PAUSE TestAccServiceEndpointArgoCD_usernamePassword
=== RUN   TestAccServiceEndpointArgoCD_token
=== PAUSE TestAccServiceEndpointArgoCD_token
=== RUN   TestAccServiceEndpointArgoCD_update
=== PAUSE TestAccServiceEndpointArgoCD_update
=== RUN   TestAccServiceEndpointArgoCD_update_usernamepassword
=== PAUSE TestAccServiceEndpointArgoCD_update_usernamepassword
=== RUN   TestAccServiceEndpointArgoCD_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointArgoCD_requiresImportErrorStep
=== RUN   TestAccServiceEndpointArgoCD_requiresImportErrorStepUsernamePassword
=== PAUSE TestAccServiceEndpointArgoCD_requiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArgoCD_basic
=== CONT  TestAccServiceEndpointArgoCD_update_usernamepassword
=== CONT  TestAccServiceEndpointArgoCD_requiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArgoCD_token
=== CONT  TestAccServiceEndpointArgoCD_requiresImportErrorStep
=== CONT  TestAccServiceEndpointArgoCD_usernamePassword
=== CONT  TestAccServiceEndpointArgoCD_update
--- PASS: TestAccServiceEndpointArgoCD_usernamePassword (86.92s)
--- PASS: TestAccServiceEndpointArgoCD_basic (86.95s)
--- PASS: TestAccServiceEndpointArgoCD_token (98.07s)
--- PASS: TestAccServiceEndpointArgoCD_requiresImportErrorStepUsernamePassword (103.03s)
--- PASS: TestAccServiceEndpointArgoCD_requiresImportErrorStep (110.51s)
--- PASS: TestAccServiceEndpointArgoCD_update (122.75s)
--- PASS: TestAccServiceEndpointArgoCD_update_usernamepassword (129.77s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        130.170s 

=== RUN   TestAccServiceEndpointArtifactory_basic
=== PAUSE TestAccServiceEndpointArtifactory_basic
=== RUN   TestAccServiceEndpointArtifactory_basic_usernamepassword
=== PAUSE TestAccServiceEndpointArtifactory_basic_usernamepassword
=== RUN   TestAccServiceEndpointArtifactory_complete_token
=== PAUSE TestAccServiceEndpointArtifactory_complete_token
=== RUN   TestAccServiceEndpointArtifactory_complete_usernamepassword
=== PAUSE TestAccServiceEndpointArtifactory_complete_usernamepassword
=== RUN   TestAccServiceEndpointArtifactory_update
=== PAUSE TestAccServiceEndpointArtifactory_update
=== RUN   TestAccServiceEndpointArtifactory_update_usernamepassword
=== PAUSE TestAccServiceEndpointArtifactory_update_usernamepassword
=== RUN   TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== RUN   TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== PAUSE TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArtifactory_basic
=== CONT  TestAccServiceEndpointArtifactory_complete_token
=== CONT  TestAccServiceEndpointArtifactory_update
=== CONT  TestAccServiceEndpointArtifactory_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointArtifactory_basic_usernamepassword
=== CONT  TestAccServiceEndpointArtifactory_complete_usernamepassword
=== CONT  TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointArtifactory_update_usernamepassword
--- PASS: TestAccServiceEndpointArtifactory_complete_token (84.31s)
--- PASS: TestAccServiceEndpointArtifactory_basic (84.44s)
--- PASS: TestAccServiceEndpointArtifactory_complete_usernamepassword (95.68s)
--- PASS: TestAccServiceEndpointArtifactory_basic_usernamepassword (95.68s)
--- PASS: TestAccServiceEndpointArtifactory_RequiresImportErrorStep (106.45s)
--- PASS: TestAccServiceEndpointArtifactory_update (109.01s)
--- PASS: TestAccServiceEndpointArtifactory_RequiresImportErrorStepUsernamePassword (116.62s)
--- PASS: TestAccServiceEndpointArtifactory_update_usernamepassword (127.61s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        127.803s

=== RUN   TestAccServiceEndpointAws_basic
=== PAUSE TestAccServiceEndpointAws_basic
=== RUN   TestAccServiceEndpointAws_complete
=== PAUSE TestAccServiceEndpointAws_complete
=== RUN   TestAccServiceEndpointAws_update
=== RUN   TestAccServiceEndpointAws_oidc
=== PAUSE TestAccServiceEndpointAws_oidc
=== RUN   TestAccServiceEndpointAws_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointAws_requiresImportErrorStep
=== CONT  TestAccServiceEndpointAws_basic
=== CONT  TestAccServiceEndpointAws_oidc
=== CONT  TestAccServiceEndpointAws_update
=== CONT  TestAccServiceEndpointAws_complete
=== CONT  TestAccServiceEndpointAws_requiresImportErrorStep
--- PASS: TestAccServiceEndpointAws_complete (90.24s)
--- PASS: TestAccServiceEndpointAws_oidc (90.36s)
--- PASS: TestAccServiceEndpointAws_basic (95.96s)
--- PASS: TestAccServiceEndpointAws_requiresImportErrorStep (100.67s)
--- PASS: TestAccServiceEndpointAws_update (117.90s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        118.076s

=== RUN   TestAccServiceEndpointAzureServiceBus_basic
=== PAUSE TestAccServiceEndpointAzureServiceBus_basic
=== RUN   TestAccServiceEndpointAzureServiceBus_complete
=== PAUSE TestAccServiceEndpointAzureServiceBus_complete
=== RUN   TestAccServiceEndpointAzureServiceBus_update
=== PAUSE TestAccServiceEndpointAzureServiceBus_update
=== RUN   TestAccServiceEndpointAzureServiceBus_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointAzureServiceBus_requiresImportErrorStep
=== CONT  TestAccServiceEndpointAzureServiceBus_basic
=== CONT  TestAccServiceEndpointAzureServiceBus_requiresImportErrorStep
=== CONT  TestAccServiceEndpointAzureServiceBus_update
=== CONT  TestAccServiceEndpointAzureServiceBus_complete
--- PASS: TestAccServiceEndpointAzureServiceBus_basic (63.79s)
--- PASS: TestAccServiceEndpointAzureServiceBus_requiresImportErrorStep (67.63s)
--- PASS: TestAccServiceEndpointAzureServiceBus_update (71.47s)
--- PASS: TestAccServiceEndpointAzureServiceBus_complete (72.49s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        72.680s

=== RUN   TestAccServiceEndpointExternalTFS_PersonalTokenBasic
=== PAUSE TestAccServiceEndpointExternalTFS_PersonalTokenBasic
=== RUN   TestAccServiceEndpointExternalTFS_PersonalTokenUpdate
=== PAUSE TestAccServiceEndpointExternalTFS_PersonalTokenUpdate
=== RUN   TestAccServiceEndpointExternalTFS_CreateAndUpdate
=== PAUSE TestAccServiceEndpointExternalTFS_CreateAndUpdate
=== RUN   TestAccServiceEndpointExternalTFS_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointExternalTFS_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointExternalTFS_PersonalTokenBasic
=== CONT  TestAccServiceEndpointExternalTFS_CreateAndUpdate
=== CONT  TestAccServiceEndpointExternalTFS_PersonalTokenUpdate
=== CONT  TestAccServiceEndpointExternalTFS_RequiresImportErrorStep
--- PASS: TestAccServiceEndpointExternalTFS_RequiresImportErrorStep (64.44s)
--- PASS: TestAccServiceEndpointExternalTFS_PersonalTokenUpdate (68.39s)
--- PASS: TestAccServiceEndpointExternalTFS_PersonalTokenBasic (68.50s)
--- PASS: TestAccServiceEndpointExternalTFS_CreateAndUpdate (69.61s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        69.803s

=== RUN   TestAccServiceEndpointRunPipeline_Defaults
=== PAUSE TestAccServiceEndpointRunPipeline_Defaults
=== RUN   TestAccServiceEndpointRunPipeline_PersonalTokenBasic
=== PAUSE TestAccServiceEndpointRunPipeline_PersonalTokenBasic
=== RUN   TestAccServiceEndpointRunPipeline_PersonalTokenUpdate
=== PAUSE TestAccServiceEndpointRunPipeline_PersonalTokenUpdate
=== CONT  TestAccServiceEndpointRunPipeline_Defaults
=== CONT  TestAccServiceEndpointRunPipeline_PersonalTokenUpdate
=== CONT  TestAccServiceEndpointRunPipeline_PersonalTokenBasic
--- PASS: TestAccServiceEndpointRunPipeline_PersonalTokenBasic (60.37s)
--- PASS: TestAccServiceEndpointRunPipeline_Defaults (60.44s)
--- PASS: TestAccServiceEndpointRunPipeline_PersonalTokenUpdate (68.02s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.197s

=== RUN   TestAccServiceEndpointNpm_dataSource
=== PAUSE TestAccServiceEndpointNpm_dataSource
=== RUN   TestAccServiceEndpointNpm_basic
=== PAUSE TestAccServiceEndpointNpm_basic
=== RUN   TestAccServiceEndpointNpm_complete
=== PAUSE TestAccServiceEndpointNpm_complete
=== RUN   TestAccServiceEndpointNpm_update
=== PAUSE TestAccServiceEndpointNpm_update
=== RUN   TestAccServiceEndpointNpm_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointNpm_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointNpm_dataSource
=== CONT  TestAccServiceEndpointNpm_update
=== CONT  TestAccServiceEndpointNpm_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointNpm_complete
=== CONT  TestAccServiceEndpointNpm_basic
--- PASS: TestAccServiceEndpointNpm_dataSource (60.51s)
--- PASS: TestAccServiceEndpointNpm_complete (60.59s)
--- PASS: TestAccServiceEndpointNpm_basic (60.61s)
--- PASS: TestAccServiceEndpointNpm_RequiresImportErrorStep (64.21s)
--- PASS: TestAccServiceEndpointNpm_update (68.15s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.339s

=== RUN   TestAccServiceEndpointSonarQube_basic
=== PAUSE TestAccServiceEndpointSonarQube_basic
=== RUN   TestAccServiceEndpointSonarQube_complete
=== PAUSE TestAccServiceEndpointSonarQube_complete
=== RUN   TestAccServiceEndpointSonarQube_update
=== PAUSE TestAccServiceEndpointSonarQube_update
=== RUN   TestAccServiceEndpointSonarQube_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointSonarQube_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSonarQube_basic
=== CONT  TestAccServiceEndpointSonarQube_update
=== CONT  TestAccServiceEndpointSonarQube_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSonarQube_complete
--- PASS: TestAccServiceEndpointSonarQube_basic (60.73s)
--- PASS: TestAccServiceEndpointSonarQube_RequiresImportErrorStep (64.33s)
--- PASS: TestAccServiceEndpointSonarQube_update (68.26s)
--- PASS: TestAccServiceEndpointSonarQube_complete (68.49s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.680s

=== RUN   TestAccServiceEndpointSnyk_basic
=== PAUSE TestAccServiceEndpointSnyk_basic
=== RUN   TestAccServiceEndpointSnyk_complete
=== PAUSE TestAccServiceEndpointSnyk_complete
=== RUN   TestAccServiceEndpointSnyk_update
=== PAUSE TestAccServiceEndpointSnyk_update
=== RUN   TestAccServiceEndpointSnyk_requiresImportErrorStep
=== PAUSE TestAccServiceEndpointSnyk_requiresImportErrorStep
=== CONT  TestAccServiceEndpointSnyk_basic
=== CONT  TestAccServiceEndpointSnyk_update
=== CONT  TestAccServiceEndpointSnyk_requiresImportErrorStep
=== CONT  TestAccServiceEndpointSnyk_complete
--- PASS: TestAccServiceEndpointSnyk_basic (61.05s)
--- PASS: TestAccServiceEndpointSnyk_complete (61.15s)
--- PASS: TestAccServiceEndpointSnyk_requiresImportErrorStep (64.62s)
--- PASS: TestAccServiceEndpointSnyk_update (68.69s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.872s

=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_basic
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_basic
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_complete_token
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_complete_token
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_update
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_update
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep
=== RUN   TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword
=== PAUSE TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_basic
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_update
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_complete_token
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword
=== CONT  TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_complete_usernamepassword (60.00s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStep (63.72s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_RequiresImportErrorStepUsernamePassword (64.56s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_update_usernamepassword (67.75s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_update (67.76s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_basic (68.60s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_basic_usernamepassword (68.67s)
--- PASS: TestAccServiceEndpointJFrogArtifactoryV2_complete_token (68.68s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.877s

=== RUN   TestAccServiceEndpointJenkins_basic_usernamepassword
=== PAUSE TestAccServiceEndpointJenkins_basic_usernamepassword
=== RUN   TestAccServiceEndpointJenkins_complete_usernamepassword
=== PAUSE TestAccServiceEndpointJenkins_complete_usernamepassword
=== RUN   TestAccServiceEndpointJenkins_update_usernamepassword
=== PAUSE TestAccServiceEndpointJenkins_update_usernamepassword
=== RUN   TestAccServiceEndpointJenkins_RequiresImportErrorStepUsernamePassword
=== PAUSE TestAccServiceEndpointJenkins_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointJenkins_basic_usernamepassword
=== CONT  TestAccServiceEndpointJenkins_update_usernamepassword
=== CONT  TestAccServiceEndpointJenkins_RequiresImportErrorStepUsernamePassword
=== CONT  TestAccServiceEndpointJenkins_complete_usernamepassword
--- PASS: TestAccServiceEndpointJenkins_basic_usernamepassword (60.91s)
--- PASS: TestAccServiceEndpointJenkins_RequiresImportErrorStepUsernamePassword (64.52s)
--- PASS: TestAccServiceEndpointJenkins_update_usernamepassword (68.44s)
--- PASS: TestAccServiceEndpointJenkins_complete_usernamepassword (68.71s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        68.990s

=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_Create_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_Create_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_azureStack
=== PAUSE TestAccServiceEndpointAzureRm_azureStack
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_Create_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_azureStack
--- PASS: TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate (61.08s)
--- PASS: TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate (68.71s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate (76.66s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate (77.28s)
--- PASS: TestAccServiceEndpointAzureRm_azureStack (80.32s)
--- PASS: TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate (85.86s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate (86.65s)
--- PASS: TestAccServiceEndpointAzureRm_Create_WithValidate (116.51s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate (142.28s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        142.481s

=== RUN   TestAccServiceEndpointAzureCR_dataSource
=== PAUSE TestAccServiceEndpointAzureCR_dataSource
=== RUN   TestAccServiceEndpointAzureCR_spn_basic
=== PAUSE TestAccServiceEndpointAzureCR_spn_basic
=== RUN   TestAccServiceEndpointAzureCR_spn_update
=== PAUSE TestAccServiceEndpointAzureCR_spn_update
=== CONT  TestAccServiceEndpointAzureCR_dataSource
=== CONT  TestAccServiceEndpointAzureCR_spn_update
=== CONT  TestAccServiceEndpointAzureCR_spn_basic
--- PASS: TestAccServiceEndpointAzureCR_dataSource (72.26s)
--- PASS: TestAccServiceEndpointAzureCR_spn_basic (72.78s)
--- PASS: TestAccServiceEndpointAzureCR_spn_update (81.96s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        82.155s

=== RUN   TestAccServiceEndpointSSH_basic
=== PAUSE TestAccServiceEndpointSSH_basic
=== RUN   TestAccServiceEndpointSSH_complete
=== PAUSE TestAccServiceEndpointSSH_complete
=== RUN   TestAccServiceEndpointSSH_update
=== PAUSE TestAccServiceEndpointSSH_update
=== RUN   TestAccServiceEndpointSSH_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointSSH_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSSH_basic
=== CONT  TestAccServiceEndpointSSH_update
=== CONT  TestAccServiceEndpointSSH_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSSH_complete
--- PASS: TestAccServiceEndpointSSH_basic (60.63s)
--- PASS: TestAccServiceEndpointSSH_complete (60.76s)
--- PASS: TestAccServiceEndpointSSH_update (68.17s)
--- PASS: TestAccServiceEndpointSSH_RequiresImportErrorStep (71.54s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        71.732s

=== RUN   TestAccServiceEndpointAzureCR_dataSource
=== PAUSE TestAccServiceEndpointAzureCR_dataSource
=== RUN   TestAccServiceEndpointAzureCR_spn_basic
=== PAUSE TestAccServiceEndpointAzureCR_spn_basic
=== RUN   TestAccServiceEndpointAzureCR_spn_update
=== PAUSE TestAccServiceEndpointAzureCR_spn_update
=== CONT  TestAccServiceEndpointAzureCR_dataSource
=== CONT  TestAccServiceEndpointAzureCR_spn_update
=== CONT  TestAccServiceEndpointAzureCR_spn_basic
--- PASS: TestAccServiceEndpointAzureCR_dataSource (72.26s)
--- PASS: TestAccServiceEndpointAzureCR_spn_basic (72.78s)
--- PASS: TestAccServiceEndpointAzureCR_spn_update (81.96s)
PASS

=== RUN   TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointID
=== PAUSE TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointID
=== RUN   TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointName
=== PAUSE TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointName
=== RUN   TestAccServiceEndpointAzureRM_dataSource_with_WorkloadIdentityFederation
=== PAUSE TestAccServiceEndpointAzureRM_dataSource_with_WorkloadIdentityFederation
=== CONT  TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointID
=== CONT  TestAccServiceEndpointAzureRM_dataSource_with_WorkloadIdentityFederation
=== CONT  TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointName
--- PASS: TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointID (61.33s)
--- PASS: TestAccServiceEndpointAzureRM_dataSource_with_serviceEndpointName (61.51s)
--- PASS: TestAccServiceEndpointAzureRM_dataSource_with_WorkloadIdentityFederation (61.94s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        62.133s

=== RUN   TestAccServiceEndpointBitbucketDataSource_withID
=== PAUSE TestAccServiceEndpointBitbucketDataSource_withID
=== RUN   TestAccServiceEndpointBitbucketDataSource_withName
=== PAUSE TestAccServiceEndpointBitbucketDataSource_withName
=== CONT  TestAccServiceEndpointBitbucketDataSource_withID
=== CONT  TestAccServiceEndpointBitbucketDataSource_withName
--- PASS: TestAccServiceEndpointBitbucketDataSource_withID (61.08s)
--- PASS: TestAccServiceEndpointBitbucketDataSource_withName (61.20s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        61.377s

=== RUN   TestAccServiceEndpointSonarCloud_dataSource
=== PAUSE TestAccServiceEndpointSonarCloud_dataSource
=== RUN   TestAccServiceEndpointSonarCloud_basic
=== PAUSE TestAccServiceEndpointSonarCloud_basic
=== RUN   TestAccServiceEndpointSonarCloud_complete
=== PAUSE TestAccServiceEndpointSonarCloud_complete
=== RUN   TestAccServiceEndpointSonarCloud_update
=== PAUSE TestAccServiceEndpointSonarCloud_update
=== RUN   TestAccServiceEndpointSonarCloud_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointSonarCloud_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointSonarCloud_dataSource
=== CONT  TestAccServiceEndpointSonarCloud_update
=== CONT  TestAccServiceEndpointSonarCloud_complete
=== CONT  TestAccServiceEndpointSonarCloud_basic
=== CONT  TestAccServiceEndpointSonarCloud_RequiresImportErrorStep
--- PASS: TestAccServiceEndpointSonarCloud_complete (58.08s)
--- PASS: TestAccServiceEndpointSonarCloud_dataSource (58.70s)
--- PASS: TestAccServiceEndpointSonarCloud_RequiresImportErrorStep (61.31s)
--- PASS: TestAccServiceEndpointSonarCloud_basic (65.57s)
--- PASS: TestAccServiceEndpointSonarCloud_update (72.97s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        73.154s


=== RUN   TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointID
=== PAUSE TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointID
=== RUN   TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointName_DataSource
=== PAUSE TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointName_DataSource
=== RUN   TestAccServiceEndpointGitHub_PersonalTokenBasic
=== PAUSE TestAccServiceEndpointGitHub_PersonalTokenBasic
=== RUN   TestAccServiceEndpointGitHub_PersonalTokenUpdate
=== PAUSE TestAccServiceEndpointGitHub_PersonalTokenUpdate
=== RUN   TestAccServiceEndpointGitHub_OauthBasic
=== PAUSE TestAccServiceEndpointGitHub_OauthBasic
=== RUN   TestAccServiceEndpointGitHub_OauthUpdate
=== PAUSE TestAccServiceEndpointGitHub_OauthUpdate
=== RUN   TestAccServiceEndpointGitHub_CreateAndUpdate
=== PAUSE TestAccServiceEndpointGitHub_CreateAndUpdate
=== CONT  TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointID
=== CONT  TestAccServiceEndpointGitHub_OauthBasic
=== CONT  TestAccServiceEndpointGitHub_CreateAndUpdate
=== CONT  TestAccServiceEndpointGitHub_OauthUpdate
=== CONT  TestAccServiceEndpointGitHub_PersonalTokenBasic
=== CONT  TestAccServiceEndpointGitHub_PersonalTokenUpdate
=== CONT  TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointName_DataSource
--- PASS: TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointID (60.73s)
--- PASS: TestAccServiceEndpointGitHub_OauthBasic (60.74s)
--- PASS: TestAccServiceEndpointGitHub_PersonalTokenBasic (68.34s)
--- PASS: TestAccServiceEndpointGitHub_dataSource_with_serviceEndpointName_DataSource (69.27s)
--- PASS: TestAccServiceEndpointGitHub_CreateAndUpdate (69.51s)
--- PASS: TestAccServiceEndpointGitHub_PersonalTokenUpdate (75.86s)
--- PASS: TestAccServiceEndpointGitHub_OauthUpdate (86.15s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        86.336s
```

</details>
</summary>


## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?
- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->