### PR TITLE
[Bug Fix] - `azuredevops_serviceendpoint_azurerm` - Fix bug with serviceendpoint_azurerm when shared projectid gets mutil…

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -5,6 +5,7 @@
 package acceptancetests
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -15,7 +16,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
 // validates that an apply followed by another apply (i.e., resource update) will be reflected in AzDO and the
@@ -414,4 +419,128 @@ resource "azuredevops_serviceendpoint_azurerm" "test" {
   }
 }
 `, projectName, serviceEndpointName)
+}
+
+
+func TestAccAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
+    mainProjectID := uuid.New().String()
+    sharedProjectID1 := uuid.New().String()
+    sharedProjectID2 := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: func(s *terraform.State) error {
+			buildClient := testutils.GetProvider().Meta().(*client.AggregatedClient).ServiceEndpointClient
+			return testAccCheckAzureRMServiceEndpointDestroy(s, buildClient)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["azuredevops_serviceendpoint_azurerm.test"]
+						if !ok {
+							return fmt.Errorf("Resource not found")
+						}
+						found := false
+						for k, v := range rs.Primary.Attributes {
+							if k == "shared_project_ids.0" && v == sharedProjectID1 {
+								found = true
+								break
+							}
+						}
+						if !found {
+							return fmt.Errorf("shared_project_ids does not contain %s", sharedProjectID1)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["azuredevops_serviceendpoint_azurerm.test"]
+						if !ok {
+							return fmt.Errorf("Resource not found")
+						}
+						found := false
+						for i := 0; i < 2; i++ {
+							if rs.Primary.Attributes[fmt.Sprintf("shared_project_ids.%d", i)] == sharedProjectID1 {
+								found = true
+								break
+							}
+						}
+						if !found {
+							return fmt.Errorf("shared_project_ids does not contain %s", sharedProjectID1)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
+	sharedProjectIDsConfig := ""
+	for _, id := range sharedProjectIDs {
+		sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
+	}
+
+	return fmt.Sprintf(`
+resource "azuredevops_serviceendpoint_azurerm" "test" {
+  project_id                        = "%s"
+  azurerm_subscription_id           = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_name         = "Test Subscription"
+  azurerm_spn_tenantid              = "00000000-0000-0000-0000-000000000000"
+  service_endpoint_authentication_scheme = "ServicePrincipal"
+  credentials {
+	serviceprincipalid  = "e31eaaac-47da-4156-b433-9b0538c94b7e"
+	serviceprincipalkey = "serviceprincipalkey"
+  }
+  shared_project_ids = [%s]
+}
+`, mainProjectID, sharedProjectIDsConfig)
+}
+
+func testAccCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serviceendpoint.Client) error {
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+    for _, rs := range s.RootModule().Resources {
+        if rs.Type != "azuredevops_serviceendpoint_azurerm" {
+            continue
+        }
+
+        projectID := rs.Primary.Attributes["project_id"]
+        endpointID := rs.Primary.ID
+
+        _, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
+            Project:    converter.String(projectID),
+			EndpointId: func(id string) *uuid.UUID {
+				parsedID, err := uuid.Parse(id)
+				if err != nil {
+					panic(fmt.Sprintf("Invalid UUID: %s", id))
+				}
+				return &parsedID
+			}(endpointID),
+        })
+
+        if err == nil {
+            return fmt.Errorf("Service endpoint still exists: %s", endpointID)
+        }
+    }
+
+    return nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -292,17 +292,17 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceServiceEndpointAzureRMUpdate(d *schema.ResourceData, m interface{}) error {
-    clients := m.(*client.AggregatedClient)
-    serviceEndpoint, err := expandServiceEndpointAzureRM(d)
-    if err != nil {
-        return fmt.Errorf(errMsgTfConfigRead, err)
-    }
+	clients := m.(*client.AggregatedClient)
+	serviceEndpoint, err := expandServiceEndpointAzureRM(d)
+	if err != nil {
+		return fmt.Errorf(errMsgTfConfigRead, err)
+	}
 
-    if shouldValidate(endpointFeatures(d)) {
-        if err := validateServiceEndpoint(clients, serviceEndpoint, d.Get("project_id").(string), endpointValidationTimeoutSeconds); err != nil {
-            return err
-        }
-    }
+	if shouldValidate(endpointFeatures(d)) {
+		if err := validateServiceEndpoint(clients, serviceEndpoint, d.Get("project_id").(string), endpointValidationTimeoutSeconds); err != nil {
+			return err
+		}
+	}
     // Handle shared_project_ids updates
     if d.HasChange("shared_project_ids") {
         old, new := d.GetChange("shared_project_ids")
@@ -329,8 +329,11 @@ func resourceServiceEndpointAzureRMUpdate(d *schema.ResourceData, m interface{})
             }
         }
     }
+	if err != nil {
+		return fmt.Errorf(" updating service endpoint in Azure DevOps: %+v", err)
+	}
 
-    return resourceServiceEndpointAzureRMRead(d, m)
+	return resourceServiceEndpointAzureRMRead(d, m)
 }
 
 func resourceServiceEndpointAzureRMDelete(d *schema.ResourceData, m interface{}) error {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -200,16 +200,16 @@ func ResourceServiceEndpointAzureRM() *schema.Resource {
 }
 
 func resourceServiceEndpointAzureRMCreate(d *schema.ResourceData, m interface{}) error {
-    clients := m.(*client.AggregatedClient)
-    serviceEndpoint, err := expandServiceEndpointAzureRM(d)
-    if err != nil {
-        return fmt.Errorf(errMsgTfConfigRead, err)
-    }
+	clients := m.(*client.AggregatedClient)
+	serviceEndpoint, err := expandServiceEndpointAzureRM(d)
+	if err != nil {
+		return fmt.Errorf(errMsgTfConfigRead, err)
+	}
 
-    resp, err := createServiceEndpoint(d, clients, serviceEndpoint)
-    if err != nil {
-        return err
-    }
+	resp, err := createServiceEndpoint(d, clients, serviceEndpoint)
+	if err != nil {
+		return err
+	}
 
     serviceEndpoint.Id = resp.Id
 
@@ -224,32 +224,33 @@ func resourceServiceEndpointAzureRMCreate(d *schema.ResourceData, m interface{})
         }
     }
 
-    if shouldValidate(endpointFeatures(d)) {
-        if err := validateServiceEndpoint(clients, serviceEndpoint, d.Get("project_id").(string), endpointValidationTimeoutSeconds); err != nil {
-            if delErr := clients.ServiceEndpointClient.DeleteServiceEndpoint(
-                clients.Ctx,
-                serviceendpoint.DeleteServiceEndpointArgs{
+	serviceEndpoint.Id = resp.Id
+	if shouldValidate(endpointFeatures(d)) {
+		if err := validateServiceEndpoint(clients, serviceEndpoint, d.Get("project_id").(string), endpointValidationTimeoutSeconds); err != nil {
+			if delErr := clients.ServiceEndpointClient.DeleteServiceEndpoint(
+				clients.Ctx,
+				serviceendpoint.DeleteServiceEndpointArgs{
                     ProjectIds: &[]string{
                         (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String(),
-                    },
-                    EndpointId: resp.Id,
-                }); delErr != nil {
-                return fmt.Errorf("delete service endpoint error: %v", delErr)
-            }
-            return err
-        }
-    }
+					},
+					EndpointId: resp.Id,
+				}); delErr != nil {
+				return fmt.Errorf(" Delete service endpoint error %v", delErr)
+			}
+			return err
+		}
+	}
 
-    d.SetId(resp.Id.String())
-    return resourceServiceEndpointAzureRMRead(d, m)
+	d.SetId(resp.Id.String())
+	return resourceServiceEndpointAzureRMRead(d, m)
 }
 
 func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) error {
-    clients := m.(*client.AggregatedClient)
-    getArgs, err := serviceEndpointGetArgs(d)
-    if err != nil {
-        return err
-    }
+	clients := m.(*client.AggregatedClient)
+	getArgs, err := serviceEndpointGetArgs(d)
+	if err != nil {
+		return err
+	}
 
 	projectID := d.Get("project_id").(string)
     _, err = validateProjectID(d, projectID, m)
@@ -257,18 +258,19 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
         return fmt.Errorf("validation failed: %v", err)
     }
 	
-    serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-    if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-        return nil
-    }
-    if err != nil {
-        return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
-    }
+	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
+	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	}
 
-    if serviceEndpoint == nil || serviceEndpoint.Id == nil {
-        d.SetId("")
-        return nil
-    }
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		d.SetId("")
+		return nil
+	}
+	d.Set("features", d.Get("features"))
 
     // Populate shared_project_ids
     sharedProjectIDs := []string{}
@@ -282,11 +284,11 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 
     d.Set("features", d.Get("features"))
 
-    if err = checkServiceConnection(serviceEndpoint); err != nil {
-        return err
-    }
-    flattenServiceEndpointAzureRM(d, serviceEndpoint)
-    return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
+	}
+	flattenServiceEndpointAzureRM(d, serviceEndpoint)
+	return nil
 }
 
 func resourceServiceEndpointAzureRMUpdate(d *schema.ResourceData, m interface{}) error {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -206,12 +206,6 @@ func resourceServiceEndpointAzureRMCreate(d *schema.ResourceData, m interface{})
         return fmt.Errorf(errMsgTfConfigRead, err)
     }
 
-	projectID := d.Get("project_id").(string)
-    _, err = validateProjectID(d, projectID, m)
-    if err != nil {
-        return fmt.Errorf("validation failed: %v", err)
-    }
-
     resp, err := createServiceEndpoint(d, clients, serviceEndpoint)
     if err != nil {
         return err
@@ -257,6 +251,12 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
         return err
     }
 
+	projectID := d.Get("project_id").(string)
+    _, err = validateProjectID(d, projectID, m)
+    if err != nil {
+        return fmt.Errorf("validation failed: %v", err)
+    }
+	
     serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
     if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
         return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -567,53 +567,52 @@ func initializeFeaturesWithValidate(validate bool) []map[string]interface{} {
 }
 
 func TestAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
-    mainProjectID := uuid.New().String()
-    sharedProjectID1 := uuid.New().String()
-    sharedProjectID2 := uuid.New().String()
-
+	mainProjectID := uuid.New().String()
+	sharedProjectID1 := uuid.New().String()
+	sharedProjectID2 := uuid.New().String()
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testutils.GetProviders(),
+		Providers: testutils.GetProviders(),
 		CheckDestroy: func(s *terraform.State) error {
 			buildClient := azdosdkmocks.NewMockServiceendpointClient(gomock.NewController(t))
-			return testAccCheckAzureRMServiceEndpointDestroy(s, buildClient)
+			return testCheckAzureRMServiceEndpointDestroy(s, buildClient)
 		},
-        Steps: []resource.TestStep{
-            {
-                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
-                ),
-            },
-            {
-                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.1", sharedProjectID2),
-                ),
-            },
-            {
-                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
-                ),
-            },
-        },
-    })
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+				),
+			},
+			{
+				Config: testAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.1", sharedProjectID2),
+				),
+			},
+			{
+				Config: testAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
+				),
+			},
+		},
+	})
 }
 
 func testAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
-    sharedProjectIDsConfig := ""
-    for _, id := range sharedProjectIDs {
-        sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
-    }
+	sharedProjectIDsConfig := ""
+	for _, id := range sharedProjectIDs {
+		sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
+	}
 
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_azurerm" "test" {
   project_id                        = "%s"
   azurerm_subscription_id           = "00000000-0000-0000-0000-000000000000"
@@ -632,16 +631,16 @@ resource "azuredevops_serviceendpoint_azurerm" "test" {
 func testCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serviceendpoint.Client) error {
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
 
-    for _, rs := range s.RootModule().Resources {
-        if rs.Type != "azuredevops_serviceendpoint_azurerm" {
-            continue
-        }
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azuredevops_serviceendpoint_azurerm" {
+			continue
+		}
 
-        projectID := rs.Primary.Attributes["project_id"]
-        endpointID := rs.Primary.ID
+		projectID := rs.Primary.Attributes["project_id"]
+		endpointID := rs.Primary.ID
 
-        _, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
-            Project:    converter.String(projectID),
+		_, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
+			Project: converter.String(projectID),
 			EndpointId: func(id string) *uuid.UUID {
 				parsedID, err := uuid.Parse(id)
 				if err != nil {
@@ -649,12 +648,12 @@ func testCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serv
 				}
 				return &parsedID
 			}(endpointID),
-        })
+		})
 
-        if err == nil {
-            return fmt.Errorf("Service endpoint still exists: %s", endpointID)
-        }
-    }
+		if err == nil {
+			return fmt.Errorf("Service endpoint still exists: %s", endpointID)
+		}
+	}
 
-    return nil
+	return nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -566,7 +566,7 @@ func initializeFeaturesWithValidate(validate bool) []map[string]interface{} {
 	return features
 }
 
-func TestAccAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
+func TestAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
     mainProjectID := uuid.New().String()
     sharedProjectID1 := uuid.New().String()
     sharedProjectID2 := uuid.New().String()
@@ -607,7 +607,7 @@ func TestAccAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
     })
 }
 
-func testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
+func testAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
     sharedProjectIDsConfig := ""
     for _, id := range sharedProjectIDs {
         sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
@@ -629,7 +629,7 @@ resource "azuredevops_serviceendpoint_azurerm" "test" {
 `, mainProjectID, sharedProjectIDsConfig)
 }
 
