### PR TITLE
Add CreateBuildDefinition

### DIFF
--- a/website/docs/r/build_folder_permissions.html.markdown
+++ b/website/docs/r/build_folder_permissions.html.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
     | DeleteBuildDefinition          | Delete build pipeline                 |
     | OverrideBuildCheckInValidation | Override check-in validation by build |
     | AdministerBuildPermissions     | Administer build permissions          |
+    | CreateBuildDefinition          | Create build pipeline                 |
 
 ---
 


### PR DESCRIPTION
The permission used to create build pipelines is missing from the documentation.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->