### PR TITLE
`azuredevops_serviceendpoint_github` - Add support for oauth2

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
@@ -12,18 +12,18 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
 )
 
-func TestAccServiceEndpointGitHubEnterprise_PersonalTokenBasic(t *testing.T) {
+func TestAccServiceEndpointGitHubEnterprise_personalTokenBasic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointName := testutils.GenerateResourceName()
 
 	resourceType := "azuredevops_serviceendpoint_github_enterprise"
-	tfSvcEpNode := resourceType + ".serviceendpoint"
+	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testutils.GetProviders(),
 		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: personTokenConfigBasicGithubEnterprise(projectName, serviceEndpointName),
+				Config: hclGithubEnterprisePersonTokenConfigBasic(projectName, serviceEndpointName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_personal.#", "1"),
@@ -37,20 +37,20 @@ func TestAccServiceEndpointGitHubEnterprise_PersonalTokenBasic(t *testing.T) {
 	})
 }
 
-func TestAccServiceEndpointGitHubEnterprise_PersonalTokenUpdate(t *testing.T) {
+func TestAccServiceEndpointGitHubEnterprise_personalTokenUpdate(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointNameFirst := testutils.GenerateResourceName()
 	serviceEndpointNameSecond := testutils.GenerateResourceName()
 	description := "Manage by Terraform Update"
 
 	resourceType := "azuredevops_serviceendpoint_github_enterprise"
-	tfSvcEpNode := resourceType + ".serviceendpoint"
+	tfSvcEpNode := resourceType + ".test"
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testutils.GetProviders(),
 		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: personTokenConfigBasicGithubEnterprise(projectName, serviceEndpointNameFirst),
+				Config: hclGithubEnterprisePersonTokenConfigBasic(projectName, serviceEndpointNameFirst),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_personal.#", "1"),
@@ -59,7 +59,7 @@ func TestAccServiceEndpointGitHubEnterprise_PersonalTokenUpdate(t *testing.T) {
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst),
 				),
 			}, {
-				Config: personTokenConfigUpdateGithubEnterprise(projectName, serviceEndpointNameSecond, description),
+				Config: hclGithubEnterprisePersonTokenConfigUpdate(projectName, serviceEndpointNameSecond, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_personal.#", "1"),
@@ -73,9 +73,68 @@ func TestAccServiceEndpointGitHubEnterprise_PersonalTokenUpdate(t *testing.T) {
 	})
 }
 
+func TestAccServiceEndpointGitHubEnterprise_oauthBasic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_serviceendpoint_github_enterprise"
+	tfSvcEpNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclGithubEnterpriseOauthBasic(projectName, serviceEndpointName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_oauth.#", "1"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+				),
+			},
+		},
+	})
+}
+func TestAccServiceEndpointGitHubEnterprise_oauthUpdate(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointNameFirst := testutils.GenerateResourceName()
+	serviceEndpointNameSecond := testutils.GenerateResourceName()
+	description := "Manage by Terraform Update"
+
+	resourceType := "azuredevops_serviceendpoint_github_enterprise"
+	tfSvcEpNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclGithubEnterpriseOauthBasic(projectName, serviceEndpointNameFirst),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_oauth.#", "1"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameFirst),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "description", "Managed by Terraform"),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst),
+				),
+			}, {
+				Config: hclGithubEnterpriseOauthUpdate(projectName, serviceEndpointNameSecond, description),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "auth_oauth.#", "1"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameSecond),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameSecond),
+				),
+			},
+		},
+	})
+}
+
 // validates that an apply followed by another apply (i.e., resource update) will be reflected in AzDO and the
 // underlying terraform state.
-func TestAccServiceEndpointGitHubEnterprise_CreateAndUpdate(t *testing.T) {
+func TestAccServiceEndpointGitHubEnterprise_createAndUpdate(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointNameFirst := testutils.GenerateResourceName()
 	serviceEndpointNameSecond := testutils.GenerateResourceName()
@@ -118,11 +177,11 @@ func TestAccServiceEndpointGitHubEnterprise_CreateAndUpdate(t *testing.T) {
 	})
 }
 