-func testAccCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serviceendpoint.Client) error {
+func testCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serviceendpoint.Client) error {
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
 
     for _, rs := range s.RootModule().Resources {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -571,79 +571,49 @@ func TestAccAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
     sharedProjectID1 := uuid.New().String()
     sharedProjectID2 := uuid.New().String()
 
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testutils.GetProviders(),
 		CheckDestroy: func(s *terraform.State) error {
-			buildClient := testutils.GetProvider().Meta().(*client.AggregatedClient).ServiceEndpointClient
+			buildClient := azdosdkmocks.NewMockServiceendpointClient(gomock.NewController(t))
 			return testAccCheckAzureRMServiceEndpointDestroy(s, buildClient)
 		},
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
-					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources["azuredevops_serviceendpoint_azurerm.test"]
-						if !ok {
-							return fmt.Errorf("Resource not found")
-						}
-						found := false
-						for k, v := range rs.Primary.Attributes {
-							if k == "shared_project_ids.0" && v == sharedProjectID1 {
-								found = true
-								break
-							}
-						}
-						if !found {
-							return fmt.Errorf("shared_project_ids does not contain %s", sharedProjectID1)
-						}
-						return nil
-					},
-				),
-			},
-			{
-				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
-					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources["azuredevops_serviceendpoint_azurerm.test"]
-						if !ok {
-							return fmt.Errorf("Resource not found")
-						}
-						found := false
-						for i := 0; i < 2; i++ {
-							if rs.Primary.Attributes[fmt.Sprintf("shared_project_ids.%d", i)] == sharedProjectID1 {
-								found = true
-								break
-							}
-						}
-						if !found {
-							return fmt.Errorf("shared_project_ids does not contain %s", sharedProjectID1)
-						}
-						return nil
-					},
-				),
-			},
-			{
-				Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
-					resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
-				),
-			},
-		},
-	})
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+                ),
+            },
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.1", sharedProjectID2),
+                ),
+            },
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
+                ),
+            },
+        },
+    })
 }
 
 func testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
