### PR TITLE
Test files tidy up and pass all UTs

### DIFF
--- a/azuredevops/internal/acceptancetests/data_agent_pool_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_pool_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_agent_pool) && (!exclude_data_sources || !exclude_data_agent_pool)
-// +build all data_sources data_agent_pool
-// +build !exclude_data_sources !exclude_data_agent_pool
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_agent_pools_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_pools_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_agent_pools) && (!exclude_data_sources || !exclude_data_agent_pools)
-// +build all data_sources data_agent_pools
-// +build !exclude_data_sources !exclude_data_agent_pools
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_agent_queue_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_queue_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_agent_queue) && (!exclude_data_sources || !exclude_data_agent_queue)
-// +build all data_sources data_agent_queue
-// +build !exclude_data_sources !exclude_data_agent_queue
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_area_test.go
+++ b/azuredevops/internal/acceptancetests/data_area_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_area) && (!exclude_data_sources || !exclude_data_area)
-// +build all core data_sources data_area
-// +build !exclude_data_sources !exclude_data_area
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/data_build_definition_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_build_definition) && (!exclude_data_sources || !exclude_data_build_definition)
-// +build all data_sources data_build_definition
-// +build !exclude_data_sources !exclude_data_build_definition
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_client_config_test.go
+++ b/azuredevops/internal/acceptancetests/data_client_config_test.go
@@ -1,5 +1,4 @@
 //go:build all || core
-// +build all core
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_descriptor_test.go
+++ b/azuredevops/internal/acceptancetests/data_descriptor_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_descriptor) && (!exclude_data_sources || !exclude_data_descriptor)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_environment_test.go
+++ b/azuredevops/internal/acceptancetests/data_environment_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_environment) && !exclude_data_environment
-// +build all data_environment
-// +build !exclude_data_environment
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_feed_test.go
+++ b/azuredevops/internal/acceptancetests/data_feed_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_feed) && (!exclude_data_sources || !exclude_data_feed)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_git_repositories_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repositories_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || git || data_git_repositories) && (!exclude_data_sources || !exclude_git || !exclude_data_git_repositories)
-// +build all data_sources git data_git_repositories
-// +build !exclude_data_sources !exclude_git !exclude_data_git_repositories
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repository_file_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || git || data_git_repository) && (!exclude_data_sources || !exclude_git || !data_git_repository)
-// +build all data_sources git data_git_repository
-// +build !exclude_data_sources !exclude_git !data_git_repository
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repository_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || git || data_git_repository) && (!exclude_data_sources || !exclude_git || !data_git_repository)
-// +build all data_sources git data_git_repository
-// +build !exclude_data_sources !exclude_git !data_git_repository
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_membership_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_group_membership) && (!exclude_data_sources || !exclude_data_group_membership)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
-// +build all core data_sources data_group
-// +build !exclude_data_sources !exclude_data_group
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_groups_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_groups) && (!exclude_data_sources || !exclude_data_groups)
-// +build all core data_sources data_groups
-// +build !exclude_data_sources !exclude_data_groups
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
-// +build all core data_sources data_group
-// +build !exclude_data_sources !exclude_data_group
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_groups) && (!exclude_data_sources || !exclude_data_groups)
-// +build all core data_sources data_groups
-// +build !exclude_data_sources !exclude_data_groups
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_identity_user_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_user_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_identity_user) && (!exclude_data_sources || !exclude_data_identity_user)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_iteration_test.go
+++ b/azuredevops/internal/acceptancetests/data_iteration_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_iteration) && (!exclude_data_sources || !exclude_data_iteration)
-// +build all core data_sources data_iteration
-// +build !exclude_data_sources !exclude_data_iteration
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_project_test.go
+++ b/azuredevops/internal/acceptancetests/data_project_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || resource_project || data_project) && (!exclude_data_sources || !exclude_data_project)
-// +build all core data_sources resource_project data_project
-// +build !exclude_data_sources !exclude_data_project
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_projects_test.go
+++ b/azuredevops/internal/acceptancetests/data_projects_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || resource_project || data_projects) && (!data_sources || !exclude_data_projects)
-// +build all core data_sources resource_project data_projects
-// +build !data_sources !exclude_data_projects
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_securityrole_definitions_test.go
+++ b/azuredevops/internal/acceptancetests/data_securityrole_definitions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_securityrole_definitions) && (!data_sources || !exclude_data_securityrole_definitions)
-// +build all core data_sources data_securityrole_definitions
-// +build !data_sources !exclude_data_securityrole_definitions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_service_principal_test.go
+++ b/azuredevops/internal/acceptancetests/data_service_principal_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_service_principal) && (!exclude_data_sources || !exclude_data_service_principal)
-// +build all core data_sources data_service_principal
-// +build !exclude_data_sources !exclude_data_service_principal
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurecr_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_azurecr) && (!exclude_data_sources || !exclude_data_serviceendpoint_azurecr)
-// +build all data_sources data_serviceendpoint_azurecr
-// +build !exclude_data_sources !exclude_data_serviceendpoint_azurecr
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_azurerm) && (!exclude_data_sources || !exclude_data_serviceendpoint_azurerm)
-// +build all data_sources data_serviceendpoint_azurerm
-// +build !exclude_data_sources !exclude_data_serviceendpoint_azurerm
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_bitbucket_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_github) && (!exclude_data_sources || !exclude_data_serviceendpoint_github)
-// +build all data_sources data_serviceendpoint_github
-// +build !exclude_data_sources !exclude_data_serviceendpoint_github
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_dockerregistry_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_serviceendpoint_dockerregistry) && (!exclude_data_sources || !exclude_data_serviceendpoint_dockerregistry)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_github) && (!exclude_data_sources || !exclude_data_serviceendpoint_github)
-// +build all data_sources data_serviceendpoint_github
-// +build !exclude_data_sources !exclude_data_serviceendpoint_github
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_npm_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_npm) && (!exclude_data_sources || !exclude_data_serviceendpoint_npm)
-// +build all data_sources data_serviceendpoint_npm
-// +build !exclude_data_sources !exclude_data_serviceendpoint_npm
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_sonarcloud_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_sonarcloud_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_serviceendpoint_sonarcloud) && (!exclude_data_sources || !exclude_data_serviceendpoint_sonarcloud)
-// +build all data_sources data_serviceendpoint_sonarcloud
-// +build !exclude_data_sources !exclude_data_serviceendpoint_sonarcloud
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_storage_key_test.go
+++ b/azuredevops/internal/acceptancetests/data_storage_key_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_storage_key) && (!exclude_data_sources || !exclude_data_storage_key)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_team_test.go
+++ b/azuredevops/internal/acceptancetests/data_team_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_team) && (!exclude_data_sources || !exclude_data_team)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_teams_test.go
+++ b/azuredevops/internal/acceptancetests/data_teams_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_teams) && (!exclude_data_sources || !exclude_data_teams)
-// +build all core data_sources data_teams
-// +build !exclude_data_sources !exclude_data_teams
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/data_user_test.go
+++ b/azuredevops/internal/acceptancetests/data_user_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_user) && (!exclude_data_sources || !exclude_data_user)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -1,3 +1,5 @@
+//go:build (all || data_sources || data_users) && (!exclude_data_sources || !exclude_data_users)
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_variable_group_test.go
@@ -1,6 +1,4 @@
 //go:build (all || data_sources || data_variable_group) && (!exclude_data_sources || !exclude_data_variable_group)
-// +build all data_sources data_variable_group
-// +build !exclude_data_sources !exclude_data_variable_group
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_agent_pool_test.go
+++ b/azuredevops/internal/acceptancetests/resource_agent_pool_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_agentpool) && !exclude_resource_agentpool
-// +build all resource_agentpool
-// +build !exclude_resource_agentpool
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
+++ b/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_agent_queue) && !exclude_resource_agent_queue
-// +build all resource_agent_queue
-// +build !exclude_resource_agent_queue
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_area_permissions) && (!exclude_permissions || !exclude_resource_area_permissions)
-// +build all permissions resource_area_permissions
-// +build !exclude_permissions !exclude_resource_area_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_auto_reviewers_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_auto_reviewers_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_branchpolicy_auto_reviewers) && !exclude_resource_branchpolicy_auto_reviewers
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_build_validation_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_build_validation_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_branchpolicy_build_validation) && !exclude_resource_branchpolicy_build_validation
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_comment_resolution_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_comment_resolution_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_branchpolicy_comment_resolution) && !exclude_resource_branchpolicy_comment_resolution
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_merge_types_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_merge_types_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_branchpolicy_merge_types) && !exclude_resource_branchpolicy_merge_types
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_branchpolicy_min_reviewer_acceptance_test || policy) && (!exclude_resource_branchpolicy_min_reviewer_acceptance_test || !exclude_policy)
-// +build all resource_branchpolicy_min_reviewer_acceptance_test policy
-// +build !exclude_resource_branchpolicy_min_reviewer_acceptance_test !exclude_policy
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_branchpolicy_status_check_acceptance_test || policy) && (!exclude_resource_branchpolicy_status_check_acceptance_test || !exclude_policy)
-// +build all resource_branchpolicy_status_check_acceptance_test policy
-// +build !exclude_resource_branchpolicy_status_check_acceptance_test !exclude_policy
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_work_item_linking_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_work_item_linking_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_branchpolicy_work_item_linking) && !exclude_resource_branchpolicy_work_item_linking
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_build_definition_permissions) && (!exclude_permissions || !exclude_resource_build_definition_permissions)
-// +build all permissions resource_build_definition_permissions
-// +build !exclude_permissions !exclude_resource_build_definition_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_build_definition) && !exclude_resource_build_definition
-// +build all resource_build_definition
-// +build !exclude_resource_build_definition
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_build_Folder_permissions) && (!exclude_permissions || !exclude_resource_build_Folder_permissions)
-// +build all permissions resource_build_Folder_permissions
-// +build !exclude_permissions !exclude_resource_build_Folder_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_build_folder_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_build_folder) && (!exclude_permissions || !exclude_resource_build_folder)
-// +build all resource_build_folder
-// +build !exclude_permissions !exclude_resource_build_folder
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_approval_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_approval_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-// +build all resource_check_branch_control
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-// +build all resource_check_branch_control
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_business_hours) && !exclude_approvalsandchecks
-// +build all resource_check_business_hours
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_common_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_common_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-// +build all resource_check_branch_control
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_exclusive_lock) && !exclude_approvalsandchecks
-// +build all resource_check_exclusive_lock
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_required_template) && !exclude_approvalsandchecks
-// +build all resource_check_required_template
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_check_rest_api) && !exclude_resource_check_rest_api
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_dashboard_test.go
+++ b/azuredevops/internal/acceptancetests/resource_dashboard_test.go
@@ -267,7 +267,7 @@ func checkDashboardDestroyed(s *terraform.State) error {
 		id := resource.Primary.ID
 		dashboardId, err := uuid.Parse(id)
 		if err != nil {
-			return fmt.Errorf(" Parsing dashboard ID: %+v", err)
+			return fmt.Errorf("Parsing dashboard ID: %+v", err)
 		}
 
 		args := dashboard.GetDashboardArgs{
@@ -280,7 +280,7 @@ func checkDashboardDestroyed(s *terraform.State) error {
 		}
 		// indicates the project still exists - this should fail the test
 		if _, err = clients.DashboardClient.GetDashboard(clients.Ctx, args); err == nil {
-			return fmt.Errorf(" Dashboard with ID %s should not exist", id)
+			return fmt.Errorf("Dashboard with ID %s should not exist", id)
 		}
 	}
 	return nil
@@ -290,7 +290,7 @@ func checkDashboardExist(expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_dashboard.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a `azuredevops_dashboard` in the Terraform state")
+			return fmt.Errorf("Did not find a `azuredevops_dashboard` in the Terraform state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -298,7 +298,7 @@ func checkDashboardExist(expectedName string) resource.TestCheckFunc {
 		id := res.Primary.ID
 		dashboardId, err := uuid.Parse(id)
 		if err != nil {
-			return fmt.Errorf(" Parsing dashboard ID %s", id)
+			return fmt.Errorf("Parsing dashboard ID %s", id)
 		}
 
 		args := dashboard.GetDashboardArgs{
@@ -313,11 +313,11 @@ func checkDashboardExist(expectedName string) resource.TestCheckFunc {
 		resp, err := clients.DashboardClient.GetDashboard(clients.Ctx, args)
 
 		if err != nil {
-			return fmt.Errorf(" Dashboard with ID: %s cannot be found!. Error: %v", id, err)
+			return fmt.Errorf("Dashboard with ID: %s cannot be found!. Error: %v", id, err)
 		}
 
 		if *resp.Name != expectedName {
-			return fmt.Errorf(" Dashboard with ID: %s has Name: %s, but expected Name: %s", id, *resp.Name, expectedName)
+			return fmt.Errorf("Dashboard with ID: %s has Name: %s, but expected Name: %s", id, *resp.Name, expectedName)
 		}
 		return nil
 	}
@@ -332,7 +332,7 @@ func importDashboardId(resourceType string) resource.ImportStateIdFunc {
 			}
 			return fmt.Sprintf("%s/%s", projectId, res.Primary.ID), nil
 		}
-		return "", fmt.Errorf(" Not found: %s", resourceType)
+		return "", fmt.Errorf("Not found: %s", resourceType)
 	}
 }
 

--- a/azuredevops/internal/acceptancetests/resource_dashboard_test.go
+++ b/azuredevops/internal/acceptancetests/resource_dashboard_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_dashboard) && !exclude_resource_dashboard
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_elastic_pool_test.go
+++ b/azuredevops/internal/acceptancetests/resource_elastic_pool_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_elasticpool) && !exclude_resource_elasticpool
-// +build all resource_elasticpool
-// +build !exclude_resource_elasticpool
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_environment_resource_kubernetes) && !exclude_resource_environment_resource_kubernetes
-// +build all resource_environment_resource_kubernetes
-// +build !exclude_resource_environment_resource_kubernetes
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
@@ -57,7 +57,7 @@ func checkEnvironmentKubernetesExists(tfNode string, expectedName string) resour
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources[tfNode]
 		if !ok {
-			return fmt.Errorf(" Did not find an resource in the TF state")
+			return fmt.Errorf("Did not find an resource in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -74,11 +74,11 @@ func checkEnvironmentKubernetesExists(tfNode string, expectedName string) resour
 
 		readResource, err := readEnvironmentKubernetes(clients, projectId, environmentId, id)
 		if err != nil {
-			return fmt.Errorf(" Resource with ID=%d cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Resource with ID=%d cannot be found!. Error=%v", id, err)
 		}
 
 		if *readResource.Name != expectedName {
-			return fmt.Errorf(" Resource with ID=%d has Name=%s, but expected Name=%s", id, *readResource.Name, expectedName)
+			return fmt.Errorf("Resource with ID=%d has Name=%s, but expected Name=%s", id, *readResource.Name, expectedName)
 		}
 		return nil
 	}
@@ -108,7 +108,7 @@ func checkEnvironmentKubernetesDestroyed(s *terraform.State) error {
 
 		// indicates the environment still exists - this should fail the test
 		if _, err := readEnvironmentKubernetes(clients, projectId, environmentId, id); err == nil {
-			return fmt.Errorf(" Resource ID %d should not exist", id)
+			return fmt.Errorf("Resource ID %d should not exist", id)
 		}
 	}
 	return nil

--- a/azuredevops/internal/acceptancetests/resource_environment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_environment) && !exclude_resource_environment
-// +build all resource_environment
-// +build !exclude_resource_environment
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_extension_test.go
+++ b/azuredevops/internal/acceptancetests/resource_extension_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_extension) && !exclude_resource_extension
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_extension_test.go
+++ b/azuredevops/internal/acceptancetests/resource_extension_test.go
@@ -193,7 +193,7 @@ func checkExtensionDestroyed(s *terraform.State) error {
 		})
 
 		if err == nil {
-			return fmt.Errorf(" Extension with Publisher ID=%s , Extension ID: %s should not exist", ids[0], ids[1])
+			return fmt.Errorf("Extension with Publisher ID=%s , Extension ID: %s should not exist", ids[0], ids[1])
 		}
 	}
 	return nil
@@ -203,7 +203,7 @@ func checkExtensionExist(expectedExtensionId string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_extension.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find `azuredevops_extension` in the TF state")
+			return fmt.Errorf("Did not find `azuredevops_extension` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -215,11 +215,11 @@ func checkExtensionExist(expectedExtensionId string) resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Extension with Publisher ID=%s , Extension ID: %s cannot be found!. Error=%v", ids[0], ids[1], err)
+			return fmt.Errorf("Extension with Publisher ID=%s , Extension ID: %s cannot be found!. Error=%v", ids[0], ids[1], err)
 		}
 
 		if *extension.ExtensionId != expectedExtensionId {
-			return fmt.Errorf(" Extension with Publisher ID=%s has Extension ID=%s, but expected Extension ID=%s", *extension.PublisherId, *extension.ExtensionId, expectedExtensionId)
+			return fmt.Errorf("Extension with Publisher ID=%s has Extension ID=%s, but expected Extension ID=%s", *extension.PublisherId, *extension.ExtensionId, expectedExtensionId)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || data_sources || data_feed) && (!data_sources || !exclude_feed)
-// +build all core data_sources data_feed
-// +build !data_sources !exclude_feed
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
@@ -81,7 +81,7 @@ func checkFeedPermissionDestroyed(s *terraform.State) error {
 
 		if err == nil {
 			if permissions != nil && len(*permissions) > 0 {
-				return fmt.Errorf(" Feed permissions (Feed ID: %s) should not exist", id)
+				return fmt.Errorf("Feed permissions (Feed ID: %s) should not exist", id)
 			}
 		}
 	}
@@ -92,7 +92,7 @@ func CheckFeedPermissionExist() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_feed_permission.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a `azuredevops_feed_permission` in the TF state")
+			return fmt.Errorf("Did not find a `azuredevops_feed_permission` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -105,7 +105,7 @@ func CheckFeedPermissionExist() resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Feed permissions with Feed ( Feed ID=%s ) cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Feed permissions with Feed ( Feed ID=%s ) cannot be found!. Error=%v", id, err)
 		}
 
 		return nil

--- a/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_feed_retention_policy) && !exclude_resource_feed_retention_policy
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
@@ -187,7 +187,7 @@ func checkFeedRetentionPolicyDestroyed(s *terraform.State) error {
 
 		if err == nil {
 			if policy != nil && (policy.CountLimit != nil || policy.DaysToKeepRecentlyDownloadedPackages != nil) {
-				return fmt.Errorf(" Feed Retention Policy (Feed ID: %s) should not exist", id)
+				return fmt.Errorf("Feed Retention Policy (Feed ID: %s) should not exist", id)
 			}
 		}
 	}
@@ -198,7 +198,7 @@ func CheckFeedRetentionPolicyExist(expectedCountLimit int) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_feed_retention_policy.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a `azuredevops_feed_retention_policy` in the TF state")
+			return fmt.Errorf("Did not find a `azuredevops_feed_retention_policy` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -211,11 +211,11 @@ func CheckFeedRetentionPolicyExist(expectedCountLimit int) resource.TestCheckFun
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Feed Retention Policy with Feed ( Feed ID=%s ) cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Feed Retention Policy with Feed ( Feed ID=%s ) cannot be found!. Error=%v", id, err)
 		}
 
 		if *policy.CountLimit != expectedCountLimit {
-			return fmt.Errorf(" Feed Retention Policy with ( Feed ID=%s ) has CountLimit=%d, but expected CountLimit=%d", id, *policy.CountLimit, expectedCountLimit)
+			return fmt.Errorf("Feed Retention Policy with ( Feed ID=%s ) has CountLimit=%d, but expected CountLimit=%d", id, *policy.CountLimit, expectedCountLimit)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_feed_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_feed) && !exclude_resource_feed
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_feed_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_test.go
@@ -141,7 +141,7 @@ func checkFeedDestroyed(s *terraform.State) error {
 			Project: &projectID,
 		})
 		if err == nil {
-			return fmt.Errorf(" Feed (Feed ID: %s) should not exist", id)
+			return fmt.Errorf("Feed (Feed ID: %s) should not exist", id)
 		}
 	}
 	return nil
@@ -151,7 +151,7 @@ func CheckFeedExist(expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_feed.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find `azuredevops_feed` in the TF state")
+			return fmt.Errorf("Did not find `azuredevops_feed` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -164,11 +164,11 @@ func CheckFeedExist(expectedName string) resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Feed with ID=%s cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Feed with ID=%s cannot be found!. Error=%v", id, err)
 		}
 
 		if *feeds.Name != expectedName {
-			return fmt.Errorf(" Feed with ID=%s has Name=%s, but expected Name=%s", id, *feeds.Name, expectedName)
+			return fmt.Errorf("Feed with ID=%s has Name=%s, but expected Name=%s", id, *feeds.Name, expectedName)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
@@ -107,7 +107,7 @@ func CheckGitPermissionProjectExists(expectedName string) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources["azuredevops_project.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a project in the TF state")
+			return fmt.Errorf("Did not find a project in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -119,11 +119,11 @@ func CheckGitPermissionProjectExists(expectedName string) resource.TestCheckFunc
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Project with ID=%s cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Project with ID=%s cannot be found!. Error=%v", id, err)
 		}
 
 		if *project.Name != expectedName {
-			return fmt.Errorf(" Project with ID=%s has Name=%s, but expected Name=%s", id, *project.Name, expectedName)
+			return fmt.Errorf("Project with ID=%s has Name=%s, but expected Name=%s", id, *project.Name, expectedName)
 		}
 
 		return nil

--- a/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_git_permissions) && (!exclude_permissions || !exclude_resource_git_permissions)
-// +build all permissions resource_git_permissions
-// +build !exclude_permissions !exclude_resource_git_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_git_repository_branch) && !exclude_resource_git_repository_branch
-// +build all core resource_git_repository_branch
-// +build !exclude_resource_git_repository_branch
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -128,13 +128,13 @@ func checkRepositoryBranchExist(expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_git_repository_branch.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find `azuredevops_git_repository_branch` in the TF state")
+			return fmt.Errorf("Did not find `azuredevops_git_repository_branch` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
 		repoId, branchName, err := tfhelper.ParseGitRepoBranchID(res.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parse resource IDs: %w", err)
+			return fmt.Errorf("Parse resource IDs: %w", err)
 		}
 
 		branch, err := clients.GitReposClient.GetBranch(clients.Ctx, git.GetBranchArgs{
@@ -143,11 +143,11 @@ func checkRepositoryBranchExist(expectedName string) resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Repositroy: %s, Branch: %s cannot be found. Error=%v", repoId, branchName, err)
+			return fmt.Errorf("Repositroy: %s, Branch: %s cannot be found. Error=%v", repoId, branchName, err)
 		}
 
 		if *branch.Name != expectedName {
-			return fmt.Errorf(" Branch Name=%s, but expected Name=%s", *branch.Name, expectedName)
+			return fmt.Errorf("Branch Name=%s, but expected Name=%s", *branch.Name, expectedName)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_git_repository_file) && !exclude_resource_git_repository_file
-// +build all core resource_git_repository_file
-// +build !exclude_resource_git_repository_file
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -192,7 +192,7 @@ func repositoryFileIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return "", fmt.Errorf(" Resource node not found: %s", resourceName)
+			return "", fmt.Errorf("Resource node not found: %s", resourceName)
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["repository_id"], rs.Primary.Attributes["file"]), nil
 	}
@@ -204,7 +204,7 @@ func checkGitRepoFileNotExists(fileName string) resource.TestCheckFunc {
 
 		repo, ok := s.RootModule().Resources["azuredevops_git_repository.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a repo definition in the TF state")
+			return fmt.Errorf("Did not find a repo definition in the TF state")
 		}
 
 		ctx := context.Background()
@@ -226,7 +226,7 @@ func checkGitRepoFileContent(expectedContent string) resource.TestCheckFunc {
 
 		gitFile, ok := s.RootModule().Resources["azuredevops_git_repository_file.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a repo definition in the TF state")
+			return fmt.Errorf("Did not find a repo definition in the TF state")
 		}
 
 		fileID := gitFile.Primary.ID

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -232,10 +232,10 @@ func TestAccGitRepository_import_by_name(t *testing.T) {
 					func(state *terraform.State) error {
 						id, ok := state.RootModule().Resources["id"]
 						if !ok {
-							return fmt.Errorf(" Resource `ID` not found in state")
+							return fmt.Errorf("Resource `ID` not found in state")
 						}
 						if err := uuid.Validate(id.String()); err != nil {
-							return fmt.Errorf(" Resource `ID` is not in UUID format. Current value: %s", id.String())
+							return fmt.Errorf("Resource `ID` is not in UUID format. Current value: %s", id.String())
 						}
 						return nil
 					},
@@ -404,7 +404,7 @@ func checkGitRepoExists(expectedName string) resource.TestCheckFunc {
 
 		gitRepo, ok := s.RootModule().Resources["azuredevops_git_repository.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a repo definition in the TF state")
+			return fmt.Errorf("Did not find a repo definition in the TF state")
 		}
 
 		repoID := gitRepo.Primary.ID
@@ -416,7 +416,7 @@ func checkGitRepoExists(expectedName string) resource.TestCheckFunc {
 		}
 
 		if *repo.Name != expectedName {
-			return fmt.Errorf(" AzDO Git Repository has Name=%s, but expected Name=%s", *repo.Name, expectedName)
+			return fmt.Errorf("AzDO Git Repository has Name=%s, but expected Name=%s", *repo.Name, expectedName)
 		}
 
 		return nil

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_git_repository) && !exclude_resource_git_repository
-// +build all core resource_git_repository
-// +build !exclude_resource_git_repository
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_group_entitlement) && !exclude_resource_group_entitlement
-// +build all resource_group_entitlement
-// +build !exclude_resource_group_entitlement
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
@@ -63,13 +63,13 @@ func checkGroupEntitlementExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources["azuredevops_group_entitlement.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a GroupEntitlement in the TF state")
+			return fmt.Errorf("Did not find a GroupEntitlement in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing GroupEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing GroupEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		groupEntitlement, err := clients.MemberEntitleManagementClient.GetGroupEntitlement(clients.Ctx, memberentitlementmanagement.GetGroupEntitlementArgs{
@@ -81,7 +81,7 @@ func checkGroupEntitlementExists() resource.TestCheckFunc {
 		}
 
 		if groupEntitlement == nil || groupEntitlement.Id == nil {
-			return fmt.Errorf(" GroupEntitlement with ID=%s cannot be found.", id)
+			return fmt.Errorf("GroupEntitlement with ID=%s cannot be found.", id)
 		}
 
 		return nil
@@ -101,7 +101,7 @@ func checkGroupEntitlementDestroyed(s *terraform.State) error {
 
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing GroupEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing GroupEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		groupEntitlement, err := clients.MemberEntitleManagementClient.GetGroupEntitlement(clients.Ctx, memberentitlementmanagement.GetGroupEntitlementArgs{
@@ -116,7 +116,7 @@ func checkGroupEntitlementDestroyed(s *terraform.State) error {
 		}
 
 		if groupEntitlement != nil && groupEntitlement.LicenseRule != nil && string(*groupEntitlement.LicenseRule.Status) != "none" {
-			return fmt.Errorf(" Status should be none : %s with readGroupEntitlement error %v", string(*groupEntitlement.LicenseRule.Status), err)
+			return fmt.Errorf("Status should be none : %s with readGroupEntitlement error %v", string(*groupEntitlement.LicenseRule.Status), err)
 		}
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_membership_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_group_membership) && !exclude_resource_group_membership
-// +build all core resource_group_membership
-// +build !exclude_resource_group_membership
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_test.go
@@ -158,7 +158,7 @@ func checkGroupExists(expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		varGroup, ok := s.RootModule().Resources["azuredevops_group.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a group resource in the TF state")
+			return fmt.Errorf("Did not find a group resource in the TF state")
 		}
 
 		getGroupArgs := graph.GetGroupArgs{
@@ -170,10 +170,10 @@ func checkGroupExists(expectedName string) resource.TestCheckFunc {
 			return err
 		}
 		if group == nil {
-			return fmt.Errorf(" Group with Name=%s does not exit", varGroup.Primary.Attributes["display_name"])
+			return fmt.Errorf("Group with Name=%s does not exit", varGroup.Primary.Attributes["display_name"])
 		}
 		if *group.DisplayName != expectedName {
-			return fmt.Errorf(" Group has Name=%s, but expected %s", *group.DisplayName, expectedName)
+			return fmt.Errorf("Group has Name=%s, but expected %s", *group.DisplayName, expectedName)
 		}
 
 		return nil
@@ -198,7 +198,7 @@ func checkGroupDestroyed(s *terraform.State) error {
 			if utils.ResponseWasNotFound(err) {
 				return nil
 			}
-			return fmt.Errorf(" Group with ID %s should not exist in scope %s", id, resource.Primary.Attributes["scope"])
+			return fmt.Errorf("Group with ID %s should not exist in scope %s", id, resource.Primary.Attributes["scope"])
 		}
 
 	}

--- a/azuredevops/internal/acceptancetests/resource_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_group) && !exclude_resource_group
-// +build all core resource_group
-// +build !exclude_resource_group
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_iteration_permissions) && (!exclude_permissions || !exclude_resource_iteration_permissions)
-// +build all permissions resource_iteration_permissions
-// +build !exclude_permissions !exclude_resource_iteration_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_library_permissions) && (!exclude_permissions || !exclude_resource_library_permissions)
-// +build all permissions resource_library_permissions
-// +build !exclude_permissions !exclude_resource_library_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
@@ -1,6 +1,4 @@
 //go:build (all || pipeline_authorization) && !exclude_pipeline_authorization
-// +build all pipeline_authorization
-// +build !exclude_pipeline_authorization
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_project_features_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_features_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_project || resource_project_features) && !exclude_resource_project_features
-// +build all core resource_project resource_project_features
-// +build !exclude_resource_project_features
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_project_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_project_permissions) && (!exclude_permissions || !exclude_resource_project_permissions)
-// +build all permissions resource_project_permissions
-// +build !exclude_permissions !exclude_resource_project_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_project || resource_project_features) && !exclude_resource_project_features
-// +build all core resource_project resource_project_features
-// +build !exclude_resource_project_features
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_project_tags_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_tags_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_project_tags) && !exclude_resource_project_tags
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_tags_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_tags_test.go
@@ -118,11 +118,11 @@ func checkProjectTagsDestroyed(s *terraform.State) error {
 			if utils.ResponseWasNotFound(err) {
 				return nil
 			}
-			return fmt.Errorf(" Get project Tags (Project ID: %s). Error: %+v", id, err)
+			return fmt.Errorf("Get project Tags (Project ID: %s). Error: %+v", id, err)
 		}
 
 		if tags != nil && len(*tags) != 0 {
-			return fmt.Errorf(" Project Tags (Project ID: %s) should not exist", id)
+			return fmt.Errorf("Project Tags (Project ID: %s) should not exist", id)
 		}
 	}
 	return nil
