### PR TITLE
fix doc links for azuredevops_git_repository and azuredevops_git_repositories

### DIFF
--- a/website/docs/d/git_repositories.html.markdown
+++ b/website/docs/d/git_repositories.html.markdown
@@ -8,7 +8,7 @@ description: |-
 # Data Source: azuredevops_git_repositories
 
 Use this data source to access information about **multiple** existing Git Repositories within Azure DevOps.
-To read informations about a **single** Git Repository use the data source [`azuredevops_git_repository`](data_git_repository.html)
+To read informations about a **single** Git Repository use the data source [`azuredevops_git_repository`](git_repository.html)
 
 ## Example Usage
 

--- a/website/docs/d/git_repository.html.markdown
+++ b/website/docs/d/git_repository.html.markdown
@@ -8,7 +8,7 @@ description: |-
 # Data Source: azuredevops_git_repository
 
 Use this data source to access information about a **single** (existing) Git Repository within Azure DevOps.
-To read information about **multiple** Git Repositories use the data source [`azuredevops_git_repositories`](data_git_repositories.html)
+To read information about **multiple** Git Repositories use the data source [`azuredevops_git_repositories`](git_repositories.html)
 
 ## Example Usage
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Current Behavior:
The link to the documentation for the `azuredevops_git_repository` data source on https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/git_repositories currently leads to a ["Page Not Found"](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/data_git_repository) error.


The link to the documentation for the `azuredevops_git_repositories` data source on 
https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/git_repository currently leads to a ["Page Not Found"](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/data_git_repositories) error.


Proposed Fix:
Update the link to point to the correct documentation for the azuredevops_git_repository and azuredevops_git_repositories source