-	sharedProjectIDsConfig := ""
-	for _, id := range sharedProjectIDs {
-		sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
-	}
+    sharedProjectIDsConfig := ""
+    for _, id := range sharedProjectIDs {
+        sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
+    }
 
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_azurerm" "test" {
   project_id                        = "%s"
   azurerm_subscription_id           = "00000000-0000-0000-0000-000000000000"
@@ -651,8 +621,8 @@ resource "azuredevops_serviceendpoint_azurerm" "test" {
   azurerm_spn_tenantid              = "00000000-0000-0000-0000-000000000000"
   service_endpoint_authentication_scheme = "ServicePrincipal"
   credentials {
-	serviceprincipalid  = "e31eaaac-47da-4156-b433-9b0538c94b7e"
-	serviceprincipalkey = "serviceprincipalkey"
+    serviceprincipalid  = "e31eaaac-47da-4156-b433-9b0538c94b7e"
+    serviceprincipalkey = "serviceprincipalkey"
   }
   shared_project_ids = [%s]
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -7,12 +7,16 @@ package serviceendpoint
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/stretchr/testify/require"
@@ -560,4 +564,97 @@ func initializeFeaturesWithValidate(validate bool) []map[string]interface{} {
 	feature["validate"] = validate
 	features = append(features, feature)
 	return features
+}
+
+func TestAccAzureRMServiceEndpointSharedProjectIDs(t *testing.T) {
+    mainProjectID := uuid.New().String()
+    sharedProjectID1 := uuid.New().String()
+    sharedProjectID2 := uuid.New().String()
+
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: func(s *terraform.State) error {
+			buildClient := azdosdkmocks.NewMockServiceendpointClient(gomock.NewController(t))
+			return testAccCheckAzureRMServiceEndpointDestroy(s, buildClient)
+		},
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "1"),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+                ),
+            },
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{sharedProjectID1, sharedProjectID2}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "2"),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.0", sharedProjectID1),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.1", sharedProjectID2),
+                ),
+            },
+            {
+                Config: testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID, []string{}),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "project_id", mainProjectID),
+                    resource.TestCheckResourceAttr("azuredevops_serviceendpoint_azurerm.test", "shared_project_ids.#", "0"),
+                ),
+            },
+        },
+    })
+}
+
+func testAccAzureRMServiceEndpointSharedProjectIDsConfig(mainProjectID string, sharedProjectIDs []string) string {
+    sharedProjectIDsConfig := ""
+    for _, id := range sharedProjectIDs {
+        sharedProjectIDsConfig += fmt.Sprintf(`"%s",`, id)
+    }
+
+    return fmt.Sprintf(`
+resource "azuredevops_serviceendpoint_azurerm" "test" {
+  project_id                        = "%s"
+  azurerm_subscription_id           = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_name         = "Test Subscription"
+  azurerm_spn_tenantid              = "00000000-0000-0000-0000-000000000000"
+  service_endpoint_authentication_scheme = "ServicePrincipal"
+  credentials {
+    serviceprincipalid  = "e31eaaac-47da-4156-b433-9b0538c94b7e"
+    serviceprincipalkey = "serviceprincipalkey"
+  }
+  shared_project_ids = [%s]
+}
+`, mainProjectID, sharedProjectIDsConfig)
+}
+
+func testAccCheckAzureRMServiceEndpointDestroy(s *terraform.State, buildClient serviceendpoint.Client) error {
+	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
+
+    for _, rs := range s.RootModule().Resources {
+        if rs.Type != "azuredevops_serviceendpoint_azurerm" {
+            continue
+        }
+
+        projectID := rs.Primary.Attributes["project_id"]
+        endpointID := rs.Primary.ID
+
+        _, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
+            Project:    converter.String(projectID),
+			EndpointId: func(id string) *uuid.UUID {
+				parsedID, err := uuid.Parse(id)
+				if err != nil {
+					panic(fmt.Sprintf("Invalid UUID: %s", id))
+				}
+				return &parsedID
+			}(endpointID),
+        })
+
+        if err == nil {
+            return fmt.Errorf("Service endpoint still exists: %s", endpointID)
+        }
+    }
+
+    return nil
 }