@@ -132,7 +132,7 @@ func CheckProjectTagsExist() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		res, ok := s.RootModule().Resources["azuredevops_project_tags.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a `azuredevops_project_tags` in the TF state")
+			return fmt.Errorf("Did not find a `azuredevops_project_tags` in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -148,7 +148,7 @@ func CheckProjectTagsExist() resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Project Tags with Project ( Project ID=%s ) not found!. Error=%v", id, err)
+			return fmt.Errorf("Project Tags with Project ( Project ID=%s ) not found!. Error=%v", id, err)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_project_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_test.go
@@ -212,7 +212,7 @@ func checkProjectExists(expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		state, ok := s.RootModule().Resources["azuredevops_project.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a project in the TF state")
+			return fmt.Errorf("Did not find a project in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
@@ -224,11 +224,11 @@ func checkProjectExists(expectedName string) resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Project with ID=%s cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("Project with ID=%s cannot be found!. Error=%v", id, err)
 		}
 
 		if *project.Name != expectedName {
-			return fmt.Errorf(" Project with ID=%s has Name=%s, but expected Name=%s", id, *project.Name, expectedName)
+			return fmt.Errorf("Project with ID=%s has Name=%s, but expected Name=%s", id, *project.Name, expectedName)
 		}
 
 		return nil
@@ -238,12 +238,12 @@ func checkProjectExists(expectedName string) resource.TestCheckFunc {
 func checkImportProject() resource.ImportStateCheckFunc {
 	return func(states []*terraform.InstanceState) error {
 		if len(states) != 1 {
-			return fmt.Errorf(" Expected project imported but not found in the state.")
+			return fmt.Errorf("Expected project imported but not found in the state.")
 		}
 		state := states[0]
 		projectId := state.ID
 		if err := uuid.Validate(projectId); err != nil {
-			return fmt.Errorf(" Project ID should be a valid UUID. Got: %s", projectId)
+			return fmt.Errorf("Project ID should be a valid UUID. Got: %s", projectId)
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_project_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_project) && !exclude_resource_project
-// +build all core resource_project
-// +build !exclude_resource_project
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_author_email_patterns_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_author_email_patterns_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_repositorypolicy_author_email_patterns) && !resource_repositorypolicy_author_email_patterns
-// +build all resource_repositorypolicy_author_email_patterns
-// +build !resource_repositorypolicy_author_email_patterns
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_case_enforcement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_case_enforcement_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_policy_case_enforcement) && !resource_policy_case_enforcement
-// +build all resource_policy_case_enforcement
-// +build !resource_policy_case_enforcement
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_check_credentials_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_check_credentials_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_policy_check_credentials) && !resource_policy_check_credentials
-// +build all resource_policy_check_credentials
-// +build !resource_policy_check_credentials
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_path_patterns_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_path_patterns_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_repositorypolicy_file_path_patterns) && !exclude_resource_repositorypolicy_file_path_patterns
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_reserved_names_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_reserved_names_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_policy_reserved_names) && !resource_policy_reserved_names
-// +build all resource_policy_reserved_names
-// +build !resource_policy_reserved_names
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_file_size_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_file_size_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_policy_file_size) && !resource_policy_file_size
-// +build all resource_policy_file_size
-// +build !resource_policy_file_size
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_path_length_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_path_length_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_policy_path_lenght) && !resource_policy_path_lenght
-// +build all resource_policy_path_lenght
-// +build !resource_policy_path_lenght
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_resource_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_resource_authorization_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_authorization) && !exclude_resource_authorization
-// +build all resource_authorization
-// +build !exclude_resource_authorization
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_securityrole_assignment) && !exclude_resource_securityrole_assignment
-// +build all core resource_securityrole_assignment
-// +build !exclude_resource_securityrole_assignment
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
@@ -46,13 +46,13 @@ func checkServicePrincipalEntitlementExists(expectedServicePrincipalId string) r
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources["azuredevops_service_principal_entitlement.service_principal"]
 		if !ok {
-			return fmt.Errorf(" Did not find a ServicePrincipalEntitlement in the TF state")
+			return fmt.Errorf("Did not find a ServicePrincipalEntitlement in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing ServicePrincipalEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing ServicePrincipalEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		servicePrincipalEntitlement, err := clients.MemberEntitleManagementClient.GetServicePrincipalEntitlement(clients.Ctx, memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
@@ -60,7 +60,7 @@ func checkServicePrincipalEntitlementExists(expectedServicePrincipalId string) r
 		})
 
 		if err != nil {
-			return fmt.Errorf(" ServicePrincipalEntitlement with ID=%s cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("ServicePrincipalEntitlement with ID=%s cannot be found!. Error=%v", id, err)
 		}
 
 		if !strings.EqualFold(strings.ToLower(*servicePrincipalEntitlement.ServicePrincipal.OriginId), strings.ToLower(expectedServicePrincipalId)) {
@@ -84,7 +84,7 @@ func checkServicePrincipalEntitlementDestroyed(s *terraform.State) error {
 
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing ServicePrincipalEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing ServicePrincipalEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		servicePrincipalEntitlement, err := clients.MemberEntitleManagementClient.GetServicePrincipalEntitlement(clients.Ctx, memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
@@ -99,7 +99,7 @@ func checkServicePrincipalEntitlementDestroyed(s *terraform.State) error {
 		}
 
 		if servicePrincipalEntitlement != nil && servicePrincipalEntitlement.AccessLevel != nil && string(*servicePrincipalEntitlement.AccessLevel.Status) != "none" {
-			return fmt.Errorf(" Status should be none : %s with readServicePrincipalEntitlement error %v", string(*servicePrincipalEntitlement.AccessLevel.Status), err)
+			return fmt.Errorf("Status should be none : %s with readServicePrincipalEntitlement error %v", string(*servicePrincipalEntitlement.AccessLevel.Status), err)
 		}
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_service_principal_entitlement) && !exclude_resource_service_principal_entitlement
-// +build all resource_service_principal_entitlement
-// +build !exclude_resource_service_principal_entitlement
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_argocd) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_argocd
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_artifactory) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_artifactory
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_aws) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_aws
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azure_service_bus_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azure_service_bus_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_azure_service_bus) && !exclude_resource_serviceendpoint_azure_service_bus
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_azurecr) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_azurecr
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_azuredevops) && !resource_serviceendpoint_azuredevops
-// +build all resource_serviceendpoint_azuredevops
-// +build !resource_serviceendpoint_azuredevops
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_azurerm) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_azurerm
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_bitbucket) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_bitbucket
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_black_duck_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_black_duck_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_black_duck) && !exclude_resource_serviceendpoint_black_duck
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_checkmarx_one) && !exclude_resource_serviceendpoint_checkmarx_one
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sast_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sast_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_checkmarx_sast) && !exclude_resource_serviceendpoint_checkmarx_sast
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sca_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sca_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_checkmarx_sca) && !exclude_resource_serviceendpoint_checkmarx_sca
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_dockerregistry_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_dockerregistry) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_dockerregistry
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_dynamic_lifecycle_services_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_dynamic_lifecycle_services_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_dynamic_lifecycle_services) && !exclude_resource_serviceendpoint_dynamic_lifecycle_services
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_externaltfs_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_externaltfs_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_externaltfs) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_externaltfs
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_gcp_terraform_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_gcp_terraform_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_gcp_terraform) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_gcp_terraform
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_git_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_git_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_generic_git) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_generic_git
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_generic) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_generic
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_github_enterprise) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_github_enterprise
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_github) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_github
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_gitlab_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_gitlab_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_gitlab) && !exclude_resource_serviceendpoint_gitlab
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_incomingwebhook_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_incomingwebhook_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_incomingwebhook) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_incomingwebhook
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jenkins_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jenkins_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_jenkins) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_jenkins
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_jfrog_artifactory_v2) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_jfrog_artifactory_v2
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_jfrog_distribution_v2) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_jfrog_distribution_v2
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_jfrog_platform_v2) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_jfrog_platform_v2
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_jfrog_xray_v2) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_jfrog_xray_v2
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_kubernetes) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_kubernetes
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
@@ -139,7 +139,7 @@ func checkSvcEndpointKubernetesExists(expectedName string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		serviceEndpointDef, ok := s.RootModule().Resources["azuredevops_serviceendpoint_kubernetes.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a service endpoint in the TF state")
+			return fmt.Errorf("Did not find a service endpoint in the TF state")
 		}
 
 		serviceEndpoint, err := getServiceEndpointKubernetesFromResource(serviceEndpointDef)
@@ -148,7 +148,7 @@ func checkSvcEndpointKubernetesExists(expectedName string) resource.TestCheckFun
 		}
 
 		if *serviceEndpoint.Name != expectedName {
-			return fmt.Errorf(" Service Endpoint has Name=%s, but expected Name=%s", *serviceEndpoint.Name, expectedName)
+			return fmt.Errorf("Service Endpoint has Name=%s, but expected Name=%s", *serviceEndpoint.Name, expectedName)
 		}
 
 		return nil
@@ -162,7 +162,7 @@ func checkSvcEndpointKubernetesDestroyed(s *terraform.State) error {
 		}
 
 		if _, err := getServiceEndpointKubernetesFromResource(res); err == nil {
-			return fmt.Errorf(" Unexpectedly found a service endpoint that should be deleted")
+			return fmt.Errorf("Unexpectedly found a service endpoint that should be deleted")
 		}
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_maven) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_maven
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_nexus_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_nexus_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_nexus) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_nexus
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_npm_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_npm) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_npm
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_nuget_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_nuget_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_nuget) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_nuget
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_octopus_deploy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_octopus_deploy_test.go
@@ -1,6 +1,4 @@
 //go:build (all || azuredevops_serviceendpoint_octopusdeploy) && !exclude_serviceendpoints
