### PR TITLE
[Enhance] -`azuredevops_git_repository` - git repo ephemeral password

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_test.go
@@ -113,7 +113,21 @@ func TestGitRepo_FlattenExpand_RoundTrip(t *testing.T) {
 	repoName := "repoName"
 	gitRepo := git.GitRepository{Id: &repoID, Name: &repoName, Project: &project}
 
-	resourceData := schema.TestResourceDataRaw(t, ResourceGitRepository().Schema, nil)
+	resourceData := schema.TestResourceDataRaw(t, ResourceGitRepository().Schema, map[string]interface{}{
+		"project_id": projectID.String(),
+		"repo_id":    repoID.String(),
+		"name":       repoName,
+		"initialization": []interface{}{
+			map[string]interface{}{
+				"init_type":             "Clean",
+				"username":              "",
+				"password":              "",
+				"source_type":           "",
+				"source_url":            "",
+				"service_connection_id": "",
+			},
+		},
+	})
 	resourceData.SetId(gitRepo.Id.String())
 	configureCleanInitialization(resourceData)
 	flattenGitRepository(resourceData, &gitRepo)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -39,13 +39,13 @@ func ResourceServiceEndpointGenericGit() *schema.Resource {
 		},
 		"username": {
 			Type:        schema.TypeString,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_GenericGit_GIT_SERVICE_CONNECTION_USERNAME", nil),
+			DefaultFunc: schema.EnvDefaultFunc("AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME", nil),
 			Description: "The username to use for the GenericGit service git connection.",
 			Optional:    true,
 		},
 		"password": {
 			Type:        schema.TypeString,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_GenericGit_GIT_SERVICE_CONNECTION_PASSWORD", nil),
+			DefaultFunc: schema.EnvDefaultFunc("AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD", nil),
 			Description: "The password or token key to use for the GenericGit git service connection.",
 			Sensitive:   true,
 			Optional:    true,

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -255,7 +255,7 @@ A `initialization` - block supports the following:
 
 * `username` (Optional) The username used to authenticate to a private repository for import initialization. Conflicts with `service_connection_id`.
 
-* `password` (Optional) The password used to authenticate to a private repository for import initialization. Conflicts with `service_connection_id`.
+* `password` (Optional) The password used to authenticate to a private repository for import initialization. Conflicts with `service_connection_id`. Note: This is a write-only attribute, which allows ephemeral resources to be used.
 
     ~>**Note** At least `service_connection_id` or `username/password` needs to be set to import private repository.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Changes `password` property to be **write-only**, so that ephemeral resources can be used to pass in the password.

Issue Number:

#1342 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->