### PR TITLE
Added import support for feed permissions #1151

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
@@ -6,10 +6,14 @@ package acceptancetests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/feed"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 )
 
 func TestAccFeedPermission_basic(t *testing.T) {
@@ -28,6 +32,33 @@ func TestAccFeedPermission_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfNode, "role"),
 					resource.TestCheckResourceAttrSet(tfNode, "identity_descriptor"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFeedPermission_importErrorStep(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+
+	tfNode := "azuredevops_feed_permission.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      checkFeedPermissionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclFeedPermissionBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckFeedPermissionExist(),
+					resource.TestCheckResourceAttrSet(tfNode, "feed_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "role"),
+					resource.TestCheckResourceAttrSet(tfNode, "identity_descriptor"),
+				),
+			},
+			{
+				Config: hclFeedPermissionImport(projectName),
+				ExpectError: feedPermissionRequiresImportError(),
 			},
 		},
 	})
@@ -60,4 +91,67 @@ resource "azuredevops_feed_permission" "test" {
   identity_descriptor = azuredevops_group.test.descriptor
 }
 `, name)
+}
+
+func hclFeedPermissionImport(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_feed_permission" "import" {
+  feed_id             = azuredevops_feed.test.id
+  project_id          = azuredevops_project.test.id
+  role                = "reader"
+  identity_descriptor = azuredevops_group.test.descriptor
+}
+`, hclFeedPermissionBasic(name))
+}
+
+func checkFeedPermissionDestroyed(s *terraform.State) error {
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+	for _, res := range s.RootModule().Resources {
+		if res.Type != "azuredevops_feed_permission" {
+			continue
+		}
+		id := res.Primary.Attributes["feed_id"]
+		projectID := res.Primary.Attributes["project_id"]
+		permissions, err := clients.FeedClient.GetFeedPermissions(clients.Ctx, feed.GetFeedPermissionsArgs{
+			FeedId:  &id,
+			Project: &projectID,
+		})
+
+		if err == nil {
+			if permissions != nil && len(*permissions) > 0 {
+				return fmt.Errorf(" Feed permissions (Feed ID: %s) should not exist", id)
+			}
+		}
+	}
+	return nil
+}
+
+func CheckFeedPermissionExist() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.RootModule().Resources["azuredevops_feed_permission.test"]
+		if !ok {
+			return fmt.Errorf(" Did not find a `azuredevops_feed_permission` in the TF state")
+		}
+
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+		id := res.Primary.Attributes["feed_id"]
+		projectID := res.Primary.Attributes["project_id"]
+
+		_, err := clients.FeedClient.GetFeedPermissions(clients.Ctx, feed.GetFeedPermissionsArgs{
+			FeedId:  &id,
+			Project: &projectID,
+		})
+
+		if err != nil {
+			return fmt.Errorf(" Feed permissions with Feed ( Feed ID=%s ) cannot be found!. Error=%v", id, err)
+		}
+
+		return nil
+	}
+}
+
+func feedPermissionRequiresImportError() *regexp.Regexp {
+	return regexp.MustCompile(`Error: feed Permission for Feed : .* and Identity : .* already exists`)
 }

--- a/website/docs/r/feed_permission.html.markdown
+++ b/website/docs/r/feed_permission.html.markdown
@@ -74,3 +74,17 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 * `read` - (Defaults to 5 minute) Used when retrieving the Feed Permission.
 * `update` - (Defaults to 10 minutes) Used when updating the Feed Permission.
 * `delete` - (Defaults to 10 minutes) Used when deleting the Feed Permission.
+
+## Import
+
+Azure DevOps Feed Permission can be imported using the Project ID, Feed ID and Identity Descriptor or Feed ID and Identity Descriptor e.g.:
+
+```sh
+terraform import azuredevops_feed_permission.permission 00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/vssgp.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+or 
+
+```sh
+terraform import azuredevops_feed_permission.permission 00000000-0000-0000-0000-000000000000/vssgp.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

1. Added support for importing feed permissions on organisation and project scopes.
2. Usage: `terraform import azuredevops_feed_permission.myFeedPermission <feedId>/<identityDescriptor>` to import the permissions from organisation level feeds and `terraform import azuredevops_feed_permission.myFeedPermission <projetId>/<feedId>/<identityDescriptor>` to import from project level feeds.

Issue Number: https://github.com/microsoft/terraform-provider-azuredevops/issues/1151

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No