-func personTokenConfigBasicGithubEnterprise(projectName string, serviceEndpointName string) string {
+func hclGithubEnterprisePersonTokenConfigBasic(projectName string, serviceEndpointName string) string {
 	projectResource := testutils.HclProjectResource(projectName)
 
 	serviceEndpointResource := fmt.Sprintf(`
-resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {
+resource "azuredevops_serviceendpoint_github_enterprise" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%[1]s"
   url                   = "https://github.contoso.com"
@@ -134,16 +193,45 @@ resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
-func personTokenConfigUpdateGithubEnterprise(projectName string, serviceEndpointName string, description string) string {
+func hclGithubEnterprisePersonTokenConfigUpdate(projectName string, serviceEndpointName string, description string) string {
 	projectResource := testutils.HclProjectResource(projectName)
 
 	serviceEndpointResource := fmt.Sprintf(`
-resource "azuredevops_serviceendpoint_github_enterprise" "serviceendpoint" {
+resource "azuredevops_serviceendpoint_github_enterprise" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%[1]s"
   url                   = "https://github.contoso.com"
   auth_personal {
     personal_access_token = "test_token_update"
+  }
+  description = "%[2]s"
+}`, serviceEndpointName, description)
+
+	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
+}
+
+func hclGithubEnterpriseOauthBasic(projectName string, serviceEndpointName string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	serviceEndpointResource := fmt.Sprintf(`
+resource "azuredevops_serviceendpoint_github_enterprise" "test" {
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%[1]s"
+  auth_oauth {
+    oauth_configuration_id = "00000000-0000-0000-0000-000000000000"
+  }
+}`, serviceEndpointName)
+
+	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
+}
+
+func hclGithubEnterpriseOauthUpdate(projectName string, serviceEndpointName string, description string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	serviceEndpointResource := fmt.Sprintf(`
+resource "azuredevops_serviceendpoint_github_enterprise" "test" {
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%[1]s"
+  auth_oauth {
+    oauth_configuration_id = "00000000-0000-0000-0000-000000000000"
   }
   description = "%[2]s"
 }`, serviceEndpointName, description)

--- a/website/docs/r/serviceendpoint_github_enterprise.html.markdown
+++ b/website/docs/r/serviceendpoint_github_enterprise.html.markdown
@@ -11,6 +11,8 @@ Manages a GitHub Enterprise Server service endpoint within Azure DevOps.
 
 ## Example Usage
 
+### With token
+
 ```hcl
 resource "azuredevops_project" "example" {
   name               = "Example Project"
@@ -33,6 +35,27 @@ resource "azuredevops_serviceendpoint_github_enterprise" "example" {
 }
 ```
 
+### With OAuth 
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_serviceendpoint_github_enterprise" "example" {
+  project_id            = azuredevops_project.example.id
+  service_endpoint_name = "Example GitHub Enterprise"
+  description           = "Managed by Terraform"
+  auth_oauth {
+    oauth_configuration_id = "00000000-0000-0000-0000-000000000000"
+  }
+}
+```
+ss
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,11 +64,13 @@ The following arguments are supported:
 
 * `service_endpoint_name` - (Required) The Service Endpoint name.
 
-* `url` - (Required) GitHub Enterprise Server Url.
-
 ---
 
 * `auth_personal` - (Optional) An `auth_personal` block as documented below. Allows connecting using a personal access token.
+
+* `auth_oauth` - (Optional) An `auth_oauth` block as documented below. Allows connecting using an Oauth token.
+
+* `url` - (Optional) GitHub Enterprise Server Url.
 
 * `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
 
@@ -56,6 +81,12 @@ The following arguments are supported:
 An `auth_personal` block supports the following:
 
 * `personal_access_token` - (Required) The Personal Access Token for GitHub.
+
+---
+
+An `auth_oauth` block supports the following:
+
+* `oauth_configuration_id` - (Required) The OAuth Configuration ID.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1352 

```log
=== RUN   TestAccServiceEndpointGitHubEnterprise_personalTokenBasic
=== PAUSE TestAccServiceEndpointGitHubEnterprise_personalTokenBasic
=== RUN   TestAccServiceEndpointGitHubEnterprise_personalTokenUpdate
=== PAUSE TestAccServiceEndpointGitHubEnterprise_personalTokenUpdate
=== RUN   TestAccServiceEndpointGitHubEnterprise_oauthBasic
=== PAUSE TestAccServiceEndpointGitHubEnterprise_oauthBasic
=== RUN   TestAccServiceEndpointGitHubEnterprise_oauthUpdate
=== PAUSE TestAccServiceEndpointGitHubEnterprise_oauthUpdate
=== RUN   TestAccServiceEndpointGitHubEnterprise_createAndUpdate
=== PAUSE TestAccServiceEndpointGitHubEnterprise_createAndUpdate
=== CONT  TestAccServiceEndpointGitHubEnterprise_personalTokenBasic
=== CONT  TestAccServiceEndpointGitHubEnterprise_oauthUpdate
=== CONT  TestAccServiceEndpointGitHubEnterprise_createAndUpdate
=== CONT  TestAccServiceEndpointGitHubEnterprise_oauthBasic
=== CONT  TestAccServiceEndpointGitHubEnterprise_personalTokenUpdate
--- PASS: TestAccServiceEndpointGitHubEnterprise_oauthBasic (62.10s)
--- PASS: TestAccServiceEndpointGitHubEnterprise_personalTokenBasic (62.20s)
--- PASS: TestAccServiceEndpointGitHubEnterprise_createAndUpdate (72.35s)
--- PASS: TestAccServiceEndpointGitHubEnterprise_personalTokenUpdate (77.18s)
--- PASS: TestAccServiceEndpointGitHubEnterprise_oauthUpdate (78.20s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        79.609s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->