### PR TITLE
[Bug Fix] `azuredevops_git_repository` - Fix ID not set correctly when import by name

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
@@ -177,10 +178,9 @@ func TestAccGitRepository_incorrectInitialization(t *testing.T) {
 			},
 		},
 	})
-
 }
 
-func TestAccGitRepository_import(t *testing.T) {
+func TestAccGitRepository_importGitRepository(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	gitRepoName := testutils.GenerateResourceName()
 
@@ -203,7 +203,49 @@ func TestAccGitRepository_import(t *testing.T) {
 				)},
 		},
 	})
+}
 
+func TestAccGitRepository_import_by_name(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+
+	tfRepoNode := "azuredevops_git_repository.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclGitRepositoryBasic(projectName, gitRepoName, "Clean"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfRepoNode, "is_fork"),
+					resource.TestCheckResourceAttrSet(tfRepoNode, "remote_url"),
+					resource.TestCheckResourceAttr(tfRepoNode, "initialization.#", "1"),
+					checkGitRepoExists(gitRepoName),
+				),
+			},
+			{
+				ResourceName:            tfRepoNode,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initialization"},
+				ImportStateId:           fmt.Sprintf("%s/%s", projectName, gitRepoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
+					func(state *terraform.State) error {
+						id, ok := state.RootModule().Resources["id"]
+						if !ok {
+							return fmt.Errorf(" Resource `ID` not found in state")
+						}
+						fmt.Printf(" Resource `ID` is not in UUID format. Current value: %s", id.String())
+						if err := uuid.Validate(id.String()); err != nil {
+							return fmt.Errorf(" Resource `ID` is not in UUID format. Current value: %s", id.String())
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
 }
 
 func TestAccGitRepository_initializationClean(t *testing.T) {

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -236,7 +236,6 @@ func TestAccGitRepository_import_by_name(t *testing.T) {
 						if !ok {
 							return fmt.Errorf(" Resource `ID` not found in state")
 						}
-						fmt.Printf(" Resource `ID` is not in UUID format. Current value: %s", id.String())
 						if err := uuid.Validate(id.String()); err != nil {
 							return fmt.Errorf(" Resource `ID` is not in UUID format. Current value: %s", id.String())
 						}

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -329,6 +329,9 @@ func resourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		return nil
 	}
 
+	// repository can be imported though the repository name, set the ID to UUID instead of the name
+	d.SetId(repo.Id.String())
+
 	err = flattenGitRepository(d, repo)
 	if err != nil {
 		return fmt.Errorf(" Flatten Git repository: %w", err)


### PR DESCRIPTION
- Fix ID not set correctly when import by name
- Add AccTest for import by name

Fixes: #1369

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```log
=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_withDefaultBranch
=== PAUSE TestAccGitRepository_withDefaultBranch
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_importGitRepository
=== PAUSE TestAccGitRepository_importGitRepository
=== RUN   TestAccGitRepository_import_by_name
=== PAUSE TestAccGitRepository_import_by_name
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== RUN   TestAccGitRepository_privateImportServiceEndpointBranchNotEmpty
    resource_git_repository_test.go:328: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepository_privateImportServiceEndpointBranchNotEmpty (0.00s)
=== RUN   TestAccGitRepository_privateUserNamePasswordImportBranchNotEmpty
    resource_git_repository_test.go:367: Skipping as AZDO_GENERIC_GIT_SERVICE_CONNECTION_USERNAME or AZDO_GENERIC_GIT_SERVICE_CONNECTION_PASSWORD is not specified
--- SKIP: TestAccGitRepository_privateUserNamePasswordImportBranchNotEmpty (0.00s)
=== CONT  TestAccGitRepository_DataSource
=== CONT  TestAccGitRepository_incorrectInitialization
=== CONT  TestAccGitRepository_update
=== CONT  TestAccGitRepository_initializationClean
=== CONT  TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_import_by_name
=== CONT  TestAccGitRepository_importGitRepository
=== CONT  TestAccGitRepository_withDefaultBranch
=== CONT  TestAccGitRepository_DataSource_notExist
=== CONT  TestAccGitRepository_disabled
=== CONT  TestAccGitRepository_uninitialized
--- PASS: TestAccGitRepository_incorrectInitialization (17.74s)
--- PASS: TestAccGitRepository_DataSource_notExist (123.50s)
--- PASS: TestAccGitRepository_withDefaultBranch (138.05s)
--- PASS: TestAccGitRepository_uninitialized (144.06s)
--- PASS: TestAccGitRepository_initializationClean (145.00s)
--- PASS: TestAccGitRepository_DataSource (155.16s)
--- PASS: TestAccGitRepository_importGitRepository (156.14s)
--- PASS: TestAccGitRepository_import_by_name (162.58s)
--- PASS: TestAccGitRepository_forkBranchNotEmpty (168.71s)
--- PASS: TestAccGitRepository_update (208.31s)
--- PASS: TestAccGitRepository_disabled (208.36s)
--- PASS: TestAccGitRepository_disabledCannotUpdate (260.90s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        261.848s

```

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->