-// +build all azuredevops_serviceendpoint_octopusdeploy
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_openshift_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_openshift_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_openshift) && !exclude_resource_serviceendpoint_openshift
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_serviceendpoint_permissions) && (!exclude_permissions || !exclude_resource_serviceendpoint_permissions)
-// +build all permissions resource_serviceendpoint_permissions
-// +build !exclude_permissions !exclude_resource_serviceendpoint_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_runpipeline_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_runpipeline_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_runpipeline) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_runpipeline
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_servicefabric_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_servicefabric_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_service_fabric) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_service_fabric
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_snyk_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_snyk_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_snyk) && !exclude_resource_serviceendpoint_snyk
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarcloud_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarcloud_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_SonarCloud) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_SonarCloud
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarqube_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarqube_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_sonarqube) && !exclude_serviceendpoints
-// +build all resource_serviceendpoint_sonarqube
-// +build !exclude_serviceendpoints
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_ssh_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_ssh_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_serviceendpoint_ssh) && !resource_serviceendpoint_ssh
-// +build all resource_serviceendpoint_ssh
-// +build !resource_serviceendpoint_ssh
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_visualstudiomarketplace_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_visualstudiomarketplace_test.go
@@ -1,3 +1,5 @@
+//go:build (all || resource_serviceendpoint_visualstudiomarketplace) && !exclude_resource_serviceendpoint_visualstudiomarketplace
+
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_servicehook_permissions) && (!exclude_permissions || !exclude_resource_servicehook_permissions)
-// +build all permissions resource_servicehook_permissions
-// +build !exclude_permissions !exclude_resource_servicehook_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_check_required_template) && !exclude_approvalsandchecks
-// +build all resource_check_required_template
-// +build !exclude_approvalsandchecks
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_tagging_permissions) && (!exclude_permissions || !exclude_resource_tagging_permissions)
-// +build all permissions resource_tagging_permissions
-// +build !exclude_permissions !exclude_resource_tagging_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_team_administrators_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_administrators_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_team_administrators) && !exclude_resource_team_administrators
-// +build all core resource_team_administrators
-// +build !exclude_resource_team_administrators
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_team_members_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_members_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_team_members) && !exclude_resource_team_members
-// +build all core resource_team_members
-// +build !exclude_resource_team_members
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_team_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || resource_team) && !exclude_resource_team
-// +build all core resource_team
-// +build !exclude_resource_team
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_user_entitlement) && !exclude_resource_user_entitlement
-// +build all resource_user_entitlement
-// +build !exclude_resource_user_entitlement
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
@@ -45,13 +45,13 @@ func checkUserEntitlementExists(expectedPrincipalName string) resource.TestCheck
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources["azuredevops_user_entitlement.user"]
 		if !ok {
-			return fmt.Errorf(" Did not find a UserEntitlement in the TF state")
+			return fmt.Errorf("Did not find a UserEntitlement in the TF state")
 		}
 
 		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing UserEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing UserEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		userEntitlement, err := clients.MemberEntitleManagementClient.GetUserEntitlement(clients.Ctx, memberentitlementmanagement.GetUserEntitlementArgs{
@@ -59,7 +59,7 @@ func checkUserEntitlementExists(expectedPrincipalName string) resource.TestCheck
 		})
 
 		if err != nil {
-			return fmt.Errorf(" UserEntitlement with ID=%s cannot be found!. Error=%v", id, err)
+			return fmt.Errorf("UserEntitlement with ID=%s cannot be found!. Error=%v", id, err)
 		}
 
 		if !strings.EqualFold(strings.ToLower(*userEntitlement.User.PrincipalName), strings.ToLower(expectedPrincipalName)) {
@@ -83,7 +83,7 @@ func checkUserEntitlementDestroyed(s *terraform.State) error {
 
 		id, err := uuid.Parse(resource.Primary.ID)
 		if err != nil {
-			return fmt.Errorf(" Parsing UserEntitlement ID, got %s: %v", resource.Primary.ID, err)
+			return fmt.Errorf("Parsing UserEntitlement ID, got %s: %v", resource.Primary.ID, err)
 		}
 
 		userEntitlement, err := clients.MemberEntitleManagementClient.GetUserEntitlement(clients.Ctx, memberentitlementmanagement.GetUserEntitlementArgs{
@@ -98,7 +98,7 @@ func checkUserEntitlementDestroyed(s *terraform.State) error {
 		}
 
 		if userEntitlement != nil && userEntitlement.AccessLevel != nil && string(*userEntitlement.AccessLevel.Status) != "none" {
-			return fmt.Errorf(" Status should be none : %s with readUserEntitlement error %v", string(*userEntitlement.AccessLevel.Status), err)
+			return fmt.Errorf("Status should be none : %s with readUserEntitlement error %v", string(*userEntitlement.AccessLevel.Status), err)
 		}
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_variable_group_permissions) && (!exclude_permissions || !exclude_resource_variable_group_permissions)
-// +build all permissions resource_variable_group_permissions
-// +build !exclude_permissions !exclude_resource_variable_group_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -183,7 +183,7 @@ func checkVariableGroupExists(expectedName string, expectedAllowAccess bool) res
 	return func(s *terraform.State) error {
 		varGroup, ok := s.RootModule().Resources["azuredevops_variable_group.test"]
 		if !ok {
-			return fmt.Errorf(" Did not find a variable group in the TF state")
+			return fmt.Errorf("Did not find a variable group in the TF state")
 		}
 
 		variableGroup, err := getVariableGroupFromResource(varGroup)
@@ -192,7 +192,7 @@ func checkVariableGroupExists(expectedName string, expectedAllowAccess bool) res
 		}
 
 		if *variableGroup.Name != expectedName {
-			return fmt.Errorf(" Variable Group has Name=%s, but expected %s", *variableGroup.Name, expectedName)
+			return fmt.Errorf("Variable Group has Name=%s, but expected %s", *variableGroup.Name, expectedName)
 		}
 
 		// testing Allow access with definition reference AzDo object
@@ -203,14 +203,14 @@ func checkVariableGroupExists(expectedName string, expectedAllowAccess bool) res
 
 		if expectedAllowAccess {
 			if len(*definitionReference) == 0 {
-				return fmt.Errorf("  reference should be not empty for allow access true")
+				return fmt.Errorf("reference should be not empty for allow access true")
 			}
 			if len(*definitionReference) > 0 && *(*definitionReference)[0].Authorized != expectedAllowAccess {
-				return fmt.Errorf(" Variable Group has Allow_access=%t, but expected %t", *(*definitionReference)[0].Authorized, expectedAllowAccess)
+				return fmt.Errorf("Variable Group has Allow_access=%t, but expected %t", *(*definitionReference)[0].Authorized, expectedAllowAccess)
 			}
 		} else {
 			if len(*definitionReference) > 0 {
-				return fmt.Errorf(" Definition reference should be empty for allow access false")
+				return fmt.Errorf("Definition reference should be empty for allow access false")
 			}
 		}
 		return nil
@@ -227,12 +227,12 @@ func checkVariableGroupDestroyed(s *terraform.State) error {
 
 		// Indicates the variable group still exists -- this should fail the test
 		if _, err := getVariableGroupFromResource(res); err == nil {
-			return fmt.Errorf(" Unexpectedly found a variable group that should be deleted")
+			return fmt.Errorf("Unexpectedly found a variable group that should be deleted")
 		}
 
 		// Indicates the definition reference still exists -- this should fail the test
 		if _, err := getDefinitionResourceFromVariableGroupResource(res); err == nil {
-			return fmt.Errorf(" Unexpectedly found a definition reference for allow access that should be deleted")
+			return fmt.Errorf("Unexpectedly found a definition reference for allow access that should be deleted")
 		}
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -1,6 +1,4 @@
 //go:build (all || resource_variable_group) && !exclude_resource_variable_group
-// +build all resource_variable_group
-// +build !exclude_resource_variable_group
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
@@ -1,6 +1,4 @@
 //go:build (all || wiki || resource_wiki) && !exclude_resource_wiki
-// +build all wiki resource_wiki
-// +build !exclude_resource_wiki
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_wiki_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_test.go
@@ -1,6 +1,4 @@
 //go:build (all || wiki || resource_wiki) && !exclude_resource_wiki
-// +build all wiki resource_wiki
-// +build !exclude_resource_wiki
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_workitem_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitem_test.go
@@ -1,6 +1,4 @@
 //go:build (all || core || workitem) && !exclude_resource_workitem
-// +build all core workitem
-// +build !exclude_resource_workitem
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
@@ -1,6 +1,4 @@
 //go:build (all || permissions || resource_workitemquery_permissions) && (!exclude_permissions || !resource_workitemquery_permissions)
-// +build all permissions resource_workitemquery_permissions
-// +build !exclude_permissions !resource_workitemquery_permissions
 
 package acceptancetests
 

--- a/azuredevops/internal/acceptancetests/testutils/pipelinechecks.go
+++ b/azuredevops/internal/acceptancetests/testutils/pipelinechecks.go
@@ -17,7 +17,7 @@ func CheckPipelineCheckExistsWithName(tfNode string, expectedName string) resour
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[tfNode]
 		if !ok {
-			return fmt.Errorf(" Did not find a check in the state")
+			return fmt.Errorf("Did not find a check in the state")
 		}
 
 		check, err := getCheckFromState(resourceState)
@@ -27,7 +27,7 @@ func CheckPipelineCheckExistsWithName(tfNode string, expectedName string) resour
 
 		if DisplayName, found := check.Settings.(map[string]interface{})["displayName"]; found {
 			if DisplayName != expectedName {
-				return fmt.Errorf(" Check has Name=%s, but expected Name=%s", DisplayName, expectedName)
+				return fmt.Errorf("Check has Name=%s, but expected Name=%s", DisplayName, expectedName)
 			}
 		} else {
 			return fmt.Errorf("displayName setting not found")
@@ -48,7 +48,7 @@ func CheckPipelineCheckDestroyed(resourceType string) resource.TestCheckFunc {
 
 			// indicates the resource exists - this should fail the test
 			if _, err := getSvcEndpointFromState(res); err == nil {
-				return fmt.Errorf(" Unexpectedly found a check that should have been deleted")
+				return fmt.Errorf("Unexpectedly found a check that should have been deleted")
 			}
 		}
 

--- a/azuredevops/internal/acceptancetests/testutils/serviceendpoint.go
+++ b/azuredevops/internal/acceptancetests/testutils/serviceendpoint.go
@@ -16,7 +16,7 @@ func CheckServiceEndpointExistsWithName(tfNode string, expectedName string) reso
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[tfNode]
 		if !ok {
-			return fmt.Errorf(" Did not find a service endpoint in the state")
+			return fmt.Errorf("Did not find a service endpoint in the state")
 		}
 
 		serviceEndpoint, err := getSvcEndpointFromState(resourceState)
@@ -25,7 +25,7 @@ func CheckServiceEndpointExistsWithName(tfNode string, expectedName string) reso
 		}
 
 		if *serviceEndpoint.Name != expectedName {
-			return fmt.Errorf(" Service Endpoint has Name=%s, but expected Name=%s", *serviceEndpoint.Name, expectedName)
+			return fmt.Errorf("Service Endpoint has Name=%s, but expected Name=%s", *serviceEndpoint.Name, expectedName)
 		}
 
 		return nil

--- a/azuredevops/internal/service/approvalsandchecks/common_check.go
+++ b/azuredevops/internal/service/approvalsandchecks/common_check.go
@@ -99,7 +99,7 @@ func genCheckCreateFunc(flatFunc flatFunc, expandFunc expandFunc) func(d *schema
 		clients := m.(*client.AggregatedClient)
 		configuration, projectID, err := expandFunc(d)
 		if err != nil {
-			return fmt.Errorf(" failed to expand check. Error: %+v", err)
+			return fmt.Errorf("failed to expand check. Error: %+v", err)
 		}
 
 		createdCheck, err := clients.PipelinesChecksClientExtras.AddCheckConfiguration(clients.Ctx, pipelineschecksextras.AddCheckConfigurationArgs{
@@ -107,7 +107,7 @@ func genCheckCreateFunc(flatFunc flatFunc, expandFunc expandFunc) func(d *schema
 			Configuration: configuration,
 		})
 		if err != nil {
-			return fmt.Errorf(" failed creating check, project ID: %s. Error: %+v", projectID, err)
+			return fmt.Errorf("failed creating check, project ID: %s. Error: %+v", projectID, err)
 		}
 
 		d.SetId(fmt.Sprintf("%d", *createdCheck.Id))
@@ -209,7 +209,7 @@ func doBaseExpansion(d *schema.ResourceData, checkType *pipelineschecksextras.Ch
 	if d.Id() != "" {
 		taskCheckId, err := strconv.Atoi(d.Id())
 		if err != nil {
-			return nil, "", fmt.Errorf(" parsing task check ID: (%+v)", err)
+			return nil, "", fmt.Errorf("parsing task check ID: (%+v)", err)
 		}
 		taskCheck.Id = &taskCheckId
 	}
@@ -222,7 +222,7 @@ func doBaseFlattening(d *schema.ResourceData, check *pipelineschecksextras.Check
 	d.Set("project_id", projectID)
 
 	if check.Resource == nil {
-		return fmt.Errorf(" resource not found")
+		return fmt.Errorf("resource not found")
 	}
 
 	d.Set("target_resource_id", check.Resource.Id)

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_rest_api.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_rest_api.go
@@ -167,7 +167,7 @@ func flattenRestAPI(d *schema.ResourceData, check *pipelineschecksextras.CheckCo
 			if v, exist := inputs["waitForCompletion"]; exist {
 				waitForCompletion, err := strconv.ParseBool(v.(string))
 				if err != nil {
-					return fmt.Errorf(" parsing `waitForCompletion`: %v", err)
+					return fmt.Errorf("parsing `waitForCompletion`: %v", err)
 				}
 				d.Set("completion_event", string(CompleteEventValues.Callback))
 				if !waitForCompletion {
@@ -232,13 +232,13 @@ func expandRestAPI(d *schema.ResourceData) (*pipelineschecksextras.CheckConfigur
 	if v, ok := d.GetOk("retry_interval"); ok {
 		retryInterval := v.(int)
 		if completionEvent == string(CompleteEventValues.Callback) {
-			return nil, "", fmt.Errorf(" Does not need to set `retry_interval` when `completion_event=Callback`.")
+			return nil, "", fmt.Errorf("Does not need to set `retry_interval` when `completion_event=Callback`.")
 		}
 
 		timeout := d.Get("timeout").(int)
 		minRetryInterval := timeout / 10
 		if minRetryInterval > retryInterval {
-			return nil, "", fmt.Errorf(" We require you enter a value of 0 or at least %d,"+
+			return nil, "", fmt.Errorf("We require you enter a value of 0 or at least %d,"+
 				" to keep the number of retries below 10. Starting Autumn 2023, non-compliant "+
 				"checks will fail automatically. Timeout: %d, retryInterval: %d", minRetryInterval, timeout, retryInterval)
 		}

--- a/azuredevops/internal/service/build/data_build_definition.go
+++ b/azuredevops/internal/service/build/data_build_definition.go
@@ -397,15 +397,15 @@ func dataSourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	buildDefinitions, err := getBuildDefinitionsByNameAndProject(clients, name, path, projectID)
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
-			return fmt.Errorf(" Build Definition with name %s does not exist in project %s in %s path", name, projectID, path)
+			return fmt.Errorf("Build Definition with name %s does not exist in project %s in %s path", name, projectID, path)
 		}
-		return fmt.Errorf(" Finding build definitions. Error: %v", err)
+		return fmt.Errorf("Finding build definitions. Error: %v", err)
 	}
 	if buildDefinitions == nil || 0 >= len(*buildDefinitions) {
-		return fmt.Errorf(" Build Definition with name %s does not exist in project %s in %s path", name, projectID, path)
+		return fmt.Errorf("Build Definition with name %s does not exist in project %s in %s path", name, projectID, path)
 	}
 	if 1 < len(*buildDefinitions) {
-		return fmt.Errorf(" Multiple build definitions with name %s found in project %s", name, projectID)
+		return fmt.Errorf("Multiple build definitions with name %s found in project %s", name, projectID)
 	}
 
 	buildDetail := &(*buildDefinitions)[0]

--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -706,12 +706,12 @@ func flattenBuildDefinition(d *schema.ResourceData, buildDefinition *build.Build
 	if buildDefinition.Process != nil {
 		pipeJobs, err := flattenBuildDefinitionJobs(buildDefinition.Process)
 		if err != nil {
-			return fmt.Errorf(" Flattening pipeline jobs: %+v", err)
+			return fmt.Errorf("Flattening pipeline jobs: %+v", err)
 		}
 
 		err = d.Set("jobs", pipeJobs)
 		if err != nil {
-			return fmt.Errorf(" Setting build definition jobs: %+v", err)
+			return fmt.Errorf("Setting build definition jobs: %+v", err)
 		}
 
 		// set agent identifier
@@ -750,12 +750,12 @@ func flattenBuildDefinitionJobs(input interface{}) ([]interface{}, error) {
 
 			v, err := json.Marshal(phases)
 			if err != nil {
-				return nil, fmt.Errorf(" Get pipeline jobs byte array: %+v", err)
+				return nil, fmt.Errorf("Get pipeline jobs byte array: %+v", err)
 			}
 
 			err = json.Unmarshal(v, &jobs)
 			if err != nil {
-				return nil, fmt.Errorf(" Convert Pipelins Jobs to PipelineJob: %+v", err)
+				return nil, fmt.Errorf("Convert Pipelins Jobs to PipelineJob: %+v", err)
 			}
 
 			for _, job := range jobs {
@@ -879,7 +879,7 @@ func flattenRepository(buildDefinition *build.BuildDefinition) (interface{}, err
 	if strings.EqualFold(*buildDefinition.Repository.Type, string(model.RepoTypeValues.GitHubEnterprise)) {
 		repoUrl, err := url.Parse(*buildDefinition.Repository.Url)
 		if err != nil {
-			return nil, fmt.Errorf(" Unable to parse repository URL: %+v ", err)
+			return nil, fmt.Errorf("Unable to parse repository URL: %+v ", err)
 		}
 		githubEnterpriseUrl = fmt.Sprintf("%s://%s", repoUrl.Scheme, repoUrl.Host)
 	}
@@ -901,7 +901,7 @@ func flattenRepository(buildDefinition *build.BuildDefinition) (interface{}, err
 		if buildStatus, ok := (*buildDefinition.Repository.Properties)["reportBuildStatus"]; ok {
 			reportBuildStatus, err := strconv.ParseBool(buildStatus)
 			if err != nil {
-				return nil, fmt.Errorf(" Unable parse Repository build status. Error: %+v", err)
+				return nil, fmt.Errorf("Unable parse Repository build status. Error: %+v", err)
 			}
 			repo[0]["report_build_status"] = reportBuildStatus
 		}
@@ -1284,7 +1284,7 @@ func expandVariables(d *schema.ResourceData) (*map[string]build.BuildDefinitionV
 		varName := varAsMap[bdVariableName].(string)
 
 		if _, ok := expandedVars[varName]; ok {
-			return nil, fmt.Errorf(" Unexpectedly found duplicate variable with name %s", varName)
+			return nil, fmt.Errorf("Unexpectedly found duplicate variable with name %s", varName)
 		}
 
 		isSecret := converter.Bool(varAsMap[bdVariableIsSecret].(bool))
@@ -1361,7 +1361,7 @@ func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error
 
 			if jobType == 1 { // Agent Job
 				if v, ok := executionOptionsMap["max_concurrency"]; !ok || v.(int) == 0 {
-					return nil, fmt.Errorf(" `max_concurrency` must be set when job is `AgentJob`")
+					return nil, fmt.Errorf("`max_concurrency` must be set when job is `AgentJob`")
 				}
 				executeOptions.MaxConcurrency = converter.ToPtr(executionOptionsMap["max_concurrency"].(int))
 			}
@@ -1369,7 +1369,7 @@ func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error
 			// TODO
 			//if jobType == 2 { // Agentless Job
 			//	if v, ok := executionOptionsMap["max_concurrency"]; ok && v.(int) > 0 {
-			//		return nil, fmt.Errorf(" `max_concurrency` must not be set when job is `AgentlessJob`")
+			//		return nil, fmt.Errorf("`max_concurrency` must not be set when job is `AgentlessJob`")
 			//	}
 			//}
 
@@ -1379,7 +1379,7 @@ func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error
 			}
 		case model.JobExecutionOptionsTypeValues.MultiAgent: // multi-agent, only available when job type is AgentJob
 			if jobType == 2 {
-				return nil, fmt.Errorf(" `Multi-Agent` is not supported when job Type is `AgentlessJob`")
+				return nil, fmt.Errorf("`Multi-Agent` is not supported when job Type is `AgentlessJob`")
 			}
 			executeOptions = model.JobExecutionOptions{
 				Type:            converter.ToPtr(2),
@@ -1388,12 +1388,12 @@ func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error
 
 			if v, ok := executionOptionsMap["multipliers"]; ok {
 				if len(v.(string)) > 0 {
-					return nil, fmt.Errorf(" `multipliers` must not be set when Execution Options Type is `Multi-Agent`")
+					return nil, fmt.Errorf("`multipliers` must not be set when Execution Options Type is `Multi-Agent`")
 				}
 			}
 			if jobType == 1 {
 				if v, ok := executionOptionsMap["max_concurrency"]; !ok || v.(int) == 0 {
-					return nil, fmt.Errorf(" `max_concurrency` must be set when job is `AgentJob`")
+					return nil, fmt.Errorf("`max_concurrency` must be set when job is `AgentJob`")
 				}
 				executeOptions.MaxConcurrency = converter.ToPtr(executionOptionsMap["max_concurrency"].(int))
 			}
@@ -1414,7 +1414,7 @@ func expandBuildDefinitionJobs(input []interface{}) (*[]model.PipelineJob, error
 		} else {
 			demands := targetMap["demands"].([]interface{})
 			if len(demands) > 0 {
-				return nil, fmt.Errorf(" `demands` must not be set when Job Type is `AgentlessJob`")
+				return nil, fmt.Errorf("`demands` must not be set when Job Type is `AgentlessJob`")
 			}
 		}
 		job.Target = &target
@@ -1457,11 +1457,11 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 
 	if strings.EqualFold(repoType, string(model.RepoTypeValues.OtherGit)) {
 		if _, ok := repository["service_connection_id"]; !ok {
-			return nil, "", fmt.Errorf(" `repository.service_connection_id` must be set when `repoType` is `Git`")
+			return nil, "", fmt.Errorf("`repository.service_connection_id` must be set when `repoType` is `Git`")
 		}
 
 		if _, ok := repository["url"]; !ok {
-			return nil, "", fmt.Errorf(" `repository.service_connection_id` must be set when `repoType` is `Git`")
+			return nil, "", fmt.Errorf("`repository.service_connection_id` must be set when `repoType` is `Git`")
 		}
 	}
 
@@ -1527,7 +1527,7 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 
 	variables, err := expandVariables(d)
 	if err != nil {
-		return nil, "", fmt.Errorf(" Expanding varibles: %+v", err)
+		return nil, "", fmt.Errorf("Expanding varibles: %+v", err)
 	}
 
 	queueStatus := build.DefinitionQueueStatus(d.Get("queue_status").(string))
@@ -1577,12 +1577,12 @@ func expandBuildDefinition(d *schema.ResourceData, meta interface{}) (*build.Bui
 
 		jobs, err := expandBuildDefinitionJobs(d.Get("jobs").([]interface{}))
 		if err != nil {
-			return nil, "", fmt.Errorf(" Expanding jobs: %+v", err)
+			return nil, "", fmt.Errorf("Expanding jobs: %+v", err)
 		}
 
 		agentSpecification := d.Get("agent_specification").(string)
 		if len(agentSpecification) <= 0 {
-			return nil, "", fmt.Errorf(" Expanding jobs: `agent_specification` must be set when `repo_type` is `Git`")
+			return nil, "", fmt.Errorf("Expanding jobs: `agent_specification` must be set when `repo_type` is `Git`")
 		}
 
 		buildDefinition.Process = map[string]interface{}{

--- a/azuredevops/internal/service/build/resource_build_folder.go
+++ b/azuredevops/internal/service/build/resource_build_folder.go
@@ -28,7 +28,7 @@ func ResourceBuildFolder() *schema.Resource {
 			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 				projectNameOrID, path, err := tfhelper.ParseImportedName(d.Id())
 				if err != nil {
-					return nil, fmt.Errorf(" parsing the resource ID from the Terraform resource data: %v", err)
+					return nil, fmt.Errorf("parsing the resource ID from the Terraform resource data: %v", err)
 				}
 
 				if projectID, err := tfhelper.GetRealProjectId(projectNameOrID, m); err == nil {
@@ -75,7 +75,7 @@ func resourceBuildFolderCreate(d *schema.ResourceData, m interface{}) error {
 
 	createdBuildFolder, err := createBuildFolder(clients, path, projectID, description)
 	if err != nil {
-		return fmt.Errorf(" failed creating resource Build Folder, %+v", err)
+		return fmt.Errorf("failed creating resource Build Folder, %+v", err)
 	}
 
 	d.SetId(createdBuildFolder.Project.Id.String())
@@ -128,7 +128,7 @@ func resourceBuildFolderUpdate(d *schema.ResourceData, m interface{}) error {
 	projectID := d.Get("project_id").(string)
 	projectUuid, err := uuid.Parse(projectID)
 	if err != nil {
-		return fmt.Errorf(" failed to parse Project ID. Project ID: %s , Error: %+v", projectID, err)
+		return fmt.Errorf("failed to parse Project ID. Project ID: %s , Error: %+v", projectID, err)
 	}
 
 	_, err = clients.BuildClient.UpdateFolder(m.(*client.AggregatedClient).Ctx, build.UpdateFolderArgs{

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -97,7 +97,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	)
 
 	if err != nil {
-		return fmt.Errorf(" creating authorized resource: %+v", err)
+		return fmt.Errorf("creating authorized resource: %+v", err)
 	}
 
 	// ensure authorization is complete
@@ -112,7 +112,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" waiting for pipeline authorization ready. %v ", err)
+		return fmt.Errorf("waiting for pipeline authorization ready. %v ", err)
 	}
 
 	d.SetId(*response.Resource.Id)
@@ -212,7 +212,7 @@ func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 		pipePermissionParams)
 
 	if err != nil {
-		return fmt.Errorf(" deleting authorized resource: %+v", err)
+		return fmt.Errorf("deleting authorized resource: %+v", err)
 	}
 
 	return nil

--- a/azuredevops/internal/service/build/resource_resource_authorization.go
+++ b/azuredevops/internal/service/build/resource_resource_authorization.go
@@ -67,7 +67,7 @@ func resourceResourceAuthorizationCreate(d *schema.ResourceData, m interface{}) 
 
 	err := sendAuthorizedResourceToAPI(clients, authorizedResource, projectID, definitionID)
 	if err != nil {
-		return fmt.Errorf(" creating authorized resource: %+v", err)
+		return fmt.Errorf("creating authorized resource: %+v", err)
 	}
 
 	d.SetId(*authorizedResource.Id)
@@ -145,7 +145,7 @@ func resourceResourceAuthorizationUpdate(d *schema.ResourceData, m interface{}) 
 
 	err := sendAuthorizedResourceToAPI(clients, authorizedResource, projectID, definitionID)
 	if err != nil {
-		return fmt.Errorf(" updating authorized resource: %+v", err)
+		return fmt.Errorf("updating authorized resource: %+v", err)
 	}
 
 	return resourceResourceAuthorizationRead(d, m)
@@ -161,7 +161,7 @@ func resourceResourceAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 
 	err := sendAuthorizedResourceToAPI(clients, authorizedResource, projectID, definitionID)
 	if err != nil {
-		return fmt.Errorf(" deleting authorized resource: %+v", err)
+		return fmt.Errorf("deleting authorized resource: %+v", err)
 	}
 
 	return nil

--- a/azuredevops/internal/service/core/data_project.go
+++ b/azuredevops/internal/service/core/data_project.go
@@ -93,7 +93,7 @@ func dataProjectRead(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	err = flattenProject(clients, d, project)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" flattening project: %v", err))
+		return diag.FromErr(fmt.Errorf("flattening project: %v", err))
 	}
 	return nil
 }

--- a/azuredevops/internal/service/core/data_projects.go
+++ b/azuredevops/internal/service/core/data_projects.go
@@ -87,21 +87,21 @@ func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	projects, err := getProjectsForStateAndName(clients, state, name)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" finding projects with state %s. Error: %v", state, err))
+		return diag.FromErr(fmt.Errorf("finding projects with state %s. Error: %v", state, err))
 	}
 
 	results := flattenProjectReferences(&projects)
 
 	projectNames, err := datahelper.GetAttributeValues(results, "name")
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" failed to get list of project names: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to get list of project names: %v", err))
 	}
 	if len(projectNames) <= 0 && name != "" {
 		projectNames = append(projectNames, name)
 	}
 	h := sha1.New()
 	if _, err := h.Write([]byte(state + strings.Join(projectNames, "-"))); err != nil {
-		return diag.FromErr(fmt.Errorf(" Unable to compute hash for project names: %v", err))
+		return diag.FromErr(fmt.Errorf("Unable to compute hash for project names: %v", err))
 	}
 	d.SetId("projects#" + base64.URLEncoding.EncodeToString(h.Sum(nil)))
 

--- a/azuredevops/internal/service/core/data_team.go
+++ b/azuredevops/internal/service/core/data_team.go
@@ -82,24 +82,24 @@ func dataTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) di
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Get Team (Team Name: %s). Error: %+v", teamName, err))
+		return diag.FromErr(fmt.Errorf("Get Team (Team Name: %s). Error: %+v", teamName, err))
 	}
 
 	members, err := getTeamMembers(clients, team)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Get Team members (Team Name: %s). Error: %+v", teamName, err))
+		return diag.FromErr(fmt.Errorf("Get Team members (Team Name: %s). Error: %+v", teamName, err))
 	}
 
 	administrators, err := getTeamAdministrators(d, clients, team)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Get Team administrators (Team Name: %s). Error: %+v", teamName, err))
+		return diag.FromErr(fmt.Errorf("Get Team administrators (Team Name: %s). Error: %+v", teamName, err))
 	}
 
 	descriptor, err := clients.GraphClient.GetDescriptor(clients.Ctx, graph.GetDescriptorArgs{
 		StorageKey: team.Id,
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Get Team descriptor (Team Name: %s). Error: %+v", teamName, err))
+		return diag.FromErr(fmt.Errorf("Get Team descriptor (Team Name: %s). Error: %+v", teamName, err))
 	}
 
 	d.SetId(team.Id.String())

--- a/azuredevops/internal/service/core/data_teams.go
+++ b/azuredevops/internal/service/core/data_teams.go
@@ -151,7 +151,7 @@ func dataTeamsRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(fmt.Sprintf("%d", rand.Int()))
 
 	if err := d.Set("teams", result); err != nil {
-		return fmt.Errorf(" setting `teams`: %+v", err)
+		return fmt.Errorf("setting `teams`: %+v", err)
 	}
 
 	return nil

--- a/azuredevops/internal/service/core/resource_project.go
+++ b/azuredevops/internal/service/core/resource_project.go
@@ -100,12 +100,12 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	clients := m.(*client.AggregatedClient)
 	project, err := expandProject(clients, d, true)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" expand project reference: %+v", err))
+		return diag.FromErr(fmt.Errorf("expand project reference: %+v", err))
 	}
 
 	operationRef, err := clients.CoreClient.QueueCreateProject(clients.Ctx, core.QueueCreateProjectArgs{ProjectToCreate: project})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" creating project: %v", err))
+		return diag.FromErr(fmt.Errorf("creating project: %v", err))
 	}
 
 	// waiting creation operation finished or timeout
@@ -127,12 +127,12 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return diag.FromErr(fmt.Errorf(" waiting for project create finished. %v ", err))
+		return diag.FromErr(fmt.Errorf("waiting for project create finished. %v ", err))
 	}
 
 	project, err = getProject(clients, "", *project.Name, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" waiting for project ready. %v ", err))
+		return diag.FromErr(fmt.Errorf("waiting for project ready. %v ", err))
 	}
 
 	featureStates, ok := d.GetOk("features")
@@ -161,14 +161,14 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf(" looking up project with (ID: %s or Name: %s). Error: %+v", projectID, name, err))
+		return diag.FromErr(fmt.Errorf("looking up project with (ID: %s or Name: %s). Error: %+v", projectID, name, err))
 	}
 
 	// Set ID to the project UUID in case the project is imported by name
 	d.SetId(project.Id.String())
 	err = flattenProject(clients, d, project)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" flattening project: %v", err))
+		return diag.FromErr(fmt.Errorf("flattening project: %v", err))
 	}
 	return nil
 }
@@ -177,7 +177,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	clients := m.(*client.AggregatedClient)
 	project, err := expandProject(clients, d, false)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" converting terraform data model to AzDO project reference: %+v", err))
+		return diag.FromErr(fmt.Errorf("converting terraform data model to AzDO project reference: %+v", err))
 	}
 
 	requiresUpdate := false
@@ -199,7 +199,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 	if requiresUpdate {
 		if err = updateProject(clients, project, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.FromErr(fmt.Errorf(" updating project: %v", err))
+			return diag.FromErr(fmt.Errorf("updating project: %v", err))
 		}
 	}
 
@@ -234,7 +234,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 
 	err := deleteProject(clients, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" deleting project: %v", err))
+		return diag.FromErr(fmt.Errorf("deleting project: %v", err))
 	}
 
 	return nil
@@ -308,7 +308,7 @@ func getProject(clients *client.AggregatedClient, projectID string, projectName 
 		if utils.ResponseWasNotFound(err) {
 			return nil, err
 		}
-		return nil, fmt.Errorf(" Project not found. (ID: %s or name: %s), Error: %+v", projectID, projectName, err)
+		return nil, fmt.Errorf("Project not found. (ID: %s or name: %s), Error: %+v", projectID, projectName, err)
 	}
 
 	return project, nil
@@ -355,7 +355,7 @@ func updateProject(clients *client.AggregatedClient, project *core.TeamProject, 
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" waiting for project ready. %v ", err)
+		return fmt.Errorf("waiting for project ready. %v ", err)
 	}
 	return nil
 }
@@ -363,7 +363,7 @@ func updateProject(clients *client.AggregatedClient, project *core.TeamProject, 
 func deleteProject(clients *client.AggregatedClient, id string, timeout time.Duration) error {
 	uuid, err := uuid.Parse(id)
 	if err != nil {
-		return fmt.Errorf(" Invalid project UUID: %s", id)
+		return fmt.Errorf("Invalid project UUID: %s", id)
 	}
 
 	var operationRef *operations.OperationReference
@@ -404,7 +404,7 @@ func deleteProject(clients *client.AggregatedClient, id string, timeout time.Dur
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" waiting for project ready. %v ", err)
+		return fmt.Errorf("waiting for project ready. %v ", err)
 	}
 	return nil
 }

--- a/azuredevops/internal/service/core/resource_project_features.go
+++ b/azuredevops/internal/service/core/resource_project_features.go
@@ -112,7 +112,7 @@ func resourceProjectFeaturesRead(ctx context.Context, d *schema.ResourceData, m 
 	}
 	if currentFeatureStates == nil {
 		d.SetId("")
-		return diag.FromErr(fmt.Errorf(" failed to retrieve current feature states for project: %s", projectID))
+		return diag.FromErr(fmt.Errorf("failed to retrieve current feature states for project: %s", projectID))
 	}
 	d.Set("features", currentFeatureStates)
 	return nil
@@ -161,7 +161,7 @@ func updateProjectFeatureStates(ctx context.Context, fc featuremanagement.Client
 		enabledValue := featuremanagement.ContributedFeatureEnabledValue(v.(string))
 		f, ok := projectFeatureNameMapReverse[ProjectFeatureType(k)]
 		if !ok {
-			return fmt.Errorf(" unknown feature: %s, available features are: `boards`, `repositories`,`pipelines`,`testplans`,`artifacts`", k)
+			return fmt.Errorf("unknown feature: %s, available features are: `boards`, `repositories`,`pipelines`,`testplans`,`artifacts`", k)
 		}
 		//TODO handle response state
 		_, err := fc.SetFeatureStateForScope(ctx, featuremanagement.SetFeatureStateForScopeArgs{
@@ -179,7 +179,7 @@ func updateProjectFeatureStates(ctx context.Context, fc featuremanagement.Client
 			ScopeValue: &projectID,
 		})
 		if nil != err {
-			return fmt.Errorf(" Faild to update project features. Feature type: %s,  Error: %+v", f, err)
+			return fmt.Errorf("Faild to update project features. Feature type: %s,  Error: %+v", f, err)
 		}
 	}
 	return nil
@@ -202,7 +202,7 @@ func getProjectFeatureStates(ctx context.Context, fc featuremanagement.Client, p
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf(" Get project features error, project: %s, error: %+v", projectID, err)
+		return nil, fmt.Errorf("Get project features error, project: %s, error: %+v", projectID, err)
 	}
 
 	featureStates := make(map[ProjectFeatureType]featuremanagement.ContributedFeatureEnabledValue)

--- a/azuredevops/internal/service/core/resource_project_pipeline_settings.go
+++ b/azuredevops/internal/service/core/resource_project_pipeline_settings.go
@@ -81,7 +81,7 @@ func resourceProjectPipelineSettingsCreateUpdate(ctx context.Context, d *schema.
 
 	err := configureProjectPipelineGeneralSettings(clients, projectID, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" creating/updating project build general settings: %v", err))
+		return diag.FromErr(fmt.Errorf("creating/updating project build general settings: %v", err))
 	}
 	d.SetId(projectID)
 	return resourceProjectPipelineSettingsRead(ctx, d, m)

--- a/azuredevops/internal/service/core/resource_project_tags.go
+++ b/azuredevops/internal/service/core/resource_project_tags.go
@@ -65,7 +65,7 @@ func resourceProjectTagsCreate(ctx context.Context, d *schema.ResourceData, m in
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Creating Project Tags. Project ID: %s, Error: %+v", projectID.String(), err))
+		return diag.FromErr(fmt.Errorf("Creating Project Tags. Project ID: %s, Error: %+v", projectID.String(), err))
 	}
 
 	d.SetId(projectID.String())
@@ -90,7 +90,7 @@ func resourceProjectTagsRead(ctx context.Context, d *schema.ResourceData, m inte
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf(" Gettting Project tags. Projecct ID: %s. Error: %+v", projectID, err))
+		return diag.FromErr(fmt.Errorf("Gettting Project tags. Projecct ID: %s. Error: %+v", projectID, err))
 	}
 
 	if tags == nil || len(*tags) == 0 {
@@ -125,7 +125,7 @@ func resourceProjectTagsUpdate(ctx context.Context, d *schema.ResourceData, m in
 		Keys:      &[]string{"Microsoft.TeamFoundation.Project.Tag.*"},
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Gettting Project tags. Projecct ID: %s. Error: %+v", projectId, err))
+		return diag.FromErr(fmt.Errorf("Gettting Project tags. Projecct ID: %s. Error: %+v", projectId, err))
 	}
 	tagsExists := flattenProjectTags(*resp)
 
@@ -147,7 +147,7 @@ func resourceProjectTagsUpdate(ctx context.Context, d *schema.ResourceData, m in
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Updating Project Tags. Project ID: %s, Error: %+v", projectId.String(), err))
+		return diag.FromErr(fmt.Errorf("Updating Project Tags. Project ID: %s, Error: %+v", projectId.String(), err))
 	}
 	return resourceProjectTagsRead(clients.Ctx, d, m)
 }
@@ -172,7 +172,7 @@ func resourceProjectTagsDelete(ctx context.Context, d *schema.ResourceData, m in
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Deleting Project Tags. ProjectID: %s, Error: %+v", projectId, err))
+		return diag.FromErr(fmt.Errorf("Deleting Project Tags. ProjectID: %s, Error: %+v", projectId, err))
 	}
 	return nil
 }

--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -98,7 +98,7 @@ func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf(" Creating Team: %+v", err)
+		return fmt.Errorf("Creating Team: %+v", err)
 	}
 
 	teamID := team.Id.String()
@@ -184,7 +184,7 @@ func resourceTeamRead(d *schema.ResourceData, m interface{}) error {
 		StorageKey: team.Id,
 	})
 	if err != nil {
-		return fmt.Errorf(" get team descriptor. Error: %+v", err)
+		return fmt.Errorf("get team descriptor. Error: %+v", err)
 	}
 	d.Set("descriptor", descriptor.Value)
 
@@ -302,7 +302,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 				ExpandIdentity: converter.Bool(false),
 			})
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading team data: %+v", err)
+				return nil, "", fmt.Errorf("Reading team data: %+v", err)
 			}
 
 			bDescriptionUpdated := nil == description || *team.Description == *description
@@ -312,7 +312,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 			if administratorSet != nil {
 				actualAdministrators, err := getTeamAdministrators(d, clients, team)
 				if err != nil {
-					return nil, "", fmt.Errorf(" Reading team administrators: %+v", err)
+					return nil, "", fmt.Errorf("Reading team administrators: %+v", err)
 				}
 				bAdministratorsUpdated = actualAdministrators.Len() == administratorSet.Len()
 			}
