### PR TITLE
[Docs] Update azuredevops_securityrole_assignment tf docs

### DIFF
--- a/website/docs/r/securityrole_assignment.html.markdown
+++ b/website/docs/r/securityrole_assignment.html.markdown
@@ -35,7 +35,7 @@ resource "azuredevops_group" "example" {
 resource "azuredevops_securityrole_assignment" "example" {
   scope       = "distributedtask.environmentreferencerole"
   resource_id = format("%s_%s", azuredevops_project.example.id, azuredevops_environment.example.id)
-  identity_id = azuredevops_group.example.origin_id
+  identity_id = azuredevops_group.example.group_id
   role_name   = "Administrator"
 }
 ```
@@ -67,4 +67,4 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Relevant Links
 
-- [Azure DevOps Service REST API 7.0 - Authorize Definition Resource](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/resources/authorize%20definition%20resources?view=azure-devops-rest-7.0)
+- [Azure DevOps Service REST API 7.0 - Authorize Definition Resource](https://learn.microsoft.com/en-us/rest/api/azure/devops/securityroles/roleassignments/set-role-assignments?view=azure-devops-rest-7.0&tabs=HTTP)


### PR DESCRIPTION
In the given example, origin_id is given as the property of an ADO group to pass along as identity_id. However, when the ADO group finds its origin in Entra ID, this will cause the provider to hang indefinitely during creation.

I'm pretty sure that has to do with the fact that calling the underlying endpoint with this origin_id as its role assignment target will return a 200 status code with an empty response body, but the actual state will still not line up with the desired state as defined in the given terraform file, causing terraform to retry until the timeout is hit.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

No behavior change, only docs

Issue Number: N/A

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?

No


## Other information