--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -223,6 +223,8 @@ The following arguments are supported:
 
 * `server_url` - (Optional) The server URL of the service endpoint. Changing this forces a new resource to be created.
 
+* `shared_project_ids` - (Optional) list of project IDs you want the service connection shared with. 
+
 ~> **NOTE:** One of either `Subscription` scoped i.e. `azurerm_subscription_id`, `azurerm_subscription_name` or `ManagementGroup` scoped i.e. `azurerm_management_group_id`, `azurerm_management_group_name` values must be specified.
 
 * `credentials` - (Optional) A `credentials` block as defined below.


### PR DESCRIPTION
bug with serviceendpoint_azurerm  when shared projectID gets clobbered/mutilated. 

## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?
Currently there is a bug with the serviceendpoint_azurerm resource when the service connection gets shared to another project the projectid gets clobbered. this is because the value for the projectID is hardcoded to [0] and the object that this id is read from the order or IDs can change and thus break the resource. 

```
[{"projectReference":{"id":"0000-id00001","name":"Project01"},"name":"AZDO-Project01","description":"Managed by Terraform"},{"projectReference":{"id":"0000-id00002","name":"Project02"},"name":"AZDO-Project02","description":"Managed by Terraform"}]
```

if the shared projectID is alphabetically/numerically greater than the initial projectID this will cause a mismatch and thus the resource is broken. The fix takes the field, matches the specified projected of the resource and continues if successful/else fail if not match (obviously ha ha).

 This is probably an issue in all serviceendpoints that have the projectID hardcoded as [0] but in the effort of do no harm I am only targeting this resource. 
The changes 'should' be able to lift and shift however if true. 

Issue Number: NA

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Any relevant logs, error output, etc?
current error tries to delete and recreate resource since projectID changes. This is undesired since it breaks the shared service connection resource and state becomes undesirable/falsified.


Test locally, but more eyes and insight never hurt many thanks :) 