@@ -322,7 +322,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 				Team:    converter.String(teamID),
 			})
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading Team dashboard: %+v", err)
+				return nil, "", fmt.Errorf("Reading Team dashboard: %+v", err)
 			}
 			dashboardUpdate := true
 			if dashboards == nil && len(*dashboards) == 0 {
@@ -333,7 +333,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 			if memberSet != nil {
 				actualMemberships, err := getTeamMembers(clients, team)
 				if err != nil {
-					return nil, "", fmt.Errorf(" Reading team memberships: %+v", err)
+					return nil, "", fmt.Errorf("Reading team memberships: %+v", err)
 				}
 				bMembersUpdated = actualMemberships.Len() == memberSet.Len()
 			}
@@ -351,7 +351,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil { //nolint:staticcheck
-		return fmt.Errorf(" waiting for state change for team %s in project %s. %v ", teamID, projectID, err)
+		return fmt.Errorf("waiting for state change for team %s in project %s. %v ", teamID, projectID, err)
 	}
 
 	return nil

--- a/azuredevops/internal/service/core/resource_team_members.go
+++ b/azuredevops/internal/service/core/resource_team_members.go
@@ -106,7 +106,7 @@ func resourceTeamMembersCreate(d *schema.ResourceData, m interface{}) error {
 			state := "Waiting"
 			actualMemberships, err := getTeamMembers(clients, team)
 			if err != nil {
-				return nil, "", fmt.Errorf(" reading team memberships: %+v", err)
+				return nil, "", fmt.Errorf("reading team memberships: %+v", err)
 			}
 			if membersToAdd == nil || actualMemberships.Intersection(membersToAdd).Len() == membersToAdd.Len() {
 				state = "Synched"
@@ -123,7 +123,7 @@ func resourceTeamMembersCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil { //nolint:staticcheck
-		return fmt.Errorf(" waiting for distribution of adding members. %v ", err)
+		return fmt.Errorf("waiting for distribution of adding members. %v ", err)
 	}
 
 	// The ID for this resource is meaningless so we can just assign a random ID
@@ -241,7 +241,7 @@ func resourceTeamMembersUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil { //nolint:staticcheck
-		return fmt.Errorf(" waiting for distribution of member list update. %v ", err)
+		return fmt.Errorf("waiting for distribution of member list update. %v ", err)
 	}
 
 	return resourceTeamMembersRead(d, m)
@@ -305,7 +305,7 @@ func resourceTeamMembersDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil { //nolint:staticcheck
-		return fmt.Errorf(" waiting for distribution of member list update. %v ", err)
+		return fmt.Errorf("waiting for distribution of member list update. %v ", err)
 	}
 
 	d.SetId("")

--- a/azuredevops/internal/service/dashboard/resource_dashboard.go
+++ b/azuredevops/internal/service/dashboard/resource_dashboard.go
@@ -36,7 +36,7 @@ func ResourceDashboard() *schema.Resource {
 			StateContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "/")
 				if len(idParts) > 3 || len(idParts) < 2 {
-					return nil, fmt.Errorf(" Unexpected ID format (%q), Expected: <projetId>/<dasboardId> or <projetId>/<teamId>/<dasboardId>", d.Id())
+					return nil, fmt.Errorf("Unexpected ID format (%q), Expected: <projetId>/<dasboardId> or <projetId>/<teamId>/<dasboardId>", d.Id())
 				}
 
 				d.Set("project_id", idParts[0])

--- a/azuredevops/internal/service/feed/data_feed.go
+++ b/azuredevops/internal/service/feed/data_feed.go
@@ -64,7 +64,7 @@ func dataFeedRead(d *schema.ResourceData, m interface{}) error {
 		if utils.ResponseWasNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf(" reading feed during read: %+v", err)
+		return fmt.Errorf("reading feed during read: %+v", err)
 	}
 
 	if getFeed != nil {

--- a/azuredevops/internal/service/feed/resource_feed.go
+++ b/azuredevops/internal/service/feed/resource_feed.go
@@ -134,7 +134,7 @@ func resourceFeedRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" failed get feed. Projecct ID: %s , Feed ID %s : . Error: %+v", projectId, feedID, err)
+		return fmt.Errorf("failed get feed. Projecct ID: %s , Feed ID %s : . Error: %+v", projectId, feedID, err)
 	}
 
 	if feedDetail != nil {

--- a/azuredevops/internal/service/feed/resource_feed_permission.go
+++ b/azuredevops/internal/service/feed/resource_feed_permission.go
@@ -36,7 +36,7 @@ func ResourceFeedPermission() *schema.Resource {
 			StateContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "/")
 				if len(idParts) > 3 || len(idParts) < 2 {
-					return nil, fmt.Errorf(" Unexpected ID format (%q), Expected: <feedId>/<identityDescriptor> or <projetId>/<feedId>/<identityDescriptor>", d.Id())
+					return nil, fmt.Errorf("Unexpected ID format (%q), Expected: <feedId>/<identityDescriptor> or <projetId>/<feedId>/<identityDescriptor>", d.Id())
 				}
 
 				if len(idParts) == 2 {
@@ -139,12 +139,12 @@ func resourceFeedPermissionCreate(d *schema.ResourceData, m interface{}) error {
 
 	err = checkPermissions(d, m)
 	if err != nil {
-		return fmt.Errorf(" Sync Feed Permission for Feed failed: %+v", err)
+		return fmt.Errorf("Sync Feed Permission for Feed failed: %+v", err)
 	}
 
 	id, err := uuid.NewUUID()
 	if err != nil {
-		return fmt.Errorf(" Creating Permission for Feed failed: %+v", err)
+		return fmt.Errorf("Creating Permission for Feed failed: %+v", err)
 	}
 	d.SetId(fmt.Sprintf("fp-%s", id.String()))
 
@@ -206,7 +206,7 @@ func resourceFeedPermissionUpdate(d *schema.ResourceData, m interface{}) error {
 
 	err = checkPermissions(d, m)
 	if err != nil {
-		return fmt.Errorf(" Sync Feed Permission for Feed failed: %+v", err)
+		return fmt.Errorf("Sync Feed Permission for Feed failed: %+v", err)
 	}
 
 	return resourceFeedPermissionRead(d, m)
@@ -286,10 +286,10 @@ func getFeedPermission(d *schema.ResourceData, m interface{}) (*feed.FeedPermiss
 
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
-			return nil, identityResponse, fmt.Errorf(" Feed Permissions Not Found. Feed may exist at organization or project level."+
+			return nil, identityResponse, fmt.Errorf("Feed Permissions Not Found. Feed may exist at organization or project level."+
 				" Please ensure you have set the `project_id` correctly. \n Project ID: %s\n Feed ID: %s\n Error: %+v", projectId, feedId, err)
 		}
-		return nil, identityResponse, fmt.Errorf(" \nProject ID: %s\n Feed ID: %s\n Error: %+v", projectId, feedId, err)
+		return nil, identityResponse, fmt.Errorf("\nProject ID: %s\n Feed ID: %s\n Error: %+v", projectId, feedId, err)
 	}
 
 	for _, permission := range *permissions {
@@ -317,7 +317,7 @@ func checkPermissions(d *schema.ResourceData, m interface{}) error {
 		Refresh:                   pollPermissions(d, m),
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Failed waiting for Feed Permission create. %v ", err)
+		return fmt.Errorf("Failed waiting for Feed Permission create. %v ", err)
 	}
 	return nil
 }

--- a/azuredevops/internal/service/feed/resource_feed_retention_policy.go
+++ b/azuredevops/internal/service/feed/resource_feed_retention_policy.go
@@ -36,7 +36,7 @@ func ResourceFeedRetentionPolicy() *schema.Resource {
 				} else {
 					projectNameOrID, resourceID, err := tfhelper.ParseImportedName(d.Id())
 					if err != nil {
-						return nil, fmt.Errorf(" Parsing the resource ID. Expect in format `projectID/feedID`. Error: %v", err)
+						return nil, fmt.Errorf("Parsing the resource ID. Expect in format `projectID/feedID`. Error: %v", err)
 					}
 
 					if projectNameOrID, err = tfhelper.GetRealProjectId(projectNameOrID, meta); err == nil {
@@ -93,7 +93,7 @@ func resourceFeedRetentionPolicyCreate(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Creating Feed Retention Policy. FeedId: %s, Error: %+v", feedId, err))
+		return diag.FromErr(fmt.Errorf("Creating Feed Retention Policy. FeedId: %s, Error: %+v", feedId, err))
 	}
 
 	d.SetId(feedId)
@@ -115,7 +115,7 @@ func resourceFeedRetentionPolicyRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf(" Failed get Feed Retention Policy. Projecct ID: %s , Feed ID: %s. Error: %+v", projectId, feedID, err))
+		return diag.FromErr(fmt.Errorf("Failed get Feed Retention Policy. Projecct ID: %s , Feed ID: %s. Error: %+v", projectId, feedID, err))
 	}
 
 	d.Set("feed_id", feedID)
@@ -147,7 +147,7 @@ func resourceFeedRetentionPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Updating Feed Retention Policy. ProjectID: %s, FeedId: %s, Error: %+v", projectId, feedId, err))
+		return diag.FromErr(fmt.Errorf("Updating Feed Retention Policy. ProjectID: %s, FeedId: %s, Error: %+v", projectId, feedId, err))
 	}
 	return resourceFeedRetentionPolicyRead(clients.Ctx, d, m)
 }
@@ -163,7 +163,7 @@ func resourceFeedRetentionPolicyDelete(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Deleting Feed Retention Policy. ProjectID: %s, FeedId: %s, Error: %+v", projectId, feedId, err))
+		return diag.FromErr(fmt.Errorf("Deleting Feed Retention Policy. ProjectID: %s, FeedId: %s, Error: %+v", projectId, feedId, err))
 	}
 	return nil
 }

--- a/azuredevops/internal/service/git/data_git_repositories.go
+++ b/azuredevops/internal/service/git/data_git_repositories.go
@@ -106,17 +106,17 @@ func dataSourceGitRepositoriesRead(d *schema.ResourceData, m interface{}) error 
 		if utils.ResponseWasNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf(" finding repositories. Error: %v", err)
+		return fmt.Errorf("finding repositories. Error: %v", err)
 	}
 
 	results, err := flattenGitRepositories(projectRepos)
 	if err != nil {
-		return fmt.Errorf(" flattening projects. Error: %v", err)
+		return fmt.Errorf("flattening projects. Error: %v", err)
 	}
 
 	repoNames, err := datahelper.GetAttributeValues(results, "name")
 	if err != nil {
-		return fmt.Errorf(" failed to get list of repository names: %v", err)
+		return fmt.Errorf("failed to get list of repository names: %v", err)
 	}
 
 	id, err := createGitRepositoryDataSourceID(d, &repoNames)
@@ -147,7 +147,7 @@ func createGitRepositoryDataSourceID(d *schema.ResourceData, repoNames *[]string
 		names = append([]string{projectID}, names...)
 	}
 	if _, err := h.Write([]byte(strings.Join(names, "-"))); err != nil {
-		return "", fmt.Errorf(" Unable to compute hash for Git repository names: %v", err)
+		return "", fmt.Errorf("Unable to compute hash for Git repository names: %v", err)
 	}
 	return "gitRepos#" + base64.URLEncoding.EncodeToString(h.Sum(nil)), nil
 }

--- a/azuredevops/internal/service/git/data_git_repository.go
+++ b/azuredevops/internal/service/git/data_git_repository.go
@@ -76,23 +76,23 @@ func dataSourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	projectRepos, err := getGitRepositoriesByNameAndProject(clients, name, projectID, true)
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
-			return fmt.Errorf(" Repository with name %s does not exist in project %s", name, projectID)
+			return fmt.Errorf("Repository with name %s does not exist in project %s", name, projectID)
 		}
-		return fmt.Errorf(" finding repositories. Error: %v", err)
+		return fmt.Errorf("finding repositories. Error: %v", err)
 	}
 	if projectRepos == nil || len(*projectRepos) == 0 {
-		return fmt.Errorf(" Repository with name %s does not exist in project %s", name, projectID)
+		return fmt.Errorf("Repository with name %s does not exist in project %s", name, projectID)
 	}
 
 	if len(*projectRepos) > 1 {
-		return fmt.Errorf(" Multiple Repositories with name %s found in project %s", name, projectID)
+		return fmt.Errorf("Multiple Repositories with name %s found in project %s", name, projectID)
 	}
 
 	repo := (*projectRepos)[0]
 	d.SetId(repo.Id.String())
 	err = flattenGitRepository(d, &repo)
 	if err != nil {
-		return fmt.Errorf(" flattening Git repository: %w", err)
+		return fmt.Errorf("flattening Git repository: %w", err)
 	}
 	return nil
 }

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -235,13 +235,13 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	repo, initialization, projectID, err := expandGitRepository(d)
 	if err != nil {
-		return fmt.Errorf(" failed expanding repository resource data (ProjectID:  %s, Repository: %s) Error: %+v",
+		return fmt.Errorf("failed expanding repository resource data (ProjectID:  %s, Repository: %s) Error: %+v",
 			d.Get("project_id").(string), d.Get("name").(string), err)
 	}
 
 	if _, ok := d.GetOk("default_branch"); ok {
 		if strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Uninitialized)) {
-			return fmt.Errorf(" Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannot not be set.")
+			return fmt.Errorf("Repository 'initialization.init_type = Uninitialized', there will be no branches, 'default_branch' cannot not be set.")
 		}
 	}
 
@@ -259,7 +259,7 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 		if parentRepoID, ok := d.GetOk("parent_repository_id"); ok {
 			parentRepo, err := gitRepositoryRead(clients, parentRepoID.(string), "", "")
 			if err != nil {
-				return fmt.Errorf(" Failed to locate parent repository [%s]: %+v", parentRepoID, err)
+				return fmt.Errorf("Failed to locate parent repository [%s]: %+v", parentRepoID, err)
 			}
 			args.GitRepositoryToCreate.ParentRepository = &git.GitRepositoryRef{
 				Id:      parentRepo.Id,
@@ -271,7 +271,7 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 
 	createdRepo, err := clients.GitReposClient.CreateRepository(clients.Ctx, args)
 	if err != nil {
-		return fmt.Errorf(" Creating repository in Azure DevOps: %+v", err)
+		return fmt.Errorf("Creating repository in Azure DevOps: %+v", err)
 	}
 
 	d.SetId(createdRepo.Id.String())
@@ -295,14 +295,14 @@ func resourceGitRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 		createdRepo.DefaultBranch = converter.String(v)
 		_, err = updateGitRepository(clients, createdRepo, projectID)
 		if err != nil {
-			return fmt.Errorf(" updating repository : %+v", err)
+			return fmt.Errorf("updating repository : %+v", err)
 		}
 	}
 
 	if v := d.Get("disabled").(bool); v {
 		_, err = updateIsDisabledGitRepository(clients, createdRepo.Id.String(), projectID.String(), true)
 		if err != nil {
-			return fmt.Errorf(" disabling created repository in Azure DevOps: %+v", err)
+			return fmt.Errorf("disabling created repository in Azure DevOps: %+v", err)
 		}
 	}
 
@@ -321,7 +321,7 @@ func resourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
+		return fmt.Errorf("Looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
 	}
 
 	if repo == nil {
@@ -334,7 +334,7 @@ func resourceGitRepositoryRead(d *schema.ResourceData, m interface{}) error {
 
 	err = flattenGitRepository(d, repo)
 	if err != nil {
-		return fmt.Errorf(" Flatten Git repository: %w", err)
+		return fmt.Errorf("Flatten Git repository: %w", err)
 	}
 	return nil
 }
@@ -344,7 +344,7 @@ func resourceGitRepositoryUpdate(d *schema.ResourceData, m interface{}) error {
 
 	repo, initialization, projectID, err := expandGitRepository(d)
 	if err != nil {
-		return fmt.Errorf(" Expanding Repository: %+v", err)
+		return fmt.Errorf("Expanding Repository: %+v", err)
 	}
 
 	parsedID, err := uuid.Parse(d.Id())
@@ -362,19 +362,19 @@ func resourceGitRepositoryUpdate(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Looking up repository with ID %s and Name %s. Error: %v", *repo.Id, *repo.Name, err)
+		return fmt.Errorf("Looking up repository with ID %s and Name %s. Error: %v", *repo.Id, *repo.Name, err)
 	}
 
 	// Enable before update to match the config, disabled repository cannot be updated. Disabled -> Enabled
 	if *repoExist.IsDisabled && !disabled {
 		repoExist, err = updateIsDisabledGitRepository(clients, repo.Id.String(), projectID.String(), disabled)
 		if err != nil {
-			return fmt.Errorf(" Enabling repository in Azure DevOps: %+v", err)
+			return fmt.Errorf("Enabling repository in Azure DevOps: %+v", err)
 		}
 	}
 
 	if *repoExist.IsDisabled {
-		return fmt.Errorf(" A disabled repository cannot be updated, please enable the repository before attempting to update : %s", repo.Id.String())
+		return fmt.Errorf("A disabled repository cannot be updated, please enable the repository before attempting to update : %s", repo.Id.String())
 	}
 
 	// Initialize the repository if not initialized
@@ -389,14 +389,14 @@ func resourceGitRepositoryUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 	_, err = updateGitRepository(clients, repo, projectID)
 	if err != nil {
-		return fmt.Errorf(" Updating repository in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating repository in Azure DevOps: %+v", err)
 	}
 
 	// Disable after updating to match the config, disabled repository cannot be updated Enabled -> Disabled
 	if !*repoExist.IsDisabled && disabled {
 		_, err = updateIsDisabledGitRepository(clients, repo.Id.String(), projectID.String(), disabled)
 		if err != nil {
-			return fmt.Errorf(" Disabling repository in Azure DevOps: %+v", err)
+			return fmt.Errorf("Disabling repository in Azure DevOps: %+v", err)
 		}
 	}
 
@@ -411,7 +411,7 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := uuid.Parse(repoID)
 	if err != nil {
-		return fmt.Errorf(" Invalid repository ID: %s", repoID)
+		return fmt.Errorf("Invalid repository ID: %s", repoID)
 	}
 
 	// you cannot delete a disabled repo
@@ -421,16 +421,16 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
+		return fmt.Errorf("looking up repository with ID %s and Name %s. Error: %v", repoID, repoName, err)
 	}
 
 	if *repoActual.IsDisabled {
-		return fmt.Errorf(" A disabled repository cannot be deleted, please enable the repository before attempting to delete : %s", repoID)
+		return fmt.Errorf("A disabled repository cannot be deleted, please enable the repository before attempting to delete : %s", repoID)
 	}
 
 	repoUUId, err := uuid.Parse(repoID)
 	if err != nil {
-		return fmt.Errorf(" Parse repository ID to UUID: %s. Error: %+v", repoID, err)
+		return fmt.Errorf("Parse repository ID to UUID: %s. Error: %+v", repoID, err)
 	}
 	err = clients.GitReposClient.DeleteRepository(clients.Ctx, git.DeleteRepositoryArgs{
 		RepositoryId: &repoUUId,
@@ -450,7 +450,7 @@ func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID
 			state := "Waiting"
 			gitRepo, err := gitRepositoryRead(clients, "", *repoName, projectID.String())
 			if err != nil {
-				return nil, "", fmt.Errorf(" Retrieving repository: %+v", err)
+				return nil, "", fmt.Errorf("Retrieving repository: %+v", err)
 			}
 
 			if converter.ToString(gitRepo.DefaultBranch, "") != "" {
@@ -465,7 +465,7 @@ func waitForBranch(clients *client.AggregatedClient, repoName *string, projectID
 		ContinuousTargetOccurence: 1,
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Retrieving expected branch for repository [%s]: %+v", *repoName, err)
+		return fmt.Errorf("Retrieving expected branch for repository [%s]: %+v", *repoName, err)
 	}
 	return nil
 }
@@ -561,7 +561,7 @@ func gitRepositoryRead(clients *client.AggregatedClient, repoID string, repoName
 func flattenGitRepository(d *schema.ResourceData, repository *git.GitRepository) error {
 	d.Set("name", repository.Name)
 	if repository.Project == nil || repository.Project.Id == nil {
-		return fmt.Errorf(" Unable to flatten Git repository without a valid projectID")
+		return fmt.Errorf("Unable to flatten Git repository without a valid projectID")
 	}
 	d.Set("project_id", repository.Project.Id.String())
 	d.Set("default_branch", repository.DefaultBranch)
@@ -630,7 +630,7 @@ func expandGitRepository(d *schema.ResourceData) (*git.GitRepository, *repoIniti
 func updateIsDisabledGitRepository(clients *client.AggregatedClient, repoID string, projectID string, isDisabled bool) (*git.GitRepository, error) {
 	uuid, err := uuid.Parse(repoID)
 	if err != nil {
-		return nil, fmt.Errorf(" invalid repositoryId UUID: %s", repoID)
+		return nil, fmt.Errorf("invalid repositoryId UUID: %s", repoID)
 	}
 	repo, err := clients.GitReposClient.UpdateRepository(
 		clients.Ctx,
@@ -640,7 +640,7 @@ func updateIsDisabledGitRepository(clients *client.AggregatedClient, repoID stri
 			Project:           converter.String(projectID),
 		})
 	if err != nil {
-		return nil, fmt.Errorf(" updating isDisabled on repository : %+v", err)
+		return nil, fmt.Errorf("updating isDisabled on repository : %+v", err)
 	}
 
 	return repo, nil
@@ -718,17 +718,17 @@ func initializeRepository(clients *client.AggregatedClient, initialization *repo
 					RepositoryId: repository.Id,
 				})
 				if err != nil {
-					return fmt.Errorf(" Creating repository in Azure DevOps: %+v", err)
+					return fmt.Errorf("Creating repository in Azure DevOps: %+v", err)
 				}
 
-				return fmt.Errorf(" Import repository in Azure DevOps: %+v ", importErr)
+				return fmt.Errorf("Import repository in Azure DevOps: %+v ", importErr)
 			}
 		}
 
 		if strings.EqualFold(initialization.initType, string(RepoInitTypeValues.Clean)) {
 			err := initializeGitRepository(clients, repository, repository.DefaultBranch)
 			if err != nil {
-				return fmt.Errorf(" initializing repository in Azure DevOps: %+v ", err)
+				return fmt.Errorf("initializing repository in Azure DevOps: %+v ", err)
 			}
 		}
 	}

--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -144,7 +144,7 @@ func resourceGitRepositoryBranchCreate(ctx context.Context, d *schema.ResourceDa
 		RepositoryId: converter.String(repoId),
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Creating branch %q: %+v", branchName, err))
+		return diag.FromErr(fmt.Errorf("Creating branch %q: %+v", branchName, err))
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", repoId, branchName))
@@ -229,12 +229,12 @@ func resourceGitRepositoryBranchDelete(ctx context.Context, d *schema.ResourceDa
 func updateRefs(clients *client.AggregatedClient, args git.UpdateRefsArgs) (*[]git.GitRefUpdateResult, error) {
 	updateRefResults, err := clients.GitReposClient.UpdateRefs(clients.Ctx, args)
 	if err != nil {
-		return nil, fmt.Errorf(" Updating refs: %w", err)
+		return nil, fmt.Errorf("Updating refs: %w", err)
 	}
 
 	for _, refUpdate := range *updateRefResults {
 		if !*refUpdate.Success {
-			return nil, fmt.Errorf(" Update refs failed. Update Status: %s", *refUpdate.UpdateStatus)
+			return nil, fmt.Errorf("Update refs failed. Update Status: %s", *refUpdate.UpdateStatus)
 		}
 	}
 

--- a/azuredevops/internal/service/git/resource_git_repository_branch.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch.go
@@ -109,21 +109,21 @@ func resourceGitRepositoryBranchCreate(ctx context.Context, d *schema.ResourceDa
 			PeelTags:     converter.Bool(true),
 		})
 		if err != nil {
-			return diag.FromErr(fmt.Errorf(" Getting refs matching %q: %w", filter, err))
+			return diag.FromErr(fmt.Errorf("Getting refs matching %q: %w", filter, err))
 		}
 
 		if len(gotRefs.Value) == 0 {
-			return diag.FromErr(fmt.Errorf(" No refs found that match ref %q.", rs))
+			return diag.FromErr(fmt.Errorf("No refs found that match ref %q.", rs))
 		}
 
 		gotRef := gotRefs.Value[0]
 		if gotRef.Name == nil {
-			return diag.FromErr(fmt.Errorf(" Got unexpected GetRefs response, a ref without a name was returned."))
+			return diag.FromErr(fmt.Errorf("Got unexpected GetRefs response, a ref without a name was returned."))
 		}
 
 		// Check for complete match. Sometimes refs exist that match prefix with Ref, but do not match completely.
 		if *gotRef.Name != rs {
-			return diag.FromErr(fmt.Errorf(" Ref %q not found, closest match is %q.", filter, *gotRef.Name))
+			return diag.FromErr(fmt.Errorf("Ref %q not found, closest match is %q.", filter, *gotRef.Name))
 		}
 
 		if gotRef.PeeledObjectId != nil {
@@ -131,7 +131,7 @@ func resourceGitRepositoryBranchCreate(ctx context.Context, d *schema.ResourceDa
 		} else if gotRef.ObjectId != nil {
 			newObjectId = *gotRef.ObjectId
 		} else {
-			return diag.FromErr(fmt.Errorf(" GetRefs response doesn't have a valid commit id."))
+			return diag.FromErr(fmt.Errorf("GetRefs response doesn't have a valid commit id."))
 		}
 	}
 
@@ -181,7 +181,7 @@ func resourceGitRepositoryBranchRead(ctx context.Context, d *schema.ResourceData
 				return nil
 			}
 		}
-		return diag.FromErr(fmt.Errorf(" Reading branch %q: %w", branchName, err))
+		return diag.FromErr(fmt.Errorf("Reading branch %q: %w", branchName, err))
 	}
 
 	d.Set("name", branchName)
@@ -208,7 +208,7 @@ func resourceGitRepositoryBranchDelete(ctx context.Context, d *schema.ResourceDa
 		Name:         &branchName,
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Getting latest commit of %q: %w", branchName, err))
+		return diag.FromErr(fmt.Errorf("Getting latest commit of %q: %w", branchName, err))
 	}
 
 	_, err = updateRefs(clients, git.UpdateRefsArgs{
@@ -220,7 +220,7 @@ func resourceGitRepositoryBranchDelete(ctx context.Context, d *schema.ResourceDa
 		RepositoryId: converter.String(repoId),
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Deleting branch %q: %w", branchName, err))
+		return diag.FromErr(fmt.Errorf("Deleting branch %q: %w", branchName, err))
 	}
 
 	return nil

--- a/azuredevops/internal/service/git/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch_test.go
@@ -215,7 +215,7 @@ func TestGitRepositoryBranch_Read(t *testing.T) {
 					m:   clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" Reading branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf("Reading branch \"a-branch\": an-error")),
 		},
 	}
 	for _, tt := range tests {
@@ -286,7 +286,7 @@ func TestGitRepositoryBranch_Delete(t *testing.T) {
 					m:   clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" Deleting branch \"a-branch\": Updating refs: an-error")),
+			diag.FromErr(fmt.Errorf("Deleting branch \"a-branch\": Updating refs: an-error")),
 		},
 	}
 	for _, tt := range tests {

--- a/azuredevops/internal/service/git/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/service/git/resource_git_repository_branch_test.go
@@ -73,7 +73,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf("Creating branch \"a-branch\": Updating refs: an-error")),
 		},
 		{
 			"When more than one of ref_commit_id, ref_tag, or ref_branch are given, the first one from left to right wins",
@@ -108,7 +108,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf("Creating branch \"a-branch\": Updating refs: an-error")),
 		},
 		{
 			"When invalid RefUpdate UpdateStatus, throw error",
@@ -159,7 +159,7 @@ func TestGitRepositoryBranch_Create(t *testing.T) {
 					clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" creating branch \"a-branch\": Error got invalid GitRefUpdate.UpdateStatus: invalidRefName")),
+			diag.FromErr(fmt.Errorf("Creating branch \"a-branch\": Update refs failed. Update Status: invalidRefName")),
 		},
 	}
 	for _, tt := range tests {
@@ -286,7 +286,7 @@ func TestGitRepositoryBranch_Delete(t *testing.T) {
 					m:   clients,
 				}
 			},
-			diag.FromErr(fmt.Errorf(" Deleting branch \"a-branch\": an-error")),
+			diag.FromErr(fmt.Errorf(" Deleting branch \"a-branch\": Updating refs: an-error")),
 		},
 	}
 	for _, tt := range tests {

--- a/azuredevops/internal/service/git/resource_git_repository_file.go
+++ b/azuredevops/internal/service/git/resource_git_repository_file.go
@@ -134,7 +134,7 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 		return err
 	}
 	if ref == nil {
-		return fmt.Errorf(" Creating Git file. Branch not found. Name: %s.", branch)
+		return fmt.Errorf("Creating Git file. Branch not found. Name: %s.", branch)
 	}
 
 	version := shortBranchName(branch)
@@ -154,7 +154,7 @@ func resourceGitRepositoryFileCreate(d *schema.ResourceData, m interface{}) erro
 	changeType := git.VersionControlChangeTypeValues.Add
 	if repoItem != nil {
 		if !overwriteOnCreate {
-			return fmt.Errorf(" Refusing to overwrite existing file. Configure `overwrite_on_create` to `true` to override.")
+			return fmt.Errorf("Refusing to overwrite existing file. Configure `overwrite_on_create` to `true` to override.")
 		}
 		changeType = git.VersionControlChangeTypeValues.Edit
 	}
