### PR TITLE
`azuredevops_git_repository` - Set the timeout to create timeout, customizable via timeouts in hcl

### DIFF
--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -284,7 +284,7 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if !strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Uninitialized)) {
-		err = waitForBranch(clients, repo.Name, projectID)
+		err = waitForBranch(clients, repo.Name, projectID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID fmt.Stringer) error {
+func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID fmt.Stringer, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"Waiting"},
 		Target:  []string{"Synched"},
@@ -456,7 +456,7 @@ func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID
 
 			return state, state, nil
 		},
-		Timeout:                   60 * time.Second,
+		Timeout:                   timeout,
 		MinTimeout:                2 * time.Second,
 		Delay:                     1 * time.Second,
 		ContinuousTargetOccurence: 1,


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1355 
```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_withDefaultBranch
=== PAUSE TestAccGitRepository_withDefaultBranch
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_import
=== PAUSE TestAccGitRepository_import
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== RUN   TestAccGitRepository_privateImportServiceEndpointBranchNotEmpty
    resource_git_repository_test.go:286: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepository_privateImportServiceEndpointBranchNotEmpty (0.00s)
=== RUN   TestAccGitRepository_privateUserNamePasswordImportBranchNotEmpty
    resource_git_repository_test.go:325: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepository_privateUserNamePasswordImportBranchNotEmpty (0.00s)
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_update
=== CONT  TestAccGitRepository_withDefaultBranch
=== CONT  TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_import
=== CONT  TestAccGitRepository_uninitialized
=== CONT  TestAccGitRepository_initializationClean
--- PASS: TestAccGitRepository_incorrectInitialization (16.87s)
--- PASS: TestAccGitRepository_DataSource_notExist (116.25s)
--- PASS: TestAccGitRepository_uninitialized (122.34s)
--- PASS: TestAccGitRepository_DataSource (128.82s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (129.22s)
--- PASS: TestAccGitRepository_withDefaultBranch (134.48s)
--- PASS: TestAccGitRepository_initializationClean (134.60s)
--- PASS: TestAccGitRepository_import (147.03s)
--- PASS: TestAccGitRepository_update (168.30s)
--- PASS: TestAccGitRepository_disabled (180.92s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (202.37s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        207.801s
```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->