@@ -206,12 +206,12 @@ func resourceGitRepositoryFileRead(d *schema.ResourceData, m interface{}) error 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Get Git file. Repository not found, repositoryID: %s. Error:  %+v", repoId, err)
+		return fmt.Errorf("Get Git file. Repository not found, repositoryID: %s. Error:  %+v", repoId, err)
 	}
 
 	ref, err := checkRepositoryBranchExists(clients, repoId, branch)
 	if err != nil {
-		return fmt.Errorf(" Get Git file. Failed to get repository branch. Repository ID: %s. Branch Name: %s. Error:  %+v", repoId, branch, err)
+		return fmt.Errorf("Get Git file. Failed to get repository branch. Repository ID: %s. Branch Name: %s. Error:  %+v", repoId, branch, err)
 	}
 
 	if ref == nil {
@@ -284,7 +284,7 @@ func resourceGitRepositoryFileUpdate(d *schema.ResourceData, m interface{}) erro
 
 	_, err := checkRepositoryBranchExists(clients, repoId, branch)
 	if err != nil {
-		return fmt.Errorf(" Updating Git file. Failed to get repository branch. Repository ID: %s. Branch Name: %s. Error:  %+v", repoId, branch, err)
+		return fmt.Errorf("Updating Git file. Failed to get repository branch. Repository ID: %s. Branch Name: %s. Error:  %+v", repoId, branch, err)
 	}
 
 	// Need to retry creating the file as multiple updates could happen at the same time
@@ -383,7 +383,7 @@ func checkRepositoryBranchExists(c *client.AggregatedClient, repoId, branch stri
 		Filter:       converter.String("heads/" + branchName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf(" Failed to get  the repository branch: %s. Error: %+v", branch, err)
+		return nil, fmt.Errorf("Failed to get  the repository branch: %s. Error: %+v", branch, err)
 	}
 	if resp != nil {
 		for _, ref := range resp.Value {

--- a/azuredevops/internal/service/graph/data_descriptor.go
+++ b/azuredevops/internal/service/graph/data_descriptor.go
@@ -40,7 +40,7 @@ func dataSourceDescriptorRead(ctx context.Context, d *schema.ResourceData, m int
 	storageKey := d.Get("storage_key").(string)
 	storageKeyUUId, err := uuid.Parse(storageKey)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(" Invalid storage key: %s. Error: %+v", storageKey, err))
+		return diag.FromErr(fmt.Errorf("Invalid storage key: %s. Error: %+v", storageKey, err))
 	}
 
 	descriptor, err := clients.GraphClient.GetDescriptor(clients.Ctx, graph.GetDescriptorArgs{StorageKey: &storageKeyUUId})
@@ -48,7 +48,7 @@ func dataSourceDescriptorRead(ctx context.Context, d *schema.ResourceData, m int
 		if utils.ResponseWasNotFound(err) {
 			return diag.Errorf(" The specified storage key %s does not exist.", storageKey)
 		}
-		return diag.FromErr(fmt.Errorf(" Reading storage key: %s. Error: %+v", storageKey, err))
+		return diag.FromErr(fmt.Errorf("Reading storage key: %s. Error: %+v", storageKey, err))
 	}
 
 	d.SetId(storageKey)

--- a/azuredevops/internal/service/graph/data_group.go
+++ b/azuredevops/internal/service/graph/data_group.go
@@ -64,9 +64,9 @@ func dataSourceGroupRead(d *schema.ResourceData, m interface{}) error {
 	projectDescriptor, err := getProjectDescriptor(clients, projectID)
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
-			return fmt.Errorf(" Project with with ID: %s was not found. Error: %v", projectID, err)
+			return fmt.Errorf("Project with with ID: %s was not found. Error: %v", projectID, err)
 		}
-		return fmt.Errorf(" Finding descriptor for project with ID: %s. Error: %v", projectID, err)
+		return fmt.Errorf("Finding descriptor for project with ID: %s. Error: %v", projectID, err)
 	}
 
 	projectGroups, err := getGroupsForDescriptor(clients, projectDescriptor)
@@ -81,9 +81,9 @@ func dataSourceGroupRead(d *schema.ResourceData, m interface{}) error {
 	targetGroup := selectGroup(projectGroups, groupName)
 	if targetGroup == nil {
 		if projectID != "" {
-			return fmt.Errorf(" Could not find Group with Name: %s in project with ID: %s", groupName, projectID)
+			return fmt.Errorf("Could not find Group with Name: %s in project with ID: %s", groupName, projectID)
 		}
-		return fmt.Errorf(" Could not find group with name %s", groupName)
+		return fmt.Errorf("Could not find group with name %s", groupName)
 	}
 
 	d.SetId(*targetGroup.Descriptor)
@@ -174,7 +174,7 @@ func getGroupsWithContinuationToken(clients *client.AggregatedClient, projectDes
 	}
 
 	if response.ContinuationToken != nil && len(*response.ContinuationToken) > 1 {
-		return nil, "", fmt.Errorf(" Expected at most 1 continuation token, but found %d", len(*response.ContinuationToken))
+		return nil, "", fmt.Errorf("Expected at most 1 continuation token, but found %d", len(*response.ContinuationToken))
 	}
 
 	var newToken string

--- a/azuredevops/internal/service/graph/data_groups.go
+++ b/azuredevops/internal/service/graph/data_groups.go
@@ -101,9 +101,9 @@ func dataSourceGroupsRead(d *schema.ResourceData, m interface{}) error {
 	projectDescriptor, err := getProjectDescriptor(clients, projectID)
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
-			return fmt.Errorf(" Project with with ID %s was not found. Error: %v", projectID, err)
+			return fmt.Errorf("Project with with ID %s was not found. Error: %v", projectID, err)
 		}
-		return fmt.Errorf(" Finding descriptor for project with ID %s. Error: %v", projectID, err)
+		return fmt.Errorf("Finding descriptor for project with ID %s. Error: %v", projectID, err)
 	}
 
 	groups, err := getGroupsForDescriptor(clients, projectDescriptor)
@@ -117,7 +117,7 @@ func dataSourceGroupsRead(d *schema.ResourceData, m interface{}) error {
 
 	fgroups, err := flattenGroups(groups)
 	if err != nil {
-		return fmt.Errorf(" Flatten groups. Error: %w", err)
+		return fmt.Errorf("Flatten groups. Error: %w", err)
 	}
 
 	for _, group := range fgroups {
@@ -149,7 +149,7 @@ func flattenGroups(groups *[]graph.GraphGroup) ([]interface{}, error) {
 		if group.Descriptor != nil {
 			s["descriptor"] = *group.Descriptor
 		} else {
-			return nil, fmt.Errorf(" Group Object does not contain a descriptor")
+			return nil, fmt.Errorf("Group Object does not contain a descriptor")
 		}
 		if group.DisplayName != nil {
 			s["display_name"] = *group.DisplayName

--- a/azuredevops/internal/service/graph/data_service_principal.go
+++ b/azuredevops/internal/service/graph/data_service_principal.go
@@ -57,18 +57,18 @@ func dataSourceServicePrincipalRead(d *schema.ResourceData, m interface{}) error
 	// Query ADO for list of identity user with filter
 	filteredServicePrincipals, err := getIdentityServicePrincipalsWithFilterValue(clients, searchFilter, displayName)
 	if err != nil || filteredServicePrincipals == nil || len(*filteredServicePrincipals) == 0 {
-		return fmt.Errorf(" Finding service principal with filter %s. Error: %v", *searchFilter, err)
+		return fmt.Errorf("Finding service principal with filter %s. Error: %v", *searchFilter, err)
 	}
 
 	flattenedServicePrincipals, err := flattenIdentityServicePrincipals(filteredServicePrincipals)
 	if err != nil {
-		return fmt.Errorf(" Flatten service principals. Error: %v", err)
+		return fmt.Errorf("Flatten service principals. Error: %v", err)
 	}
 
 	// Filter for the desired user in the FilterUsers results
 	targetServicePrincipal := validateIdentityServicePrincipal(flattenedServicePrincipals, displayName)
 	if targetServicePrincipal == nil {
-		return fmt.Errorf(" Could not find service principal with name: %s", displayName)
+		return fmt.Errorf("Could not find service principal with name: %s", displayName)
 	}
 
 	servicePrincipalDescriptor := targetServicePrincipal.SubjectDescriptor
@@ -76,9 +76,9 @@ func dataSourceServicePrincipalRead(d *schema.ResourceData, m interface{}) error
 	servicePrincipal, err := getServicePrincipal(clients, servicePrincipalDescriptor)
 	if err != nil {
 		if servicePrincipalDescriptor != nil {
-			return fmt.Errorf(" Finding service principal with Descriptor %s", *servicePrincipalDescriptor)
+			return fmt.Errorf("Finding service principal with Descriptor %s", *servicePrincipalDescriptor)
 		}
-		return fmt.Errorf(" Finding service principal. Error: %v", err)
+		return fmt.Errorf("Finding service principal. Error: %v", err)
 	}
 
 	d.SetId(*servicePrincipal.Descriptor)
@@ -102,12 +102,12 @@ func getIdentityServicePrincipalsWithFilterValue(clients *client.AggregatedClien
 // Flatten Query Results
 func flattenIdentityServicePrincipals(servicePrincipals *[]identity.Identity) (*[]identity.Identity, error) {
 	if servicePrincipals == nil || len(*servicePrincipals) == 0 {
-		return nil, fmt.Errorf(" Input Service Principals Parameter is nil")
+		return nil, fmt.Errorf("Input Service Principals Parameter is nil")
 	}
 	results := make([]identity.Identity, 0)
 	for _, servicePrincipal := range *servicePrincipals {
 		if servicePrincipal.Descriptor == nil {
-			return nil, fmt.Errorf(" User Object does not contain an id")
+			return nil, fmt.Errorf("User Object does not contain an id")
 		}
 		results = append(results, identity.Identity{
 			Id:                  servicePrincipal.Id,

--- a/azuredevops/internal/service/graph/data_storagekey.go
+++ b/azuredevops/internal/service/graph/data_storagekey.go
@@ -45,7 +45,7 @@ func dataSourceDataStorageKeyRead(ctx context.Context, d *schema.ResourceData, m
 		if utils.ResponseWasNotFound(err) {
 			return diag.Errorf(" The specified descriptor %s does not exist.", storageKey)
 		}
-		return diag.FromErr(fmt.Errorf(" Reading descriptor: %s. Error: %+v", storageKey, err))
+		return diag.FromErr(fmt.Errorf("Reading descriptor: %s. Error: %+v", storageKey, err))
 	}
 
 	d.SetId(storageKey.Value.String())

--- a/azuredevops/internal/service/graph/data_user.go
+++ b/azuredevops/internal/service/graph/data_user.go
@@ -76,7 +76,7 @@ func dataIdentitySourceUserRead(ctx context.Context, d *schema.ResourceData, m i
 		if utils.ResponseWasNotFound(err) {
 			return diag.Errorf(" User does not exist with descriptor: %s", descriptor)
 		}
-		return diag.FromErr(fmt.Errorf(" Reading User: %+v", err))
+		return diag.FromErr(fmt.Errorf("Reading User: %+v", err))
 	}
 
 	if user == nil {

--- a/azuredevops/internal/service/graph/data_users.go
+++ b/azuredevops/internal/service/graph/data_users.go
@@ -239,7 +239,7 @@ func getUsersWithContinuationToken(clients *client.AggregatedClient, subjectType
 	}
 	response, err := clients.GraphClient.ListUsers(clients.Ctx, args)
 	if err != nil {
-		return nil, "", fmt.Errorf(" Listing users: %q", err)
+		return nil, "", fmt.Errorf("Listing users: %q", err)
 	}
 
 	continuationToken = ""

--- a/azuredevops/internal/service/graph/resource_group.go
+++ b/azuredevops/internal/service/graph/resource_group.go
@@ -128,7 +128,7 @@ func resourceGroupCreate(d *schema.ResourceData, m interface{}) error {
 	if val, ok := d.GetOk("scope"); ok {
 		scopeUid, err := uuid.Parse(val.(string))
 		if err != nil {
-			return fmt.Errorf(" Parsing scope: %+v", err)
+			return fmt.Errorf("Parsing scope: %+v", err)
 		}
 		desc, err := clients.GraphClient.GetDescriptor(clients.Ctx, graph.GetDescriptorArgs{
 			StorageKey: &scopeUid,
@@ -181,7 +181,7 @@ func resourceGroupCreate(d *schema.ResourceData, m interface{}) error {
 	if ok {
 		members := expandGroupMembers(*group.Descriptor, stateMembers.(*schema.Set))
 		if err := addMembers(clients, members); err != nil {
-			return fmt.Errorf(" adding group memberships during create: %+v", err)
+			return fmt.Errorf("adding group memberships during create: %+v", err)
 		}
 	}
 
@@ -310,7 +310,7 @@ func resourceGroupDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Waiting for group delete. %v ", err)
+		return fmt.Errorf("Waiting for group delete. %v ", err)
 	}
 
 	return nil
@@ -366,7 +366,7 @@ func groupReadMembers(groupDescriptor string, clients *client.AggregatedClient) 
 		Depth:             converter.Int(1),
 	})
 	if err != nil {
-		return nil, fmt.Errorf(" Reading group memberships: %+v", err)
+		return nil, fmt.Errorf("Reading group memberships: %+v", err)
 	}
 
 	members := make([]graph.GraphMembership, len(*actualMembers))

--- a/azuredevops/internal/service/graph/resource_group_membership.go
+++ b/azuredevops/internal/service/graph/resource_group_membership.go
@@ -67,11 +67,11 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 	if strings.EqualFold("overwrite", mode) {
 		actualMemberships, err := getGroupMemberships(clients, group)
 		if err != nil {
-			return fmt.Errorf(" Reading group memberships during read: %+v", err)
+			return fmt.Errorf("Reading group memberships during read: %+v", err)
 		}
 		actualMembershipsSet := getGroupMembershipSet(actualMemberships)
 		if err != nil {
-			return fmt.Errorf(" Converting membership list to set: %+v", err)
+			return fmt.Errorf("Converting membership list to set: %+v", err)
 		}
 		membersToRemove = membersToAdd.Difference(actualMembershipsSet)
 	} else {
@@ -82,7 +82,7 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 		expandGroupMembers(group, membersToAdd),
 		expandGroupMembers(group, membersToRemove))
 	if err != nil {
-		return fmt.Errorf(" Adding group memberships during create: %+v", err)
+		return fmt.Errorf("Adding group memberships during create: %+v", err)
 	}
 
 	stateConf := &retry.StateChangeConf{
@@ -93,11 +93,11 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 			state := "Waiting"
 			actualMemberships, err := getGroupMemberships(clients, group)
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading group memberships: %+v", err)
+				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
 			if err != nil {
-				return nil, "", fmt.Errorf(" Converting membership list to set: %+v", err)
+				return nil, "", fmt.Errorf("Converting membership list to set: %+v", err)
 			}
 			if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() <= 0) &&
 				(membersToRemove == nil || actualMembershipsSet.Intersection(membersToRemove).Len() <= 0) {
@@ -131,7 +131,7 @@ func resourceGroupMembershipRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Eeading group memberships during read: %+v", err)
+		return fmt.Errorf("Eeading group memberships during read: %+v", err)
 	}
 
 	mode := d.Get("mode").(string)
@@ -175,7 +175,7 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 			state := "Waiting"
 			actualMemberships, err := getGroupMemberships(clients, group)
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading group memberships: %+v", err)
+				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
 			if actualMembershipsSet.Intersection(membersToAdd).Len() <= 0 &&
@@ -191,7 +191,7 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 		ContinuousTargetOccurence: 3,
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Waiting for DevOps synching memberships for group  [%s]: %+v", group, err)
+		return fmt.Errorf("Waiting for DevOps synching memberships for group  [%s]: %+v", group, err)
 	}
 
 	return resourceGroupMembershipRead(d, m)
@@ -212,7 +212,7 @@ func resourceGroupMembershipDelete(d *schema.ResourceData, m interface{}) error 
 			state := "Waiting"
 			actualMemberships, err := getGroupMemberships(clients, group)
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading group memberships: %+v", err)
+				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
 			if actualMembershipsSet.Intersection(membersToRemove).Len() <= 0 {
@@ -227,10 +227,10 @@ func resourceGroupMembershipDelete(d *schema.ResourceData, m interface{}) error 
 		ContinuousTargetOccurence: 2,
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Waiting for DevOps synching memberships for group  [%s]: %+v", group, err)
+		return fmt.Errorf("Waiting for DevOps synching memberships for group  [%s]: %+v", group, err)
 	}
 	if err != nil {
-		return fmt.Errorf(" Removing group memberships during delete: %+v", err)
+		return fmt.Errorf("Removing group memberships during delete: %+v", err)
 	}
 
 	return nil
@@ -240,14 +240,14 @@ func applyMembershipUpdate(clients *client.AggregatedClient, toAdd *[]graph.Grap
 	if toRemove != nil && len(*toRemove) > 0 {
 		err := removeMembers(clients, toRemove)
 		if err != nil {
-			return fmt.Errorf(" Removing group memberships during update: %+v", err)
+			return fmt.Errorf("Removing group memberships during update: %+v", err)
 		}
 	}
 
 	if toAdd != nil && len(*toAdd) > 0 {
 		err := addMembers(clients, toAdd)
 		if err != nil {
-			return fmt.Errorf(" Adding group memberships during update: %+v", err)
+			return fmt.Errorf("Adding group memberships during update: %+v", err)
 		}
 	}
 	return nil

--- a/azuredevops/internal/service/identity/data_identity_group.go
+++ b/azuredevops/internal/service/identity/data_identity_group.go
@@ -50,20 +50,20 @@ func dataSourceIdentityGroupRead(d *schema.ResourceData, m interface{}) error {
 	// Get groups in specified project ID
 	projectGroups, err := getIdentityGroupsWithProjectID(clients, projectID)
 	if err != nil {
-		return fmt.Errorf(" Failed to get groups for project with ID: %s. Error: %v", projectID, err)
+		return fmt.Errorf("Failed to get groups for project with ID: %s. Error: %v", projectID, err)
 	}
 
 	// Select specific group by name/provider name.
 	targetGroup := selectIdentityGroup(&projectGroups, groupName)
 	if targetGroup == nil {
-		return fmt.Errorf(" Can not find group with name %s in project with ID %s", groupName, projectID)
+		return fmt.Errorf("Can not find group with name %s in project with ID %s", groupName, projectID)
 	}
 
 	identityGroup, err := clients.IdentityClient.ReadIdentity(clients.Ctx, identity.ReadIdentityArgs{
 		IdentityId: converter.String(targetGroup.Id.String()),
 	})
 	if err != nil {
-		return fmt.Errorf(" Failed to get Identrity Groups for project with ID: %s. Error: %v", projectID, err)
+		return fmt.Errorf("Failed to get Identrity Groups for project with ID: %s. Error: %v", projectID, err)
 	}
 
 	// Set ID and descriptor for group data resource based on targetGroup output.

--- a/azuredevops/internal/service/identity/data_identity_groups.go
+++ b/azuredevops/internal/service/identity/data_identity_groups.go
@@ -61,7 +61,7 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 	// Get groups in specified project id
 	groups, err := getIdentityGroupsWithProjectID(clients, projectID)
 	if err != nil {
-		return fmt.Errorf(" Failed to get groups for project with ID %s. Error: %v", projectID, err)
+		return fmt.Errorf("Failed to get groups for project with ID %s. Error: %v", projectID, err)
 	}
 
 	identityIds := ""
@@ -73,13 +73,13 @@ func dataSourceIdentityGroupsRead(d *schema.ResourceData, m interface{}) error {
 		IdentityIds: &identityIds,
 	})
 	if err != nil {
-		return fmt.Errorf(" Failed to get Identity Groups for project with ID %s. Error: %v", projectID, err)
+		return fmt.Errorf("Failed to get Identity Groups for project with ID %s. Error: %v", projectID, err)
 	}
 
 	// With project groups flatten results
 	flattenedGroups, err := flattenIdentityGroups(identityGroups)
 	if err != nil {
-		return fmt.Errorf(" Flattening groups. Error: %w", err)
+		return fmt.Errorf("Flattening groups. Error: %w", err)
 	}
 
 	// Set id and group list for groups data resource
@@ -94,7 +94,7 @@ func getIdentityGroupsWithProjectID(clients *client.AggregatedClient, projectID 
 		ScopeIds: &projectID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf(" Getting groups: %v", err)
+		return nil, fmt.Errorf("Getting groups: %v", err)
 	}
 	return *response, nil
 }

--- a/azuredevops/internal/service/identity/data_identity_user.go
+++ b/azuredevops/internal/service/identity/data_identity_user.go
@@ -50,13 +50,13 @@ func dataIdentitySourceUserRead(d *schema.ResourceData, m interface{}) error {
 	// Query ADO for list of identity user with filter
 	filterUser, err := getIdentityUsersWithFilterValue(clients, searchFilter, userName)
 	if err != nil {
-		return fmt.Errorf(" Finding user with filter %s. Error: %v", searchFilter, err)
+		return fmt.Errorf("Finding user with filter %s. Error: %v", searchFilter, err)
 	}
 
 	// Filter for the desired user in the FilterUsers results
 	targetUser := validateIdentityUser(filterUser, userName, searchFilter)
 	if targetUser == nil {
-		return fmt.Errorf(" Could not find user with name: %s, with filter: %s", userName, searchFilter)
+		return fmt.Errorf("Could not find user with name: %s, with filter: %s", userName, searchFilter)
 	}
 
 	// Set id and user list for users data resource

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_group_entitlement.go
@@ -125,12 +125,12 @@ func resourceGroupEntitlementCreate(d *schema.ResourceData, m interface{}) error
 	clients := m.(*client.AggregatedClient)
 	groupEntitlement, err := expandGroupEntitlement(d)
 	if err != nil {
-		return fmt.Errorf(" Creating group entitlement: %v", err)
+		return fmt.Errorf("Creating group entitlement: %v", err)
 	}
 
 	addedGroupEntitlement, err := addGroupEntitlement(clients, groupEntitlement)
 	if err != nil {
-		return fmt.Errorf(" Creating group entitlement: %v", err)
+		return fmt.Errorf("Creating group entitlement: %v", err)
 	}
 
 	d.SetId(addedGroupEntitlement.Id.String())
@@ -142,7 +142,7 @@ func resourceGroupEntitlementRead(d *schema.ResourceData, m interface{}) error {
 	groupEntitlementID := d.Id()
 	id, err := uuid.Parse(groupEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing GroupEntitlementID: %s. %v", groupEntitlementID, err)
+		return fmt.Errorf("Parsing GroupEntitlementID: %s. %v", groupEntitlementID, err)
 	}
 	groupEntitlement, err := clients.MemberEntitleManagementClient.GetGroupEntitlement(clients.Ctx, memberentitlementmanagement.GetGroupEntitlementArgs{
 		GroupId: &id,
@@ -153,7 +153,7 @@ func resourceGroupEntitlementRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" reading group entitlement: %v", err)
+		return fmt.Errorf("reading group entitlement: %v", err)
 	}
 
 	if groupEntitlement == nil || groupEntitlement.Id == nil ||
@@ -171,7 +171,7 @@ func resourceGroupEntitlementUpdate(d *schema.ResourceData, m interface{}) error
 	groupEntitlementID := d.Id()
 	id, err := uuid.Parse(groupEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing GroupEntitlement ID. GroupEntitlementID: %s. %v", groupEntitlementID, err)
+		return fmt.Errorf("Parsing GroupEntitlement ID. GroupEntitlementID: %s. %v", groupEntitlementID, err)
 	}
 
 	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
@@ -180,7 +180,7 @@ func resourceGroupEntitlementUpdate(d *schema.ResourceData, m interface{}) error
 	}
 	licensingSource, ok := d.GetOk("licensing_source")
 	if !ok {
-		return fmt.Errorf(" Reading account licensing source for GroupEntitlementID: %s", groupEntitlementID)
+		return fmt.Errorf("Reading account licensing source for GroupEntitlementID: %s", groupEntitlementID)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -205,13 +205,13 @@ func resourceGroupEntitlementUpdate(d *schema.ResourceData, m interface{}) error
 		})
 
 	if err != nil {
-		return fmt.Errorf(" Updating group entitlement: %v", err)
+		return fmt.Errorf("Updating group entitlement: %v", err)
 	}
 
 	result := *patchResponse.Results
 
 	if !*result[0].IsSuccess {
-		return fmt.Errorf(" Updating group entitlement: %s", getGroupEntitlementAPIErrorMessage(&result))
+		return fmt.Errorf("Updating group entitlement: %s", getGroupEntitlementAPIErrorMessage(&result))
 	}
 	return resourceGroupEntitlementRead(d, m)
 }
@@ -224,7 +224,7 @@ func resourceGroupEntitlementDelete(d *schema.ResourceData, m interface{}) error
 	groupEntitlementID := d.Id()
 	id, err := uuid.Parse(groupEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing GroupEntitlement ID. GroupEntitlementID: %s. %v", groupEntitlementID, err)
+		return fmt.Errorf("Parsing GroupEntitlement ID. GroupEntitlementID: %s. %v", groupEntitlementID, err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -234,7 +234,7 @@ func resourceGroupEntitlementDelete(d *schema.ResourceData, m interface{}) error
 	})
 
 	if err != nil {
-		return fmt.Errorf(" Deleting group entitlement: %v", err)
+		return fmt.Errorf("Deleting group entitlement: %v", err)
 	}
 
 	// Also delete the org wise group if the group is Azure DevOps local, meaning
@@ -246,7 +246,7 @@ func resourceGroupEntitlementDelete(d *schema.ResourceData, m interface{}) error
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Deleting Azure DevOps local group: %v", err)
+			return fmt.Errorf("Deleting Azure DevOps local group: %v", err)
 		}
 	}
 
@@ -258,7 +258,7 @@ func importGroupEntitlement(d *schema.ResourceData, m interface{}) ([]*schema.Re
 	id, err := uuid.Parse(upn)
 
 	if err != nil {
-		return nil, fmt.Errorf(" Only UUID values can used for import [%s]", upn)
+		return nil, fmt.Errorf("Only UUID values can used for import [%s]", upn)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -266,11 +266,11 @@ func importGroupEntitlement(d *schema.ResourceData, m interface{}) ([]*schema.Re
 		GroupId: &id,
 	})
 	if err != nil {
-		return nil, fmt.Errorf(" Getting the group entitlement with supplied id %s: %s", upn, err)
+		return nil, fmt.Errorf("Getting the group entitlement with supplied id %s: %s", upn, err)
 	}
 
 	if resp == nil || resp.Id == nil {
-		return nil, fmt.Errorf(" Group entitlement with ID: %s not found", upn)
+		return nil, fmt.Errorf("Group entitlement with ID: %s not found", upn)
 	}
 
 	d.SetId((*resp).Id.String())
@@ -335,7 +335,7 @@ func addGroupEntitlement(clients *client.AggregatedClient, groupEntitlement *mem
 		if result[0].Errors != nil {
 			opResults = append(opResults, result[0])
 		}
-		return nil, fmt.Errorf(" Adding group entitlement: %s", getGroupEntitlementAPIErrorMessage(&opResults))
+		return nil, fmt.Errorf("Adding group entitlement: %s", getGroupEntitlementAPIErrorMessage(&opResults))
 	}
 
 	return result[0].Result, nil

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_service_principal_entitlement.go
@@ -114,12 +114,12 @@ func resourceServicePrincipalEntitlementCreate(d *schema.ResourceData, m interfa
 	clients := m.(*client.AggregatedClient)
 	servicePrincipalEntitlement, err := expandServicePrincipalEntitlement(d)
 	if err != nil {
-		return fmt.Errorf(" Creating service principal entitlement: %v", err)
+		return fmt.Errorf("Creating service principal entitlement: %v", err)
 	}
 
 	addedServicePrincipalEntitlement, err := addServicePrincipalEntitlement(clients, servicePrincipalEntitlement)
 	if err != nil {
-		return fmt.Errorf(" Creating service principal entitlement: %v", err)
+		return fmt.Errorf("Creating service principal entitlement: %v", err)
 	}
 
 	d.SetId(addedServicePrincipalEntitlement.Id.String())
@@ -131,7 +131,7 @@ func resourceServicePrincipalEntitlementRead(d *schema.ResourceData, m interface
 	servicePrincipalEntitlementID := d.Id()
 	id, err := uuid.Parse(servicePrincipalEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+		return fmt.Errorf("Parsing ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
 	}
 
 	servicePrincipalEntitlement, err := clients.MemberEntitleManagementClient.GetServicePrincipalEntitlement(clients.Ctx, memberentitlementmanagement.GetServicePrincipalEntitlementArgs{
@@ -143,7 +143,7 @@ func resourceServicePrincipalEntitlementRead(d *schema.ResourceData, m interface
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Reading service principal entitlement: %v", err)
+		return fmt.Errorf("Reading service principal entitlement: %v", err)
 	}
 
 	if servicePrincipalEntitlement == nil || servicePrincipalEntitlement.Id == nil ||
@@ -161,12 +161,12 @@ func resourceServicePrincipalEntitlementUpdate(d *schema.ResourceData, m interfa
 	servicePrincipalEntitlementID := d.Id()
 	id, err := uuid.Parse(servicePrincipalEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+		return fmt.Errorf("Parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
 	}
 
 	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
 	if err != nil {
-		return fmt.Errorf(" Convert AccountLicenseType: %v", err)
+		return fmt.Errorf("Convert AccountLicenseType: %v", err)
 	}
 	licensingSource, _ := d.GetOk("licensing_source")
 
@@ -192,11 +192,11 @@ func resourceServicePrincipalEntitlementUpdate(d *schema.ResourceData, m interfa
 		})
 
 	if err != nil {
-		return fmt.Errorf(" Updating service principal entitlement: %v", err)
+		return fmt.Errorf("Updating service principal entitlement: %v", err)
 	}
 
 	if patchResponse != nil && patchResponse.IsSuccess != nil && !*patchResponse.IsSuccess {
-		return fmt.Errorf(" Updating service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(patchResponse.OperationResults))
+		return fmt.Errorf("Updating service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(patchResponse.OperationResults))
 	}
 	return resourceServicePrincipalEntitlementRead(d, m)
 }
@@ -209,7 +209,7 @@ func resourceServicePrincipalEntitlementDelete(d *schema.ResourceData, m interfa
 	servicePrincipalEntitlementID := d.Id()
 	id, err := uuid.Parse(servicePrincipalEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
+		return fmt.Errorf("Parsing ServicePrincipalEntitlement ID. ServicePrincipalEntitlementID: %s. %v", servicePrincipalEntitlementID, err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -219,7 +219,7 @@ func resourceServicePrincipalEntitlementDelete(d *schema.ResourceData, m interfa
 	})
 
 	if err != nil {
-		return fmt.Errorf(" Deleting service principal entitlement: %v", err)
+		return fmt.Errorf("Deleting service principal entitlement: %v", err)
 	}
 
 	return nil
@@ -272,7 +272,7 @@ func addServicePrincipalEntitlement(clients *client.AggregatedClient, servicePri
 		if servicePrincipalEntitlementsPostResponse.OperationResult != nil {
 			opResults = append(opResults, *servicePrincipalEntitlementsPostResponse.OperationResult)
 		}
-		return nil, fmt.Errorf(" Adding service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(&opResults))
+		return nil, fmt.Errorf("Adding service principal entitlement: %s", getServicePrincipalEntitlementAPIErrorMessage(&opResults))
 	}
 
 	return servicePrincipalEntitlementsPostResponse.ServicePrincipalEntitlement, nil
@@ -283,7 +283,7 @@ func importServicePrincipalEntitlement(d *schema.ResourceData, m interface{}) ([
 	id, err := uuid.Parse(servicePrincipalEntitlementId)
 
 	if err != nil {
-		return nil, fmt.Errorf(" Only UUID values can used for import [%s]", servicePrincipalEntitlementId)
+		return nil, fmt.Errorf("Only UUID values can used for import [%s]", servicePrincipalEntitlementId)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -291,11 +291,11 @@ func importServicePrincipalEntitlement(d *schema.ResourceData, m interface{}) ([
 		ServicePrincipalId: &id,
 	})
 	if err != nil {
-		return nil, fmt.Errorf(" Getting the service principal entitlement with supplied id %s: %s", servicePrincipalEntitlementId, err)
+		return nil, fmt.Errorf("Getting the service principal entitlement with supplied id %s: %s", servicePrincipalEntitlementId, err)
 	}
 
 	if resp == nil || resp.Id == nil {
-		return nil, fmt.Errorf(" Service Principal entitlement with ID: %s not found", servicePrincipalEntitlementId)
+		return nil, fmt.Errorf("Service Principal entitlement with ID: %s not found", servicePrincipalEntitlementId)
 	}
 
 	d.SetId((*resp).Id.String())

--- a/azuredevops/internal/service/memberentitlementmanagement/resource_user_entitlement.go
+++ b/azuredevops/internal/service/memberentitlementmanagement/resource_user_entitlement.go
@@ -125,12 +125,12 @@ func resourceUserEntitlementCreate(d *schema.ResourceData, m interface{}) error 
 	clients := m.(*client.AggregatedClient)
 	userEntitlement, err := expandUserEntitlement(d)
 	if err != nil {
-		return fmt.Errorf(" Creating user entitlement: %v", err)
+		return fmt.Errorf("Creating user entitlement: %v", err)
 	}
 
 	addedUserEntitlement, err := addUserEntitlement(clients, userEntitlement)
 	if err != nil {
-		return fmt.Errorf(" Creating user entitlement: %v", err)
+		return fmt.Errorf("Creating user entitlement: %v", err)
 	}
 
 	d.SetId(addedUserEntitlement.Id.String())
@@ -142,7 +142,7 @@ func resourceUserEntitlementRead(d *schema.ResourceData, m interface{}) error {
 	userEntitlementID := d.Id()
 	id, err := uuid.Parse(userEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing UserEntitlementID: %s. %v", userEntitlementID, err)
+		return fmt.Errorf("Parsing UserEntitlementID: %s. %v", userEntitlementID, err)
 	}
 
 	userEntitlement, err := clients.MemberEntitleManagementClient.GetUserEntitlement(clients.Ctx, memberentitlementmanagement.GetUserEntitlementArgs{
@@ -154,7 +154,7 @@ func resourceUserEntitlementRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Reading user entitlement: %v", err)
+		return fmt.Errorf("Reading user entitlement: %v", err)
 	}
 
 	flattenUserEntitlement(d, userEntitlement)
@@ -165,7 +165,7 @@ func resourceUserEntitlementUpdate(d *schema.ResourceData, m interface{}) error 
 	userEntitlementID := d.Id()
 	id, err := uuid.Parse(userEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing UserEntitlement ID. UserEntitlementID: %s. %v", userEntitlementID, err)
+		return fmt.Errorf("Parsing UserEntitlement ID. UserEntitlementID: %s. %v", userEntitlementID, err)
 	}
 
 	accountLicenseType, err := converter.AccountLicenseType(d.Get("account_license_type").(string))
@@ -174,7 +174,7 @@ func resourceUserEntitlementUpdate(d *schema.ResourceData, m interface{}) error 
 	}
 	licensingSource, ok := d.GetOk("licensing_source")
 	if !ok {
-		return fmt.Errorf(" Reading account licensing source for UserEntitlementID: %s", userEntitlementID)
+		return fmt.Errorf("Reading account licensing source for UserEntitlementID: %s", userEntitlementID)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -199,11 +199,11 @@ func resourceUserEntitlementUpdate(d *schema.ResourceData, m interface{}) error 
 		})
 
 	if err != nil {
-		return fmt.Errorf(" Updating user entitlement: %v", err)
+		return fmt.Errorf("Updating user entitlement: %v", err)
 	}
 
 	if !*patchResponse.IsSuccess {
-		return fmt.Errorf(" Updating user entitlement: %s", getUserEntitlementAPIErrorMessage(patchResponse.OperationResults))
+		return fmt.Errorf("Updating user entitlement: %s", getUserEntitlementAPIErrorMessage(patchResponse.OperationResults))
 	}
 	return resourceUserEntitlementRead(d, m)
 }
@@ -216,7 +216,7 @@ func resourceUserEntitlementDelete(d *schema.ResourceData, m interface{}) error 
 	userEntitlementID := d.Id()
 	id, err := uuid.Parse(userEntitlementID)
 	if err != nil {
-		return fmt.Errorf(" Parsing UserEntitlement ID. UserEntitlementID: %s. %v", userEntitlementID, err)
+		return fmt.Errorf("Parsing UserEntitlement ID. UserEntitlementID: %s. %v", userEntitlementID, err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -226,7 +226,7 @@ func resourceUserEntitlementDelete(d *schema.ResourceData, m interface{}) error 
 	})
 
 	if err != nil {
-		return fmt.Errorf(" Deleting user entitlement: %v", err)
+		return fmt.Errorf("Deleting user entitlement: %v", err)
 	}
 
 	return nil
@@ -287,7 +287,7 @@ func addUserEntitlement(clients *client.AggregatedClient, userEntitlement *membe
 		if userEntitlementsPostResponse.OperationResult != nil {
 			opResults = append(opResults, *userEntitlementsPostResponse.OperationResult)
 		}
-		return nil, fmt.Errorf(" Adding user entitlement: %s", getUserEntitlementAPIErrorMessage(&opResults))
+		return nil, fmt.Errorf("Adding user entitlement: %s", getUserEntitlementAPIErrorMessage(&opResults))
 	}
 
 	return userEntitlementsPostResponse.UserEntitlement, nil

--- a/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_build_folder_permissions.go
@@ -110,11 +110,11 @@ func createBuildFolderToken(d *schema.ResourceData, clients *client.AggregatedCl
 	})
 
 	if err != nil {
-		return "", fmt.Errorf(" failed to get the folder. Project ID: %s, Path: %s. %+v", projectID, buildFolderPath, err)
+		return "", fmt.Errorf("failed to get the folder. Project ID: %s, Path: %s. %+v", projectID, buildFolderPath, err)
 	}
 
 	if buildFolders == nil || len(*buildFolders) == 0 {
-		return "", fmt.Errorf(" folder not found. Project ID: %s, Path: %s.", projectID, buildFolderPath)
+		return "", fmt.Errorf("folder not found. Project ID: %s, Path: %s.", projectID, buildFolderPath)
 	}
 
 	Folder := (*buildFolders)[0]

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -294,7 +294,7 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 	}
 
 	if idlist == nil || len(*idlist) <= 0 {
-		return nil, fmt.Errorf(" No identity information for defined principals [%s]", descriptors)
+		return nil, fmt.Errorf("No identity information for defined principals [%s]", descriptors)
 	}
 
 	linq.From(*idlist).Where(func(ele interface{}) bool {
@@ -307,7 +307,7 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 	}).ToSlice(idlist)
 
 	if len(*idlist) != len(*principal) {
-		return nil, fmt.Errorf(" Failed to load identity information for defined principals [%s]", descriptors)
+		return nil, fmt.Errorf("Failed to load identity information for defined principals [%s]", descriptors)
 	}
 	return idlist, nil
 }
@@ -478,7 +478,7 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(principal *[]string) (*[]Pr
 				Descriptors: converter.String(descriptor),
 			})
 			if err != nil {
-				return nil, fmt.Errorf(" Unable to get identity details for descriptor [%s]", descriptor)
+				return nil, fmt.Errorf("Unable to get identity details for descriptor [%s]", descriptor)
 			}
 			idMap[descriptor] = (*identityDetails)[0]
 		}
@@ -491,7 +491,7 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(principal *[]string) (*[]Pr
 			return nil, fmt.Errorf("INTERAL ERROR: identity map does not contain an item with key [%s]", descriptor)
 		}
 		if subject.SubjectDescriptor == nil {
-			return nil, fmt.Errorf(" Identity %s does not contain a subject descriptor value", descriptor)
+			return nil, fmt.Errorf("Identity %s does not contain a subject descriptor value", descriptor)
 		}
 
 		subjectPerm := PrincipalPermission{

--- a/azuredevops/internal/service/permissions/utils/securityHelper.go
+++ b/azuredevops/internal/service/permissions/utils/securityHelper.go
@@ -14,12 +14,12 @@ import (
 func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forcePermission *PermissionType, forceReplace bool) error {
 	principal, ok := d.GetOk("principal")
 	if !ok {
-		return fmt.Errorf(" Failed to get 'principal' from schema")
+		return fmt.Errorf("Failed to get 'principal' from schema")
 	}
 
 	permissions, ok := d.GetOk("permissions")
 	if !ok {
-		return fmt.Errorf(" Failed to get 'permissions' from schema")
+		return fmt.Errorf("Failed to get 'permissions' from schema")
 	}
 
 	bReplace := d.Get("replace")
@@ -56,10 +56,10 @@ func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forc
 				principal.(string),
 			})
 			if err != nil {
-				return nil, "", fmt.Errorf(" Reading permissions for principal %s: %+v", err, principal.(string))
+				return nil, "", fmt.Errorf("Reading permissions for principal %s: %+v", err, principal.(string))
 			}
 			if len(*currentPermissions) != 1 {
-				return nil, "", fmt.Errorf(" Received multiple permission sets for principal [%s] from backend. Expected single value.", principal.(string))
+				return nil, "", fmt.Errorf("Received multiple permission sets for principal [%s] from backend. Expected single value.", principal.(string))
 			}
 
 			bInsnyc := false
@@ -83,7 +83,7 @@ func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forc
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil { //nolint:staticcheck
-		return fmt.Errorf(" waiting for permission update. %v ", err)
+		return fmt.Errorf("waiting for permission update. %v ", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", sn.token, principal.(string)))
@@ -94,12 +94,12 @@ func SetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace, forc
 func GetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace) (*PrincipalPermission, error) {
 	principal, ok := d.GetOk("principal")
 	if !ok {
-		return nil, fmt.Errorf(" Failed to get 'principal' from schema")
+		return nil, fmt.Errorf("Failed to get 'principal' from schema")
 	}
 
 	permissions, ok := d.GetOk("permissions")
 	if !ok {
-		return nil, fmt.Errorf(" Failed to get 'permissions' from schema")
+		return nil, fmt.Errorf("Failed to get 'permissions' from schema")
 	}
 
 	principalList := []string{*converter.StringFromInterface(principal)}
@@ -111,7 +111,7 @@ func GetPrincipalPermissions(d *schema.ResourceData, sn *SecurityNamespace) (*Pr
 		return nil, nil
 	}
 	if len(*principalPermissions) != 1 {
-		return nil, fmt.Errorf(" Failed to retrieve current permissions for principal [%s]", principalList[0])
+		return nil, fmt.Errorf("Failed to retrieve current permissions for principal [%s]", principalList[0])
 	}
 	for key := range ((*principalPermissions)[0]).Permissions {
 		if _, ok := permissions.(map[string]interface{})[string(key)]; !ok {

--- a/azuredevops/internal/service/policy/branch/common.go
+++ b/azuredevops/internal/service/policy/branch/common.go
@@ -136,7 +136,7 @@ func baseFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 	}
 	err = d.Set("settings", settings)
 	if err != nil {
-		return fmt.Errorf(" Unable to persist policy settings configuration: %+v", err)
+		return fmt.Errorf("Unable to persist policy settings configuration: %+v", err)
 	}
 	return nil
 }
@@ -145,12 +145,12 @@ func flattenSettings(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 	policySettings := commonPolicySettings{}
 	policyAsJSON, err := json.Marshal(policyConfig.Settings)
 	if err != nil {
-		return nil, fmt.Errorf(" Unable to marshal policy settings into JSON: %+v", err)
+		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
 	err = json.Unmarshal(policyAsJSON, &policySettings)
 	if err != nil {
-		return nil, fmt.Errorf(" Unable to unmarshal policy settings. Error: %+v", err)
+		return nil, fmt.Errorf("Unable to unmarshal policy settings. Error: %+v", err)
 	}
 	scopes := make([]interface{}, len(policySettings.Scopes))
 	for index, scope := range policySettings.Scopes {
@@ -179,7 +179,7 @@ func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyCon
 	projectID := d.Get("project_id").(string)
 	policySettings, err := expandSettings(d)
 	if err != nil {
-		return nil, nil, fmt.Errorf(" parsing policy configuration settings: (%+v)", err)
+		return nil, nil, fmt.Errorf("parsing policy configuration settings: (%+v)", err)
 	}
 	policyConfig := policy.PolicyConfiguration{
 		IsEnabled:  converter.Bool(d.Get("enabled").(bool)),
@@ -193,7 +193,7 @@ func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyCon
 	if d.Id() != "" {
 		policyID, err := strconv.Atoi(d.Id())
 		if err != nil {
-			return nil, nil, fmt.Errorf(" parsing policy configuration ID: (%+v)", err)
+			return nil, nil, fmt.Errorf("parsing policy configuration ID: (%+v)", err)
 		}
 		policyConfig.Id = &policyID
 	}
@@ -233,7 +233,7 @@ func expandSettings(d *schema.ResourceData) (map[string]interface{}, error) {
 			}
 		}
 		if strings.EqualFold(scopeSetting["matchKind"].(string), "DefaultBranch") && (scopeSetting["repositoryId"] != nil || scopeSetting["refName"] != nil) {
-			return nil, fmt.Errorf(" neither 'repository_id' nor 'repository_ref' can be set when 'match_type=DefaultBranch'")
+			return nil, fmt.Errorf("neither 'repository_id' nor 'repository_ref' can be set when 'match_type=DefaultBranch'")
 		}
 		scopes[index] = scopeSetting
 	}
@@ -257,7 +257,7 @@ func genPolicyCreateFunc(crudArgs *policyCrudArgs) schema.CreateFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" creating policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("creating policy in Azure DevOps: %+v", err)
 		}
 
 		d.SetId(strconv.Itoa(*createdPolicy.Id))
@@ -273,7 +273,7 @@ func genPolicyReadFunc(crudArgs *policyCrudArgs) schema.ReadFunc { //nolint:stat
 		policyID, err := strconv.Atoi(d.Id())
 
 		if err != nil {
-			return fmt.Errorf(" converting policy ID to an integer: (%+v)", err)
+			return fmt.Errorf("converting policy ID to an integer: (%+v)", err)
 		}
 
 		policyConfig, err := clients.PolicyClient.GetPolicyConfiguration(clients.Ctx, policy.GetPolicyConfigurationArgs{
@@ -287,7 +287,7 @@ func genPolicyReadFunc(crudArgs *policyCrudArgs) schema.ReadFunc { //nolint:stat
 		}
 
 		if err != nil {
-			return fmt.Errorf(" looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
+			return fmt.Errorf("looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
 		}
 
 		return crudArgs.FlattenFunc(d, policyConfig, &projectID)
@@ -310,7 +310,7 @@ func genPolicyUpdateFunc(crudArgs *policyCrudArgs) schema.UpdateFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" updating policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("updating policy in Azure DevOps: %+v", err)
 		}
 
 		return genPolicyReadFunc(crudArgs)(d, m)
@@ -332,7 +332,7 @@ func genPolicyDeleteFunc(crudArgs *policyCrudArgs) schema.DeleteFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" deleting policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("deleting policy in Azure DevOps: %+v", err)
 		}
 
 		return nil

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_build_validation.go
@@ -73,13 +73,13 @@ func buildValidationFlattenFunc(d *schema.ResourceData, policyConfig *policy.Pol
 	}
 	policyAsJSON, err := json.Marshal(policyConfig.Settings)
 	if err != nil {
-		return fmt.Errorf(" Unable to marshal policy settings into JSON: %+v", err)
+		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
 	policySettings := buildValidationPolicySettings{}
 	err = json.Unmarshal(policyAsJSON, &policySettings)
 	if err != nil {
-		return fmt.Errorf(" Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
+		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
 	}
 
 	settingsList := d.Get("settings").([]interface{})

--- a/azuredevops/internal/service/policy/branch/resource_branchpolicy_merge_types.go
+++ b/azuredevops/internal/service/policy/branch/resource_branchpolicy_merge_types.go
@@ -62,13 +62,13 @@ func mergeTypesFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyCo
 	}
 	policyAsJSON, err := json.Marshal(policyConfig.Settings)
 	if err != nil {
-		return fmt.Errorf(" Unable to marshal policy settings into JSON: %+v", err)
+		return fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
 	policySettings := mergeTypePolicySettings{}
 	err = json.Unmarshal(policyAsJSON, &policySettings)
 	if err != nil {
-		return fmt.Errorf(" Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
+		return fmt.Errorf("Unable to unmarshal branch policy settings (%+v): %+v", policySettings, err)
 	}
 
 	settingsList := d.Get("settings").([]interface{})

--- a/azuredevops/internal/service/policy/repository/common.go
+++ b/azuredevops/internal/service/policy/repository/common.go
@@ -100,7 +100,7 @@ func genPolicyCreateFunc(crudArgs *policyCrudArgs) schema.CreateFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Creating policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("Creating policy in Azure DevOps: %+v", err)
 		}
 
 		d.SetId(strconv.Itoa(*createPolicy.Id))
@@ -116,7 +116,7 @@ func genPolicyReadFunc(crudArgs *policyCrudArgs) schema.ReadFunc { //nolint:stat
 		policyID, err := strconv.Atoi(d.Id())
 
 		if err != nil {
-			return fmt.Errorf(" Converting policy ID to an integer: (%+v)", err)
+			return fmt.Errorf("Converting policy ID to an integer: (%+v)", err)
 		}
 
 		policyConfig, err := clients.PolicyClient.GetPolicyConfiguration(clients.Ctx, policy.GetPolicyConfigurationArgs{
@@ -130,7 +130,7 @@ func genPolicyReadFunc(crudArgs *policyCrudArgs) schema.ReadFunc { //nolint:stat
 		}
 
 		if err != nil {
-			return fmt.Errorf(" Looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
+			return fmt.Errorf("Looking up build policy configuration with ID (%v) and project ID (%v): %v", policyID, projectID, err)
 		}
 
 		return crudArgs.FlattenFunc(d, policyConfig, &projectID)
@@ -153,7 +153,7 @@ func genPolicyUpdateFunc(crudArgs *policyCrudArgs) schema.UpdateFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Updating policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("Updating policy in Azure DevOps: %+v", err)
 		}
 
 		return genPolicyReadFunc(crudArgs)(d, m)
@@ -175,7 +175,7 @@ func genPolicyDeleteFunc(crudArgs *policyCrudArgs) schema.DeleteFunc { //nolint:
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Deleting policy in Azure DevOps: %+v", err)
+			return fmt.Errorf("Deleting policy in Azure DevOps: %+v", err)
 		}
 
 		return nil
@@ -192,7 +192,7 @@ func baseFlattenFunc(d *schema.ResourceData, policyConfig *policy.PolicyConfigur
 	}
 	err = d.Set("repository_ids", repoIds)
 	if err != nil {
-		return fmt.Errorf(" Unable to persist policy settings configuration: %+v", err)
+		return fmt.Errorf("Unable to persist policy settings configuration: %+v", err)
 	}
 	return nil
 }
@@ -202,12 +202,12 @@ func flattenSettings(policyConfig *policy.PolicyConfiguration) ([]interface{}, e
 	policyAsJSON, err := json.Marshal(policyConfig.Settings)
 
 	if err != nil {
-		return nil, fmt.Errorf(" Unable to marshal policy settings into JSON: %+v", err)
+		return nil, fmt.Errorf("Unable to marshal policy settings into JSON: %+v", err)
 	}
 
 	err = json.Unmarshal(policyAsJSON, &policySettings)
 	if err != nil {
-		return nil, fmt.Errorf(" Unable to unmarshal policy settings. Error: %+v", err)
+		return nil, fmt.Errorf("Unable to unmarshal policy settings. Error: %+v", err)
 	}
 	var repoIds []interface{}
 	for _, scope := range policySettings.Scopes {
@@ -233,7 +233,7 @@ func baseExpandFunc(d *schema.ResourceData, typeID uuid.UUID) (*policy.PolicyCon
 	if d.Id() != "" {
 		policyID, err := strconv.Atoi(d.Id())
 		if err != nil {
-			return nil, nil, fmt.Errorf(" parsing policy configuration ID: (%+v)", err)
+			return nil, nil, fmt.Errorf("parsing policy configuration ID: (%+v)", err)
 		}
 		policyConfig.Id = &policyID
 	}

--- a/azuredevops/internal/service/securityroles/data_securityrole_definitions.go
+++ b/azuredevops/internal/service/securityroles/data_securityrole_definitions.go
@@ -80,12 +80,12 @@ func dataSecurityRoleDefinitionsRead(d *schema.ResourceData, m interface{}) erro
 	})
 	if err != nil {
 		d.SetId("")
-		return fmt.Errorf(" finding security role definitions for scope: %s. Error: %v", scope, err)
+		return fmt.Errorf("finding security role definitions for scope: %s. Error: %v", scope, err)
 	}
 
 	if defs == nil || len(*defs) == 0 {
 		d.SetId("")
-		return fmt.Errorf(" no role definition found at scope: %s", scope)
+		return fmt.Errorf("no role definition found at scope: %s", scope)
 	}
 
 	fdefs, err := flattenSRD(defs)

--- a/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
+++ b/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
@@ -111,7 +111,7 @@ func resourceSecurityRoleAssignmentRead(d *schema.ResourceData, m interface{}) e
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" reading group memberships during read: %+v", err)
+		return fmt.Errorf("reading group memberships during read: %+v", err)
 	}
 
 	if assignment != nil && (assignment.Identity == nil && assignment.Role == nil) {

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -91,7 +91,7 @@ func createServiceEndpoint(d *schema.ResourceData, clients *client.AggregatedCli
 		if delErr := deleteServiceEndpoint(clients, createdServiceEndpoint, d.Timeout(schema.TimeoutDelete)); delErr != nil {
 			log.Printf("[DEBUG] Failed to delete the failed service endpoint: %v ", delErr)
 		}
-		return nil, fmt.Errorf(" waiting for service endpoint ready. %v ", err)
+		return nil, fmt.Errorf("waiting for service endpoint ready. %v ", err)
 	}
 
 	return createdServiceEndpoint, err
@@ -118,7 +118,7 @@ func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *se
 			},
 			EndpointId: serviceEndpoint.Id,
 		}); err != nil {
-		return fmt.Errorf(" Delete service endpoint error %v", err)
+		return fmt.Errorf("Delete service endpoint error %v", err)
 	}
 
 	stateConf := &retry.StateChangeConf{
@@ -132,7 +132,7 @@ func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *se
 	}
 
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" Wait for service endpoint to be deleted error. %v ", err)
+		return fmt.Errorf("Wait for service endpoint to be deleted error. %v ", err)
 	}
 	return nil
 }
@@ -176,7 +176,7 @@ func serviceEndpointGetArgs(d *schema.ResourceData) (*serviceendpoint.GetService
 	var serviceEndpointID *uuid.UUID
 	parsedServiceEndpointID, err := uuid.Parse(d.Id())
 	if err != nil {
-		return nil, fmt.Errorf(" parsing the service endpoint ID from the Terraform resource data: %v", err)
+		return nil, fmt.Errorf("parsing the service endpoint ID from the Terraform resource data: %v", err)
 	}
 	serviceEndpointID = &parsedServiceEndpointID
 	projectID, err := uuid.Parse(d.Get("project_id").(string))
@@ -372,7 +372,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 	projectIDString := d.Get("project_id").(string)
 	parsedProjectID, err := uuid.Parse(projectIDString)
 	if err != nil {
-		return nil, fmt.Errorf(" Parsing projectID from the Terraform data source declaration: %v", err)
+		return nil, fmt.Errorf("Parsing projectID from the Terraform data source declaration: %v", err)
 	}
 
 	projectID = &parsedProjectID
@@ -381,7 +381,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 		var serviceEndpointID *uuid.UUID
 		parsedServiceEndpointID, err := uuid.Parse(serviceEndpointIDString.(string))
 		if err != nil {
-			return nil, fmt.Errorf(" Parsing serviceEndpointID from the Terraform data source declaration: %v", err)
+			return nil, fmt.Errorf("Parsing serviceEndpointID from the Terraform data source declaration: %v", err)
 		}
 		serviceEndpointID = &parsedServiceEndpointID
 
@@ -397,7 +397,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 				d.SetId("")
 				return nil, nil
 			}
-			return nil, fmt.Errorf(" Looking up service endpoint with ID (%v) and projectID (%v): %v", serviceEndpointID, projectID, err)
+			return nil, fmt.Errorf("Looking up service endpoint with ID (%v) and projectID (%v): %v", serviceEndpointID, projectID, err)
 		}
 
 		return serviceEndpoint, nil
@@ -410,7 +410,7 @@ func dataSourceGetBaseServiceEndpoint(d *schema.ResourceData, m interface{}) (*s
 				d.SetId("")
 				return nil, nil
 			}
-			return nil, fmt.Errorf(" Looking up service endpoint with name (%v) and projectID (%v): %v", serviceEndpointName, projectID, err)
+			return nil, fmt.Errorf("Looking up service endpoint with name (%v) and projectID (%v): %v", serviceEndpointName, projectID, err)
 		}
 
 		return serviceEndpoint, nil
@@ -460,7 +460,7 @@ const (
 
 func checkServiceConnection(endpoint *serviceendpoint.ServiceEndpoint) error {
 	if endpoint.Id != nil && (endpoint.Data == nil || endpoint.Type == nil) {
-		return fmt.Errorf(" Service connection not fully returned, this appears to be a permission issue with PAT/SPN/identity etc.")
+		return fmt.Errorf("Service connection not fully returned, this appears to be a permission issue with PAT/SPN/identity etc.")
 	}
 	return nil
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurecr.go
@@ -98,5 +98,5 @@ func dataSourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{})
 
 		return nil
 	}
-	return fmt.Errorf(" Looking up service endpoint!")
+	return fmt.Errorf("Looking up service endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_azurerm.go
@@ -96,5 +96,5 @@ func dataSourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{})
 		d.Set("service_endpoint_id", serviceEndpoint.Id.String())
 		return nil
 	}
-	return fmt.Errorf(" Looking up service endpoint!")
+	return fmt.Errorf("Looking up service endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_bitbucket.go
@@ -34,5 +34,5 @@ func dataSourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{
 		return nil
 	}
 
-	return fmt.Errorf(" Looking up Bitbucket Service Endpoint!")
+	return fmt.Errorf("Looking up Bitbucket Service Endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_github.go
@@ -30,5 +30,5 @@ func dataSourceServiceEndpointGithubRead(d *schema.ResourceData, m interface{}) 
 		d.Set("service_endpoint_id", serviceEndpoint.Id.String())
 		return nil
 	}
-	return fmt.Errorf(" Looking up service endpoint!")
+	return fmt.Errorf("Looking up service endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_npm.go
@@ -43,5 +43,5 @@ func dataSourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) err
 		return nil
 	}
 
-	return fmt.Errorf(" Looking up service endpoint!")
+	return fmt.Errorf("Looking up service endpoint!")
 }

--- a/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/data_serviceendpoint_sonarcloud.go
@@ -31,5 +31,5 @@ func dataSourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface
 
 		return nil
 	}
-	return fmt.Errorf(" Looking up Sonar Cloud service endpoint !")
+	return fmt.Errorf("Looking up Sonar Cloud service endpoint !")
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -113,7 +113,7 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -132,7 +132,7 @@ func resourceServiceEndpointArgoCDUpdate(d *schema.ResourceData, m interface{}) 
 	_, err = updateServiceEndpoint(clients, serviceEndpoint)
 
 	if err != nil {
-		return fmt.Errorf(" updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating service endpoint in Azure DevOps: %+v", err)
 	}
 	return resourceServiceEndpointArgoCDRead(d, m)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -113,7 +113,7 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -134,7 +134,7 @@ func resourceServiceEndpointArtifactoryUpdate(d *schema.ResourceData, m interfac
 	_, err = updateServiceEndpoint(clients, serviceEndpoint)
 
 	if err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointArtifactoryRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -115,7 +115,7 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -133,7 +133,7 @@ func resourceServiceEndpointAwsUpdate(d *schema.ResourceData, m interface{}) err
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 	return resourceServiceEndpointAwsRead(d, m)
 }
@@ -193,7 +193,7 @@ func flattenServiceEndpointAws(d *schema.ResourceData, serviceEndpoint *servicee
 			if v != "" {
 				useOIDC, err := strconv.ParseBool(v)
 				if err != nil {
-					return fmt.Errorf(" parse `useOIDC`. Error: %+v", err)
+					return fmt.Errorf("parse `useOIDC`. Error: %+v", err)
 				}
 				d.Set("use_oidc", useOIDC)
 			}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -162,7 +162,7 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -180,7 +180,7 @@ func resourceServiceEndpointAzureCRUpdate(d *schema.ResourceData, m interface{})
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointAzureCRRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -86,7 +86,7 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -104,7 +104,7 @@ func resourceServiceEndpointAzureDevOpsUpdate(d *schema.ResourceData, m interfac
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointAzureDevOpsRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -213,7 +213,7 @@ func resourceServiceEndpointAzureRMCreate(d *schema.ResourceData, m interface{})
 					},
 					EndpointId: resp.Id,
 				}); delErr != nil {
-				return fmt.Errorf(" Delete service endpoint error %v", delErr)
+				return fmt.Errorf("Delete service endpoint error %v", delErr)
 			}
 			return err
 		}
@@ -235,7 +235,7 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
@@ -266,7 +266,7 @@ func resourceServiceEndpointAzureRMUpdate(d *schema.ResourceData, m interface{})
 	_, err = updateServiceEndpoint(clients, serviceEndpoint)
 
 	if err != nil {
-		return fmt.Errorf(" updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointAzureRMRead(d, m)
@@ -432,7 +432,7 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 		if serverUrl, ok := d.GetOk("server_url"); ok {
 			endpointUrl = serverUrl.(string)
 		} else {
-			return nil, fmt.Errorf(" `server_url` is required when `environment` is `AzureStack`")
+			return nil, fmt.Errorf("`server_url` is required when `environment` is `AzureStack`")
 		}
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -77,7 +77,7 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -95,7 +95,7 @@ func resourceServiceEndpointBitbucketUpdate(d *schema.ResourceData, m interface{
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointBitbucketRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
@@ -50,7 +50,7 @@ func resourceServiceEndpointBlackDuckCreate(d *schema.ResourceData, m interface{
 	clients := m.(*client.AggregatedClient)
 	serviceEndpoint, err := expandServiceEndpointBlackDuck(d)
 	if err != nil {
-		return fmt.Errorf(" Expanding service connection: %+v", err)
+		return fmt.Errorf("Expanding service connection: %+v", err)
 	}
 
 	serviceEndPoint, err := createServiceEndpoint(d, clients, serviceEndpoint)
@@ -74,7 +74,7 @@ func resourceServiceEndpointBlackDuckRead(d *schema.ResourceData, m interface{})
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -88,11 +88,11 @@ func resourceServiceEndpointBlackDuckUpdate(d *schema.ResourceData, m interface{
 	clients := m.(*client.AggregatedClient)
 	serviceEndpoint, err := expandServiceEndpointBlackDuck(d)
 	if err != nil {
-		return fmt.Errorf(" Expanding service connection: %+v", err)
+		return fmt.Errorf("Expanding service connection: %+v", err)
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointBlackDuckRead(d, m)
@@ -102,7 +102,7 @@ func resourceServiceEndpointBlackDuckDelete(d *schema.ResourceData, m interface{
 	clients := m.(*client.AggregatedClient)
 	serviceEndpoint, err := expandServiceEndpointBlackDuck(d)
 	if err != nil {
-		return fmt.Errorf(" Expanding service connection: %+v", err)
+		return fmt.Errorf("Expanding service connection: %+v", err)
 	}
 
 	return deleteServiceEndpoint(clients, serviceEndpoint, d.Timeout(schema.TimeoutDelete))

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -100,7 +100,7 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -119,7 +119,7 @@ func resourceServiceEndpointCheckMarxOneServiceUpdate(d *schema.ResourceData, m 
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 	return resourceServiceEndpointCheckMarxOneServiceRead(d, m)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -92,7 +92,7 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -111,7 +111,7 @@ func resourceServiceEndpointCheckMarxSASTUpdate(d *schema.ResourceData, m interf
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 	return resourceServiceEndpointCheckMarxSASTRead(d, m)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -104,7 +104,7 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -123,7 +123,7 @@ func resourceServiceEndpointCheckMarxSCAUpdate(d *schema.ResourceData, m interfa
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 	return resourceServiceEndpointCheckMarxSCARead(d, m)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -95,7 +95,7 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -113,7 +113,7 @@ func resourceServiceEndpointDockerRegistryUpdate(d *schema.ResourceData, m inter
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointDockerRegistryRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -88,7 +88,7 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -94,7 +94,7 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -112,7 +112,7 @@ func resourceServiceEndpointGcpTerraformUpdate(d *schema.ResourceData, m interfa
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointGcpTerraformRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -84,7 +84,7 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -102,7 +102,7 @@ func resourceServiceEndpointGenericUpdate(d *schema.ResourceData, m interface{})
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointGenericRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -89,7 +89,7 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -107,7 +107,7 @@ func resourceServiceEndpointGenericGitUpdate(d *schema.ResourceData, m interface
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Upating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Upating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointGenericGitRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -99,7 +99,7 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -117,7 +117,7 @@ func resourceServiceEndpointGitHubUpdate(d *schema.ResourceData, m interface{}) 
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointGitHubRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -104,7 +104,7 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -122,7 +122,7 @@ func resourceServiceEndpointGitHubEnterpriseUpdate(d *schema.ResourceData, m int
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointGitHubEnterpriseRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -82,7 +82,7 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -100,7 +100,7 @@ func resourceServiceEndpointIncomingWebhookUpdate(d *schema.ResourceData, m inte
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointIncomingWebhookRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -90,7 +90,7 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -108,7 +108,7 @@ func resourceServiceEndpointJenkinsUpdate(d *schema.ResourceData, m interface{})
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointJenkinsRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -113,7 +113,7 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -131,7 +131,7 @@ func resourceServiceEndpointJFrogArtifactoryV2Update(d *schema.ResourceData, m i
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointJFrogArtifactoryV2Read(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -111,7 +111,7 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -129,7 +129,7 @@ func resourceServiceEndpointJFrogDistributionV2Update(d *schema.ResourceData, m 
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointJFrogDistributionV2Read(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -112,7 +112,7 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -130,7 +130,7 @@ func resourceServiceEndpointJFrogPlatformV2Update(d *schema.ResourceData, m inte
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointJFrogPlatformV2Read(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -112,7 +112,7 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -130,7 +130,7 @@ func resourceServiceEndpointJFrogXRayV2Update(d *schema.ResourceData, m interfac
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointJFrogXRayV2Read(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -201,7 +201,7 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -223,7 +223,7 @@ func resourceServiceEndpointKubernetesUpdate(d *schema.ResourceData, m interface
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointKubernetesRead(d, m)
@@ -349,7 +349,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 		}
 		clusterAdmin, err := strconv.ParseBool((*serviceEndpoint.Data)["clusterAdmin"])
 		if err != nil {
-			return fmt.Errorf(" Parsing `cluster_admin` value. Error: %+v", err)
+			return fmt.Errorf("Parsing `cluster_admin` value. Error: %+v", err)
 		}
 		configItems := map[string]interface{}{
 			"azure_environment": (*serviceEndpoint.Authorization.Parameters)["azureEnvironment"],
@@ -381,7 +381,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 				if v, ok := (*serviceEndpoint.Data)["acceptUntrustedCerts"]; ok {
 					acceptUntrustedCerts, err := strconv.ParseBool(v)
 					if err != nil {
-						return fmt.Errorf(" failed to parse `accept_untrusted_certs`: %+v ", err)
+						return fmt.Errorf("failed to parse `accept_untrusted_certs`: %+v ", err)
 					}
 					kubeconfig["accept_untrusted_certs"] = acceptUntrustedCerts
 				}
@@ -415,7 +415,7 @@ func flattenServiceEndpointKubernetes(d *schema.ResourceData, serviceEndpoint *s
 			if v, ok := (*serviceEndpoint.Data)["acceptUntrustedCerts"]; ok {
 				acceptUntrustedCerts, err := strconv.ParseBool(v)
 				if err != nil {
-					return fmt.Errorf(" Pparse `accept_untrusted_certs`. Error: %+v ", err)
+					return fmt.Errorf("Pparse `accept_untrusted_certs`. Error: %+v ", err)
 				}
 				serviceAccount["accept_untrusted_certs"] = acceptUntrustedCerts
 			}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -120,7 +120,7 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -138,7 +138,7 @@ func resourceServiceEndpointMavenUpdate(d *schema.ResourceData, m interface{}) e
 	}
 
 	if _, err := updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointMavenRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -81,7 +81,7 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -99,7 +99,7 @@ func resourceServiceEndpointNexusUpdate(d *schema.ResourceData, m interface{}) e
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointNexusRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -78,7 +78,7 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -96,7 +96,7 @@ func resourceServiceEndpointNpmUpdate(d *schema.ResourceData, m interface{}) err
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointNpmRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -101,7 +101,7 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -119,7 +119,7 @@ func resourceServiceEndpointNuGetUpdate(d *schema.ResourceData, m interface{}) e
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointNuGetRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -81,7 +81,7 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -99,7 +99,7 @@ func resourceServiceEndpointOctopusDeployUpdate(d *schema.ResourceData, m interf
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointOctopusDeployRead(d, m)
@@ -139,7 +139,7 @@ func flattenServiceEndpointOctopusDeploy(d *schema.ResourceData, serviceEndpoint
 	if v, ok := (*serviceEndpoint.Data)["ignoreSslErrors"]; ok && v != "" {
 		ignoreSslErrors, err := strconv.ParseBool(v)
 		if err != nil {
-			panic(fmt.Errorf(" Failed to parse OctopusDeploy.ignore_ssl_error.(Project: %s), (service endpoint:%s) ,Error: %+v",
+			panic(fmt.Errorf("Failed to parse OctopusDeploy.ignore_ssl_error.(Project: %s), (service endpoint:%s) ,Error: %+v",
 				*serviceEndpoint.Name, (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id, err))
 		}
 		d.Set("ignore_ssl_error", ignoreSslErrors)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
@@ -255,7 +255,7 @@ func flattenServiceEndpointOpenshift(d *schema.ResourceData, serviceEndpoint *se
 		if strings.EqualFold(*serviceEndpoint.Authorization.Scheme, "UsernamePassword") {
 			acceptUntrustedCerts, err := strconv.ParseBool((*params)["acceptUntrustedCerts"])
 			if err != nil {
-				return fmt.Errorf(" Parse `acceptUntrustedCerts`: %v", err)
+				return fmt.Errorf("Parse `acceptUntrustedCerts`: %v", err)
 			}
 			d.Set("accept_untrusted_certs", acceptUntrustedCerts)
 			d.Set("certificate_authority_file", (*params)["certificateAuthorityFile"])
@@ -263,7 +263,7 @@ func flattenServiceEndpointOpenshift(d *schema.ResourceData, serviceEndpoint *se
 		if strings.EqualFold(*serviceEndpoint.Authorization.Scheme, "Token") {
 			acceptUntrustedCerts, err := strconv.ParseBool((*params)["acceptUntrustedCerts"])
 			if err != nil {
-				return fmt.Errorf(" Parse `acceptUntrustedCerts`: %v", err)
+				return fmt.Errorf("Parse `acceptUntrustedCerts`: %v", err)
 			}
 			d.Set("accept_untrusted_certs", acceptUntrustedCerts)
 			d.Set("certificate_authority_file", (*params)["certificateAuthorityFile"])

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -88,7 +88,7 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -106,7 +106,7 @@ func resourceServiceEndpointRunPipelineUpdate(d *schema.ResourceData, m interfac
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointRunPipelineRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -186,7 +186,7 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -204,7 +204,7 @@ func resourceServiceEndpointServiceFabricUpdate(d *schema.ResourceData, m interf
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointServiceFabricRead(d, m)
@@ -265,7 +265,7 @@ func expandServiceEndpointServiceFabric(d *schema.ResourceData) (*serviceendpoin
 		return serviceEndpoint, nil
 	}
 
-	return nil, fmt.Errorf(" One of %s or %s or %s blocks must be specified", "azure_active_directory", "certificate", "none")
+	return nil, fmt.Errorf("One of %s or %s or %s blocks must be specified", "azure_active_directory", "certificate", "none")
 }
 
 func expandServiceEndpointServiceFabricServerCertificateLookup(configuration map[string]interface{}) map[string]string {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -74,7 +74,7 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -92,7 +92,7 @@ func resourceServiceEndpointSnykUpdate(d *schema.ResourceData, m interface{}) er
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointSnykRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -70,7 +70,7 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -88,7 +88,7 @@ func resourceServiceEndpointSonarCloudUpdate(d *schema.ResourceData, m interface
 	}
 
 	if _, err := updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointSonarCloudRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -78,7 +78,7 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if serviceEndpoint.Id == nil {
@@ -101,7 +101,7 @@ func resourceServiceEndpointSonarQubeUpdate(d *schema.ResourceData, m interface{
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointSonarQubeRead(d, m)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -96,7 +96,7 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {
@@ -113,7 +113,7 @@ func resourceServiceEndpointSSHUpdate(d *schema.ResourceData, m interface{}) err
 	}
 
 	if _, err = updateServiceEndpoint(clients, serviceEndpoint); err != nil {
-		return fmt.Errorf(" Updating service endpoint in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating service endpoint in Azure DevOps: %+v", err)
 	}
 
 	return resourceServiceEndpointSSHRead(d, m)
@@ -161,7 +161,7 @@ func flattenServiceEndpointSSH(d *schema.ResourceData, serviceEndpoint *servicee
 	if portStr, ok := (*serviceEndpoint.Data)["Port"]; ok {
 		port, err := strconv.ParseInt(portStr, 10, 64)
 		if err != nil {
-			return fmt.Errorf(" Parse SSH port: %s. Error: %+v ", portStr, err)
+			return fmt.Errorf("Parse SSH port: %s. Error: %+v ", portStr, err)
 		}
 		d.Set("port", port)
 	}

--- a/azuredevops/internal/service/servicehook/resource_servicehook_storage_queue_pipelines.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_storage_queue_pipelines.go
@@ -178,7 +178,7 @@ func createSubscription(clients *client.AggregatedClient, subscription *serviceh
 			Subscription: subscription,
 		})
 	if err != nil {
-		return nil, fmt.Errorf(" creating subscription in Azure DevOps: %+v", err)
+		return nil, fmt.Errorf("creating subscription in Azure DevOps: %+v", err)
 	}
 
 	return createdSubscription, err

--- a/azuredevops/internal/service/taskagent/data_agent_pool.go
+++ b/azuredevops/internal/service/taskagent/data_agent_pool.go
@@ -54,11 +54,11 @@ func dataSourceAgentPoolRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if len(*agentPools) > 1 {
-		return fmt.Errorf(" Found multiple agent pools for name: %s. Agent pools found: %+v", poolName, agentPools)
+		return fmt.Errorf("Found multiple agent pools for name: %s. Agent pools found: %+v", poolName, agentPools)
 	}
 
 	if len(*agentPools) == 0 {
-		return fmt.Errorf(" Unable to find agent pool with name: %s", poolName)
+		return fmt.Errorf("Unable to find agent pool with name: %s", poolName)
 	}
 
 	pool := (*agentPools)[0]

--- a/azuredevops/internal/service/taskagent/data_agent_pools.go
+++ b/azuredevops/internal/service/taskagent/data_agent_pools.go
@@ -55,13 +55,13 @@ func dataSourceAgentPoolsRead(d *schema.ResourceData, m interface{}) error {
 
 	agentPools, err := clients.TaskAgentClient.GetAgentPools(clients.Ctx, taskagent.GetAgentPoolsArgs{})
 	if err != nil {
-		return fmt.Errorf(" finding agent pools. Error: %v", err)
+		return fmt.Errorf("finding agent pools. Error: %v", err)
 	}
 	log.Printf("[TRACE] plugin.terraform-provider-azuredevops: Read [%d] agent pools from current organization", len(*agentPools))
 
 	err = d.Set("agent_pools", flattenAgentPoolReferences(agentPools))
 	if err != nil {
-		return fmt.Errorf(" setting agent_pools field in state. Error: %v", err)
+		return fmt.Errorf("setting agent_pools field in state. Error: %v", err)
 	}
 
 	d.SetId(time.Now().UTC().String())

--- a/azuredevops/internal/service/taskagent/data_agent_queue.go
+++ b/azuredevops/internal/service/taskagent/data_agent_queue.go
@@ -44,7 +44,7 @@ func dataSourceAgentQueueRead(d *schema.ResourceData, m interface{}) error {
 
 	agentQueue, err := getAgentQueueByName(clients, d.Get("name").(string), d.Get("project_id").(string))
 	if err != nil {
-		return fmt.Errorf(" getting agent queue by name: %v", err)
+		return fmt.Errorf("getting agent queue by name: %v", err)
 	}
 
 	d.SetId(strconv.Itoa(*agentQueue.Id))
@@ -77,11 +77,11 @@ func getAgentQueueByName(clients *client.AggregatedClient, name, projectID strin
 	}
 
 	if len(*agentQueues) > 1 {
-		return nil, fmt.Errorf(" Found multiple agent queues for name: %s. Agent queues found: %+v", name, agentQueues)
+		return nil, fmt.Errorf("Found multiple agent queues for name: %s. Agent queues found: %+v", name, agentQueues)
 	}
 
 	if len(*agentQueues) == 0 {
-		return nil, fmt.Errorf(" Unable to find agent queues with name: %s", name)
+		return nil, fmt.Errorf("Unable to find agent queues with name: %s", name)
 	}
 
 	return &(*agentQueues)[0], nil

--- a/azuredevops/internal/service/taskagent/data_environment.go
+++ b/azuredevops/internal/service/taskagent/data_environment.go
@@ -76,7 +76,7 @@ func dataEnvironmentRead(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 		if len(response.Value) == 0 {
-			return fmt.Errorf(" Unable to find environment with name: %s", name)
+			return fmt.Errorf("Unable to find environment with name: %s", name)
 		}
 		environment = &response.Value[0]
 	}

--- a/azuredevops/internal/service/taskagent/data_variable_group.go
+++ b/azuredevops/internal/service/taskagent/data_variable_group.go
@@ -110,12 +110,12 @@ func dataSourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if len(*variableGroups) == 0 {
-		return fmt.Errorf(" Unable to find variable group with name: %s", name)
+		return fmt.Errorf("Unable to find variable group with name: %s", name)
 	}
 
 	err = flattenVariableGroup(d, &(*variableGroups)[0], &projectID)
 	if err != nil {
-		return fmt.Errorf(" flattening variable group: %v", err)
+		return fmt.Errorf("flattening variable group: %v", err)
 	}
 
 	return nil

--- a/azuredevops/internal/service/taskagent/resource_agent_pool.go
+++ b/azuredevops/internal/service/taskagent/resource_agent_pool.go
@@ -75,7 +75,7 @@ func resourceAzureAgentPoolCreate(d *schema.ResourceData, m interface{}) error {
 
 	agentPool, err := clients.TaskAgentClient.AddAgentPool(clients.Ctx, args)
 	if err != nil {
-		return fmt.Errorf(" creating agent pool in Azure DevOps: %+v", err)
+		return fmt.Errorf("creating agent pool in Azure DevOps: %+v", err)
 	}
 
 	// auto update can only be set to true after creation
@@ -96,7 +96,7 @@ func resourceAzureAgentPoolCreate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf(" updating agent pool in Azure DevOps: %+v", err)
+			return fmt.Errorf("updating agent pool in Azure DevOps: %+v", err)
 		}
 	}
 	d.SetId(strconv.Itoa(*agentPool.Id))
@@ -108,7 +108,7 @@ func resourceAzureAgentPoolRead(d *schema.ResourceData, m interface{}) error {
 
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" parse agent pool ID: %+v", err)
+		return fmt.Errorf("parse agent pool ID: %+v", err)
 	}
 
 	agentPool, err := clients.TaskAgentClient.GetAgentPool(clients.Ctx, taskagent.GetAgentPoolArgs{PoolId: &poolID})
@@ -117,7 +117,7 @@ func resourceAzureAgentPoolRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" looking up Agent Pool with ID %d. Error: %v", poolID, err)
+		return fmt.Errorf("looking up Agent Pool with ID %d. Error: %v", poolID, err)
 	}
 
 	d.Set("name", agentPool.Name)
@@ -144,12 +144,12 @@ func resourceAzureAgentPoolUpdate(d *schema.ResourceData, m interface{}) error {
 
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" getting agent pool Id: %+v", err)
+		return fmt.Errorf("getting agent pool Id: %+v", err)
 	}
 	parameter.PoolId = &poolID
 
 	if _, err = clients.TaskAgentClient.UpdateAgentPool(clients.Ctx, parameter); err != nil {
-		return fmt.Errorf(" updating agent pool in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating agent pool in Azure DevOps: %+v", err)
 	}
 
 	if err := syncStatus(parameter, clients); err != nil {
@@ -162,7 +162,7 @@ func resourceAzureAgentPoolUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceAzureAgentPoolDelete(d *schema.ResourceData, m interface{}) error {
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" parse agent pool ID: %+v", err)
+		return fmt.Errorf("parse agent pool ID: %+v", err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -181,7 +181,7 @@ func resourceAzureAgentPoolDelete(d *schema.ResourceData, m interface{}) error {
 				if utils.ResponseWasNotFound(err) {
 					state = "Synched"
 				} else {
-					return nil, "", fmt.Errorf(" looking up Agent Pool with ID: %+v", err)
+					return nil, "", fmt.Errorf("looking up Agent Pool with ID: %+v", err)
 				}
 			}
 			if agentPool == nil {
@@ -195,7 +195,7 @@ func resourceAzureAgentPoolDelete(d *schema.ResourceData, m interface{}) error {
 		ContinuousTargetOccurence: 2,
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" waiting for Agent Pool deleted. %v ", err)
+		return fmt.Errorf("waiting for Agent Pool deleted. %v ", err)
 	}
 	return nil
 }
@@ -208,7 +208,7 @@ func syncStatus(params taskagent.UpdateAgentPoolArgs, client *client.AggregatedC
 			state := "Waiting"
 			agentPool, err := client.TaskAgentClient.GetAgentPool(client.Ctx, taskagent.GetAgentPoolArgs{PoolId: params.PoolId})
 			if err != nil {
-				return nil, "", fmt.Errorf(" looking up Agent Pool with ID: %+v", err)
+				return nil, "", fmt.Errorf("looking up Agent Pool with ID: %+v", err)
 			}
 			if *agentPool.AutoUpdate == *params.Pool.AutoUpdate &&
 				*agentPool.AutoProvision == *params.Pool.AutoProvision &&
@@ -223,7 +223,7 @@ func syncStatus(params taskagent.UpdateAgentPoolArgs, client *client.AggregatedC
 		ContinuousTargetOccurence: 2,
 	}
 	if _, err := stateConf.WaitForStateContext(client.Ctx); err != nil {
-		return fmt.Errorf(" waiting for Agent Pool ready. %v ", err)
+		return fmt.Errorf("waiting for Agent Pool ready. %v ", err)
 	}
 	return nil
 }

--- a/azuredevops/internal/service/taskagent/resource_agent_queue.go
+++ b/azuredevops/internal/service/taskagent/resource_agent_queue.go
@@ -60,7 +60,7 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	queue, projectID, err := expandAgentQueue(d)
 	if err != nil {
-		return fmt.Errorf(" expanding the agent queue resource from state: %+v", err)
+		return fmt.Errorf("expanding the agent queue resource from state: %+v", err)
 	}
 
 	if queue.Pool != nil {
@@ -68,7 +68,7 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 			PoolId: queue.Pool.Id,
 		})
 		if err != nil {
-			return fmt.Errorf(" looking up referenced agent pool: %+v", err)
+			return fmt.Errorf("looking up referenced agent pool: %+v", err)
 		}
 		queue.Name = referencedPool.Name
 	} else {
@@ -82,7 +82,7 @@ func resourceAgentQueueCreate(d *schema.ResourceData, m interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf(" creating agent queue: %+v", err)
+		return fmt.Errorf("creating agent queue: %+v", err)
 	}
 
 	d.SetId(strconv.Itoa(*createdQueue.Id))
@@ -93,7 +93,7 @@ func resourceAgentQueueRead(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	queueID, err := converter.ASCIIToIntPtr(d.Id())
 	if err != nil {
-		return fmt.Errorf(" Queue ID was unexpectedly not a valid integer: %+v", err)
+		return fmt.Errorf("Queue ID was unexpectedly not a valid integer: %+v", err)
 	}
 
 	queue, err := clients.TaskAgentClient.GetAgentQueue(clients.Ctx, taskagent.GetAgentQueueArgs{
@@ -107,7 +107,7 @@ func resourceAgentQueueRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf(" reading the agent queue resource: %+v", err)
+		return fmt.Errorf("reading the agent queue resource: %+v", err)
 	}
 
 	if queue.Pool != nil && queue.Pool.Id != nil {
@@ -125,7 +125,7 @@ func resourceAgentQueueDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	queueID, err := converter.ASCIIToIntPtr(d.Id())
 	if err != nil {
-		return fmt.Errorf(" Queue ID was unexpectedly not a valid integer: %+v", err)
+		return fmt.Errorf("Queue ID was unexpectedly not a valid integer: %+v", err)
 	}
 
 	err = clients.TaskAgentClient.DeleteAgentQueue(clients.Ctx, taskagent.DeleteAgentQueueArgs{
@@ -134,7 +134,7 @@ func resourceAgentQueueDelete(d *schema.ResourceData, m interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf(" deleting agent queue: %+v", err)
+		return fmt.Errorf("deleting agent queue: %+v", err)
 	}
 
 	return nil
@@ -152,7 +152,7 @@ func expandAgentQueue(d *schema.ResourceData) (*taskagent.TaskAgentQueue, string
 	if d.Id() != "" {
 		id, err := converter.ASCIIToIntPtr(d.Id())
 		if err != nil {
-			return nil, "", fmt.Errorf(" Queue ID was unexpectedly not a valid integer: %+v", err)
+			return nil, "", fmt.Errorf("Queue ID was unexpectedly not a valid integer: %+v", err)
 		}
 		queue.Id = id
 	}

--- a/azuredevops/internal/service/taskagent/resource_elastic_pool.go
+++ b/azuredevops/internal/service/taskagent/resource_elastic_pool.go
@@ -123,7 +123,7 @@ func resourceAzureAgentPoolVMSSCreate(d *schema.ResourceData, m interface{}) err
 	if v, ok := d.GetOk("project_id"); ok {
 		projectId, err := uuid.Parse(v.(string))
 		if err != nil {
-			return fmt.Errorf(" parse Project Id: %s. Error: %+v", v, err)
+			return fmt.Errorf("parse Project Id: %s. Error: %+v", v, err)
 		}
 		args.ProjectId = &projectId
 	}
@@ -145,12 +145,12 @@ func resourceAzureAgentPoolVMSSCreate(d *schema.ResourceData, m interface{}) err
 	desiredIdle := d.Get("desired_idle").(int)
 	maxCapacity := d.Get("max_capacity").(int)
 	if desiredIdle > maxCapacity {
-		return fmt.Errorf(" `desired_idle` can not be greater than `max_capacity`. Valid range is from 0 to the maximum number of virtual machines in the scale set.")
+		return fmt.Errorf("`desired_idle` can not be greater than `max_capacity`. Valid range is from 0 to the maximum number of virtual machines in the scale set.")
 	}
 
 	elasticPool, err := clients.ElasticClient.CreateElasticPool(clients.Ctx, args)
 	if err != nil {
-		return fmt.Errorf(" creating Elastic Pool: %+v", err)
+		return fmt.Errorf("creating Elastic Pool: %+v", err)
 	}
 
 	updateArgs := taskagent.UpdateAgentPoolArgs{
@@ -167,7 +167,7 @@ func resourceAzureAgentPoolVMSSCreate(d *schema.ResourceData, m interface{}) err
 	}
 
 	if err != nil {
-		return fmt.Errorf(" updating agent pool in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating agent pool in Azure DevOps: %+v", err)
 	}
 
 	d.SetId(strconv.Itoa(*elasticPool.ElasticPool.PoolId))
@@ -179,7 +179,7 @@ func resourceAzureAgentPoolVMSSRead(d *schema.ResourceData, m interface{}) error
 
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" parse Elastic Pool ID: %+v", err)
+		return fmt.Errorf("parse Elastic Pool ID: %+v", err)
 	}
 
 	elasticPool, err := clients.ElasticClient.GetElasticPool(clients.Ctx, elastic.GetElasticPoolArgs{
@@ -190,14 +190,14 @@ func resourceAzureAgentPoolVMSSRead(d *schema.ResourceData, m interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" looking up Elastic Pool with ID %d. Error: %v", poolID, err)
+		return fmt.Errorf("looking up Elastic Pool with ID %d. Error: %v", poolID, err)
 	}
 
 	agentPool, err := clients.TaskAgentClient.GetAgentPool(clients.Ctx, taskagent.GetAgentPoolArgs{
 		PoolId: &poolID,
 	})
 	if err != nil {
-		return fmt.Errorf(" looking up Agent Pool with ID %d. Error: %v", poolID, err)
+		return fmt.Errorf("looking up Agent Pool with ID %d. Error: %v", poolID, err)
 	}
 
 	d.Set("name", agentPool.Name)
@@ -222,7 +222,7 @@ func resourceAzureAgentPoolVMSSUpdate(d *schema.ResourceData, m interface{}) err
 
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" getting Elastic Pool Id: %+v", err)
+		return fmt.Errorf("getting Elastic Pool Id: %+v", err)
 	}
 
 	elasticPoolArgs := elastic.UpdateElasticPoolArgs{
@@ -252,14 +252,14 @@ func resourceAzureAgentPoolVMSSUpdate(d *schema.ResourceData, m interface{}) err
 	desiredIdle := d.Get("desired_idle").(int)
 	maxCapacity := d.Get("max_capacity").(int)
 	if desiredIdle > maxCapacity {
-		return fmt.Errorf(" `desired_idle` can not be greater than `max_capacity`. Valid range is from 0 to the maximum number of virtual machines in the scale set.")
+		return fmt.Errorf("`desired_idle` can not be greater than `max_capacity`. Valid range is from 0 to the maximum number of virtual machines in the scale set.")
 	}
 
 	elasticPoolArgs.ElasticPoolSettings.DesiredIdle = &desiredIdle
 	elasticPoolArgs.ElasticPoolSettings.MaxCapacity = &maxCapacity
 
 	if _, err := clients.ElasticClient.UpdateElasticPool(clients.Ctx, elasticPoolArgs); err != nil {
-		return fmt.Errorf(" updating Elastic Pool in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating Elastic Pool in Azure DevOps: %+v", err)
 	}
 
 	agentPoolArgs := taskagent.UpdateAgentPoolArgs{
@@ -272,7 +272,7 @@ func resourceAzureAgentPoolVMSSUpdate(d *schema.ResourceData, m interface{}) err
 
 	agentPoolArgs.PoolId = &poolID
 	if _, err = clients.TaskAgentClient.UpdateAgentPool(clients.Ctx, agentPoolArgs); err != nil {
-		return fmt.Errorf(" updating Elastic Pool in Azure DevOps: %+v", err)
+		return fmt.Errorf("updating Elastic Pool in Azure DevOps: %+v", err)
 	}
 
 	if err := syncElasticPoolStatus(agentPoolArgs, clients); err != nil {
@@ -285,7 +285,7 @@ func resourceAzureAgentPoolVMSSUpdate(d *schema.ResourceData, m interface{}) err
 func resourceAzureAgentPoolVMSSDelete(d *schema.ResourceData, m interface{}) error {
 	poolID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" parse agent pool ID: %+v", err)
+		return fmt.Errorf("parse agent pool ID: %+v", err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -304,7 +304,7 @@ func resourceAzureAgentPoolVMSSDelete(d *schema.ResourceData, m interface{}) err
 				if utils.ResponseWasNotFound(err) {
 					state = "Synched"
 				} else {
-					return nil, "", fmt.Errorf(" looking up Agent Pool with ID: %+v", err)
+					return nil, "", fmt.Errorf("looking up Agent Pool with ID: %+v", err)
 				}
 			}
 			if agentPool == nil {
@@ -318,7 +318,7 @@ func resourceAzureAgentPoolVMSSDelete(d *schema.ResourceData, m interface{}) err
 		ContinuousTargetOccurence: 2,
 	}
 	if _, err := stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return fmt.Errorf(" waiting for Elastic Pool deleted. %v ", err)
+		return fmt.Errorf("waiting for Elastic Pool deleted. %v ", err)
 	}
 	return nil
 }
@@ -331,7 +331,7 @@ func syncElasticPoolStatus(params taskagent.UpdateAgentPoolArgs, client *client.
 			state := "Waiting"
 			agentPool, err := client.TaskAgentClient.GetAgentPool(client.Ctx, taskagent.GetAgentPoolArgs{PoolId: params.PoolId})
 			if err != nil {
-				return nil, "", fmt.Errorf(" looking up Agent Pool with ID: %+v", err)
+				return nil, "", fmt.Errorf("looking up Agent Pool with ID: %+v", err)
 			}
 			if *agentPool.AutoUpdate == *params.Pool.AutoUpdate &&
 				*agentPool.AutoProvision == *params.Pool.AutoProvision {
@@ -345,7 +345,7 @@ func syncElasticPoolStatus(params taskagent.UpdateAgentPoolArgs, client *client.
 		ContinuousTargetOccurence: 2,
 	}
 	if _, err := stateConf.WaitForStateContext(client.Ctx); err != nil {
-		return fmt.Errorf(" waiting for Agent Pool ready. %v ", err)
+		return fmt.Errorf("waiting for Agent Pool ready. %v ", err)
 	}
 	return nil
 }

--- a/azuredevops/internal/service/taskagent/resource_environment.go
+++ b/azuredevops/internal/service/taskagent/resource_environment.go
@@ -55,12 +55,12 @@ func resourceEnvironmentCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	environment, err := expandEnvironment(d)
 	if err != nil {
-		return fmt.Errorf(" Expanding the environment resource from state: %+v", err)
+		return fmt.Errorf("Expanding the environment resource from state: %+v", err)
 	}
 
 	createdEnvironment, err := createEnvironment(clients, environment)
 	if err != nil {
-		return fmt.Errorf(" Creating environment in Azure DevOps: %+v", err)
+		return fmt.Errorf("Creating environment in Azure DevOps: %+v", err)
 	}
 
 	flattenEnvironment(d, createdEnvironment)
@@ -154,7 +154,7 @@ func updateEnvironment(clients *client.AggregatedClient, environment *taskagent.
 func expandEnvironment(d *schema.ResourceData) (*taskagent.EnvironmentInstance, error) {
 	projectId, err := uuid.Parse(d.Get("project_id").(string))
 	if err != nil {
-		return nil, fmt.Errorf(" faild parse project ID to UUID: %s, %+v", "project_id", err)
+		return nil, fmt.Errorf("faild parse project ID to UUID: %s, %+v", "project_id", err)
 	}
 	environment := &taskagent.EnvironmentInstance{
 		Name:        converter.String(d.Get("name").(string)),

--- a/azuredevops/internal/service/taskagent/resource_environment_resource_kubernetes.go
+++ b/azuredevops/internal/service/taskagent/resource_environment_resource_kubernetes.go
@@ -76,7 +76,7 @@ func ResourceEnvironmentKubernetes() *schema.Resource {
 func resourceEnvironmentKubernetesCreate(d *schema.ResourceData, m interface{}) error {
 	project, resource, err := expandEnvironmentKubernetesResource(d)
 	if err != nil {
-		return fmt.Errorf(" expanding the Kubernetes resource from state: %+v", err)
+		return fmt.Errorf("expanding the Kubernetes resource from state: %+v", err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -92,7 +92,7 @@ func resourceEnvironmentKubernetesCreate(d *schema.ResourceData, m interface{}) 
 		EnvironmentId: resource.EnvironmentReference.Id,
 	})
 	if err != nil {
-		return fmt.Errorf(" creating Kubernetes resource in Azure DevOps: %+v", err)
+		return fmt.Errorf("creating Kubernetes resource in Azure DevOps: %+v", err)
 	}
 
 	d.SetId(strconv.Itoa(*createdResource.Id))
@@ -102,12 +102,12 @@ func resourceEnvironmentKubernetesCreate(d *schema.ResourceData, m interface{}) 
 func resourceEnvironmentKubernetesRead(d *schema.ResourceData, m interface{}) error {
 	project, resource, err := expandEnvironmentKubernetesResource(d)
 	if err != nil {
-		return fmt.Errorf(" expanding the Kubernetes resource from state: %+v", err)
+		return fmt.Errorf("expanding the Kubernetes resource from state: %+v", err)
 	}
 
 	resourceId, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" getting kubernetes resource id: %+v", err)
+		return fmt.Errorf("getting kubernetes resource id: %+v", err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -121,7 +121,7 @@ func resourceEnvironmentKubernetesRead(d *schema.ResourceData, m interface{}) er
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" reading the Kubernetes resource: %+v", err)
+		return fmt.Errorf("reading the Kubernetes resource: %+v", err)
 	}
 
 	flattenEnvironmentKubernetesResource(d, project, fetchedResource)
@@ -131,12 +131,12 @@ func resourceEnvironmentKubernetesRead(d *schema.ResourceData, m interface{}) er
 func resourceEnvironmentKubernetesDelete(d *schema.ResourceData, m interface{}) error {
 	project, resource, err := expandEnvironmentKubernetesResource(d)
 	if err != nil {
-		return fmt.Errorf(" expanding the Kubernetes resource from state: %+v", err)
+		return fmt.Errorf("expanding the Kubernetes resource from state: %+v", err)
 	}
 
 	resourceId, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" getting kubernetes resource id: %+v", err)
+		return fmt.Errorf("getting kubernetes resource id: %+v", err)
 	}
 
 	clients := m.(*client.AggregatedClient)
@@ -147,7 +147,7 @@ func resourceEnvironmentKubernetesDelete(d *schema.ResourceData, m interface{}) 
 	})
 
 	if err != nil {
-		return fmt.Errorf(" deleting Kubernetes environment: %+v", err)
+		return fmt.Errorf("deleting Kubernetes environment: %+v", err)
 	}
 
 	return nil
@@ -156,13 +156,13 @@ func resourceEnvironmentKubernetesDelete(d *schema.ResourceData, m interface{}) 
 func expandEnvironmentKubernetesResource(d *schema.ResourceData) (*taskagent.ProjectReference, *taskagent.KubernetesResource, error) {
 	projectId, err := uuid.Parse(d.Get("project_id").(string))
 	if err != nil {
-		return nil, nil, fmt.Errorf(" Failed to parse project ID to UUID: %s, %+v", d.Get("project_id"), err)
+		return nil, nil, fmt.Errorf("Failed to parse project ID to UUID: %s, %+v", d.Get("project_id"), err)
 	}
 	project := &taskagent.ProjectReference{Id: &projectId}
 
 	serviceEndpointId, err := uuid.Parse(d.Get("service_endpoint_id").(string))
 	if err != nil {
-		return nil, nil, fmt.Errorf(" Failed to parse service endpoint ID to UUID: %s, %+v", d.Get("service_endpoint_id"), err)
+		return nil, nil, fmt.Errorf("Failed to parse service endpoint ID to UUID: %s, %+v", d.Get("service_endpoint_id"), err)
 	}
 	tagsSchemaSet := d.Get("tags").(*schema.Set)
 	tags := tfhelper.ExpandStringSet(tagsSchemaSet)

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -157,25 +157,25 @@ func resourceVariableGroupCreate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	variableGroupParameters, projectID, err := expandVariableGroupParameters(clients, d)
 	if err != nil {
-		return fmt.Errorf(" Expanding variable group resource data: %+v", err)
+		return fmt.Errorf("Expanding variable group resource data: %+v", err)
 	}
 
 	addedVariableGroup, err := createVariableGroup(clients, variableGroupParameters, projectID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf(" creating variable group in Azure DevOps: %+v", err)
+		return fmt.Errorf("creating variable group in Azure DevOps: %+v", err)
 	}
 
 	err = flattenVariableGroup(d, addedVariableGroup, projectID)
 
 	if err != nil {
-		return fmt.Errorf(" Flattening variable group: %+v", err)
+		return fmt.Errorf("Flattening variable group: %+v", err)
 	}
 
 	// Update Allow Access with definition Reference
 	definitionResourceReferenceArgs := expandAllowAccess(d, addedVariableGroup)
 	definitionResourceReference, err := updateDefinitionResourceAuth(clients, definitionResourceReferenceArgs, projectID)
 	if err != nil {
-		return fmt.Errorf(" Creating definitionResourceReference Azure DevOps object: %+v", err)
+		return fmt.Errorf("Creating definitionResourceReference Azure DevOps object: %+v", err)
 	}
 
 	flattenAllowAccess(d, definitionResourceReference)
@@ -188,7 +188,7 @@ func resourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	projectID, variableGroupID, err := tfhelper.ParseProjectIDAndResourceID(d)
 	if err != nil {
-		return fmt.Errorf(" Parsing the variable group ID from the Terraform resource data: %+v", err)
+		return fmt.Errorf("Parsing the variable group ID from the Terraform resource data: %+v", err)
 	}
 
 	variableGroup, err := clients.TaskAgentClient.GetVariableGroup(
@@ -203,7 +203,7 @@ func resourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf(" Looking up variable group given ID (*%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
+		return fmt.Errorf("Looking up variable group given ID (*%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
 	}
 	if variableGroup.Id == nil {
 		d.SetId("")
@@ -213,7 +213,7 @@ func resourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 	err = flattenVariableGroup(d, variableGroup, &projectID)
 
 	if err != nil {
-		return fmt.Errorf(" Flattening variable group: %+v", err)
+		return fmt.Errorf("Flattening variable group: %+v", err)
 	}
 
 	//Read the Authorization Resource for get allow access property
@@ -230,7 +230,7 @@ func resourceVariableGroupRead(d *schema.ResourceData, m interface{}) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf(" Looking up project resources given ID (%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
+		return fmt.Errorf("Looking up project resources given ID (%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
 	}
 
 	flattenAllowAccess(d, projectResources)
@@ -242,30 +242,30 @@ func resourceVariableGroupUpdate(d *schema.ResourceData, m interface{}) error {
 
 	variableGroupParams, projectID, err := expandVariableGroupParameters(clients, d)
 	if err != nil {
-		return fmt.Errorf(" Expanding variable group resource data: %+v", err)
+		return fmt.Errorf("Expanding variable group resource data: %+v", err)
 	}
 
 	_, variableGroupID, err := tfhelper.ParseProjectIDAndResourceID(d)
 	if err != nil {
-		return fmt.Errorf(" Parsing the variable group ID from the Terraform resource data: %+v", err)
+		return fmt.Errorf("Parsing the variable group ID from the Terraform resource data: %+v", err)
 	}
 
 	updatedVariableGroup, err := updateVariableGroup(clients, variableGroupParams, &variableGroupID, projectID)
 	if err != nil {
-		return fmt.Errorf(" Updating variable group in Azure DevOps: %+v", err)
+		return fmt.Errorf("Updating variable group in Azure DevOps: %+v", err)
 	}
 
 	err = flattenVariableGroup(d, updatedVariableGroup, projectID)
 
 	if err != nil {
-		return fmt.Errorf(" Flattening variable group: %+v", err)
+		return fmt.Errorf("Flattening variable group: %+v", err)
 	}
 
 	// Update Allow Access
 	definitionResourceReferenceArgs := expandAllowAccess(d, updatedVariableGroup)
 	definitionResourceReference, err := updateDefinitionResourceAuth(clients, definitionResourceReferenceArgs, projectID)
 	if err != nil {
-		return fmt.Errorf(" Updating definitionResourceReference Azure DevOps object: %+v", err)
+		return fmt.Errorf("Updating definitionResourceReference Azure DevOps object: %+v", err)
 	}
 
 	flattenAllowAccess(d, definitionResourceReference)
@@ -277,13 +277,13 @@ func resourceVariableGroupDelete(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	projectID, variableGroupID, err := tfhelper.ParseProjectIDAndResourceID(d)
 	if err != nil {
-		return fmt.Errorf(" Parsing the variable group ID from the Terraform resource data: %+v", err)
+		return fmt.Errorf("Parsing the variable group ID from the Terraform resource data: %+v", err)
 	}
 	//delete the definition resource (allow access)
 	varGroupID := strconv.Itoa(variableGroupID)
 	_, err = deleteDefinitionResourceAuth(clients, &varGroupID, &projectID)
 	if err != nil {
-		return fmt.Errorf(" Deleting the allow access definitionResource for variable group ID (%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
+		return fmt.Errorf("Deleting the allow access definitionResource for variable group ID (%+v) and project ID (%+v): %+v", variableGroupID, projectID, err)
 	}
 	//delete the variable group
 	return deleteVariableGroup(clients, &projectID, &variableGroupID)
@@ -315,7 +315,7 @@ func createVariableGroup(clients *client.AggregatedClient, variableGroupParams *
 				},
 			)
 			if err != nil {
-				return createdVG, "failed", fmt.Errorf(" fail to get Variable Group. %+v ", err)
+				return createdVG, "failed", fmt.Errorf("fail to get Variable Group. %+v ", err)
 			}
 			if createdVG != nil && createdVG.Variables != nil && (len(*variableGroupParams.Variables) == len(*createdVG.Variables)) {
 				return createdVG, "succeeded", nil
@@ -326,7 +326,7 @@ func createVariableGroup(clients *client.AggregatedClient, variableGroupParams *
 	}
 
 	if _, err = stateConf.WaitForStateContext(clients.Ctx); err != nil {
-		return nil, fmt.Errorf(" waiting for Variable Group ready. %+v ", err)
+		return nil, fmt.Errorf("waiting for Variable Group ready. %+v ", err)
 	}
 	return createdVG, nil
 }
@@ -731,11 +731,11 @@ func parseKVSecretResp(azKVSecrets *serviceendpoint.ServiceEndpointRequestResult
 
 		token, err := getSkipToken(kvSecrets.NextLink)
 		if err != nil {
-			return nil, "", fmt.Errorf(" falied to get skip token, error: %+v", err)
+			return nil, "", fmt.Errorf("falied to get skip token, error: %+v", err)
 		}
 		return &kvSecrets, token, nil
 	}
-	return nil, "", fmt.Errorf(" Failed to get the Azure Key value. Error: ( code: %s, messge: %s )", *azKVSecrets.StatusCode, *azKVSecrets.ErrorMessage)
+	return nil, "", fmt.Errorf("Failed to get the Azure Key value. Error: ( code: %s, messge: %s )", *azKVSecrets.StatusCode, *azKVSecrets.ErrorMessage)
 }
 
 func getKVSecretServiceEndpointProxy(clients *client.AggregatedClient, kvName string, projectID string, serviceEndpointID string, token string) (*serviceendpoint.ServiceEndpointRequestResult, error) {

--- a/azuredevops/internal/service/wiki/resource_wiki.go
+++ b/azuredevops/internal/service/wiki/resource_wiki.go
@@ -192,7 +192,7 @@ func resourceWikiDelete(d *schema.ResourceData, m interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf(" Delete Project wiki failed. Error: %+v", err)
+			return fmt.Errorf("Delete Project wiki failed. Error: %+v", err)
 		}
 	}
 	return nil

--- a/azuredevops/internal/service/wiki/resource_wiki_page.go
+++ b/azuredevops/internal/service/wiki/resource_wiki_page.go
@@ -114,7 +114,7 @@ func resourceWikiPageUpdate(d *schema.ResourceData, m interface{}) error {
 	clients := m.(*client.AggregatedClient)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" Parse wiki page ID: %s. Error: %+v", d.Id(), err)
+		return fmt.Errorf("Parse wiki page ID: %s. Error: %+v", d.Id(), err)
 	}
 
 	pageLock.Lock()
@@ -142,7 +142,7 @@ func resourceWikiPageDelete(d *schema.ResourceData, m interface{}) error {
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf(" Parse wiki page ID: %s. Error: %+v", d.Id(), err)
+		return fmt.Errorf("Parse wiki page ID: %s. Error: %+v", d.Id(), err)
 	}
 
 	pageLock.Lock()

--- a/azuredevops/internal/service/workitemtracking/resource_workitem.go
+++ b/azuredevops/internal/service/workitemtracking/resource_workitem.go
@@ -222,7 +222,7 @@ func resourceWorkItemUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 	_, err = clients.WorkItemTrackingClient.UpdateWorkItem(clients.Ctx, args)
 	if err != nil {
-		return fmt.Errorf(" Update work item. Project ID: %s, Work Item: %s, Error: %+v", project, d.Id(), err)
+		return fmt.Errorf("Update work item. Project ID: %s, Work Item: %s, Error: %+v", project, d.Id(), err)
 	}
 
 	return resourceWorkItemRead(d, m)

--- a/azuredevops/internal/service/workitemtracking/utils/classification.go
+++ b/azuredevops/internal/service/workitemtracking/utils/classification.go
@@ -100,9 +100,9 @@ func ReadClassificationNode(clients *client.AggregatedClient, d *schema.Resource
 		d.SetId("")
 		js, parseErr := json.Marshal(params)
 		if parseErr != nil {
-			return fmt.Errorf(" Marshalling JSON. Error: %+v", parseErr)
+			return fmt.Errorf("Marshalling JSON. Error: %+v", parseErr)
 		}
-		return fmt.Errorf(" getting ClassificationNode failed. %s. Error: %w", js, err)
+		return fmt.Errorf("getting ClassificationNode failed. %s. Error: %w", js, err)
 	}
 
 	d.SetId(node.Identifier.String())

--- a/azuredevops/internal/utils/tfhelper/tfhelper.go
+++ b/azuredevops/internal/utils/tfhelper/tfhelper.go
@@ -184,7 +184,7 @@ func GetRealProjectId(projectNameOrID string, meta interface{}) (string, error) 
 			IncludeHistory:      converter.Bool(false),
 		})
 		if err != nil {
-			return "", fmt.Errorf(" Failed to get the project with specified projectNameOrID: %s , %+v", projectNameOrID, err)
+			return "", fmt.Errorf("Failed to get the project with specified projectNameOrID: %s , %+v", projectNameOrID, err)
 		}
 		return (*project.Id).String(), nil
 	}

--- a/azuredevops/internal/utils/validate/url.go
+++ b/azuredevops/internal/utils/validate/url.go
@@ -14,7 +14,7 @@ func Url(i interface{}, key string) (_ []string, errors []error) {
 		return
 	}
 	if strings.HasSuffix(url, "/") {
-		errors = append(errors, fmt.Errorf(" %q should not end with slash, got %q.", key, url))
+		errors = append(errors, fmt.Errorf("%q should not end with slash, got %q.", key, url))
 		return
 	}
 	return validation.IsURLWithHTTPorHTTPS(url, key)

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -372,9 +372,9 @@ func clientErrorHandle(err error, orgUrl string) error {
 
 func buildError(statusCode int, orgUrl string) error {
 	if statusCode == http.StatusNotFound {
-		return fmt.Errorf(" Azure DevOps Organization: %s doesn't exist or can't be found. Make sure the URL is correct.", orgUrl)
+		return fmt.Errorf("Azure DevOps Organization: %s doesn't exist or can't be found. Make sure the URL is correct.", orgUrl)
 	} else if statusCode == http.StatusUnauthorized {
-		return fmt.Errorf(" You are not authorized to access Azure DevOps Organization %s", orgUrl)
+		return fmt.Errorf("You are not authorized to access Azure DevOps Organization %s", orgUrl)
 	}
 	return nil
 }

--- a/azuredevops/utils/sdk/auth.go
+++ b/azuredevops/utils/sdk/auth.go
@@ -211,10 +211,10 @@ func GetAuthTokenProvider(ctx context.Context, d *schema.ResourceData, azIdentit
 					clientID = clientIdPlan.(string)
 					tenantID = tenantIdPlan
 				} else {
-					return nil, fmt.Errorf(" Unrecognized workspace run phase: %s", workloadIdentityTokenUnmarshalled.RunPhase)
+					return nil, fmt.Errorf("Unrecognized workspace run phase: %s", workloadIdentityTokenUnmarshalled.RunPhase)
 				}
 			} else if clientID == "" {
-				return nil, fmt.Errorf(" Either client_id or client_id_plan must be set when using Terraform Cloud Workload Identity Token authentication.")
+				return nil, fmt.Errorf("Either client_id or client_id_plan must be set when using Terraform Cloud Workload Identity Token authentication.")
 			}
 
 			cred, err = azIdentityFuncs.NewClientAssertionCredential(tenantID, clientID, AssertionProviderFromString(workloadIdentityToken), nil)


### PR DESCRIPTION
This PR tidies up the test files and more, by doing the following:
1. Remove the old "+build" directives for the existing files as all files have been migrated to using the new "go:build" directives (with the same semantics)
2. Some newly added test files have no build constraints, add them back
3. Fix failing UTs, pass all unit tests
4. Somehow some source code has an empty space prefix in wrapped error messaage, remove that empty space.