### PR TITLE
Add service hook subscription resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_servicehook_subscription_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_subscription_test.go
@@ -1,0 +1,154 @@
+//go:build (all || resource_servicehook_subscription) && !exclude_subscriptions
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+func TestAccServicehookSubscription_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_servicehook_subscription"
+	tfCheckNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkServicehookSubscriptionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclServicehookSubscriptionResourceBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
+					resource.TestCheckResourceAttr(tfCheckNode, "publisher_id", "tfs"),
+					resource.TestCheckResourceAttr(tfCheckNode, "event_type", "workitem.created"),
+					resource.TestCheckResourceAttr(tfCheckNode, "consumer_id", "webHooks"),
+					resource.TestCheckResourceAttr(tfCheckNode, "consumer_action_id", "httpRequest"),
+					resource.TestCheckResourceAttr(tfCheckNode, "status", "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServicehookSubscription_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_servicehook_subscription"
+	tfCheckNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkServicehookSubscriptionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclServicehookSubscriptionResourceBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
+					resource.TestCheckResourceAttr(tfCheckNode, "status", "enabled"),
+				),
+			},
+			{
+				Config: hclServicehookSubscriptionResourceUpdated(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
+					resource.TestCheckResourceAttr(tfCheckNode, "status", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+func checkServicehookSubscriptionDestroyed(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azuredevops_servicehook_subscription" {
+			continue
+		}
+
+		// Check if subscription actually exists in Azure DevOps
+		if _, err := getServicehookSubscriptionFromResource(rs); err == nil {
+			return fmt.Errorf("Unexpectedly found a service hook subscription that should be deleted")
+		}
+	}
+
+	return nil
+}
+
+// given a resource from the state, return a servicehook subscription (and error)
+func getServicehookSubscriptionFromResource(resource *terraform.ResourceState) (*servicehooks.Subscription, error) {
+	subscriptionID, err := uuid.Parse(resource.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+	return clients.ServiceHooksClient.GetSubscription(clients.Ctx, servicehooks.GetSubscriptionArgs{
+		SubscriptionId: &subscriptionID,
+	})
+}
+
+func hclServicehookSubscriptionResourceBasic(projectName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%s"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+}
+
+resource "azuredevops_servicehook_subscription" "test" {
+  project_id         = azuredevops_project.test.id
+  publisher_id       = "tfs"
+  event_type         = "workitem.created"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    workItemType = "Bug"
+  }
+
+  consumer_inputs = {
+    url = "https://example.com/webhook"
+  }
+
+  status = "enabled"
+}
+`, projectName)
+}
+
+func hclServicehookSubscriptionResourceUpdated(projectName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%s"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+}
+
+resource "azuredevops_servicehook_subscription" "test" {
+  project_id         = azuredevops_project.test.id
+  publisher_id       = "tfs"
+  event_type         = "workitem.created"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    workItemType = "Task"
+  }
+
+  consumer_inputs = {
+    url = "https://example.com/updated-webhook"
+  }
+
+  status = "disabled"
+}
+`, projectName)
+}

--- a/azuredevops/internal/service/servicehook/resource_servicehook_subscription.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_subscription.go
@@ -1,0 +1,246 @@
+package servicehook
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// ResourceServicehookSubscription schema and implementation for service hook subscription resource
+func ResourceServicehookSubscription() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServicehookSubscriptionCreate,
+		Read:   resourceServicehookSubscriptionRead,
+		Update: resourceServicehookSubscriptionUpdate,
+		Delete: resourceServicehookSubscriptionDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+				Description:  "The ID of the project. If not provided, the subscription will be created at the organization level",
+			},
+			"publisher_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The publisher ID (e.g., 'tfs' for Team Foundation Server, 'pipelines' for Azure Pipelines)",
+			},
+			"event_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The event type (e.g., 'git.push', 'build.complete', 'workitem.created')",
+			},
+			"consumer_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The consumer ID (e.g., 'webHooks', 'azureServiceBus', 'azureStorageQueue')",
+			},
+			"consumer_action_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The consumer action ID (e.g., 'httpRequest', 'enqueue')",
+			},
+			"publisher_inputs": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Publisher-specific inputs as key-value pairs",
+			},
+			"consumer_inputs": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Sensitive:   true,
+				Description: "Consumer-specific inputs as key-value pairs (sensitive)",
+			},
+			"resource_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "1.0",
+				Description: "The resource version for the subscription",
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "enabled",
+				ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled", "disabledByUser", "disabledBySystem", "onProbation"}, false),
+				Description:  "The status of the subscription",
+			},
+		},
+	}
+}
+
+func resourceServicehookSubscriptionCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscription := expandServicehookSubscription(d)
+
+	createdSubscription, err := createSubscription(clients, subscription)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createdSubscription.Id.String())
+	return resourceServicehookSubscriptionRead(d, m)
+}
+
+func resourceServicehookSubscriptionRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscriptionId := converter.UUID(d.Id())
+
+	subscription, err := getSubscription(clients, subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	// Check if subscription was deleted
+	if subscription == nil {
+		d.SetId("")
+		return nil
+	}
+
+	return flattenServicehookSubscription(d, subscription)
+}
+
+func resourceServicehookSubscriptionUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscription := expandServicehookSubscription(d)
+
+	parsedID, err := uuid.Parse(d.Id())
+	if err != nil {
+		return err
+	}
+	subscription.Id = &parsedID
+
+	_, err = updateSubscription(clients, subscription)
+	if err != nil {
+		return err
+	}
+
+	return resourceServicehookSubscriptionRead(d, m)
+}
+
+func resourceServicehookSubscriptionDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	return clients.ServiceHooksClient.DeleteSubscription(clients.Ctx, servicehooks.DeleteSubscriptionArgs{
+		SubscriptionId: converter.UUID(d.Id()),
+	})
+}
+
+func expandServicehookSubscription(d *schema.ResourceData) *servicehooks.Subscription {
+	publisherInputs := make(map[string]string)
+
+	// Add project_id to publisher inputs if provided
+	if projectID, ok := d.GetOk("project_id"); ok {
+		publisherInputs["projectId"] = projectID.(string)
+	}
+
+	// Add any additional publisher inputs
+	if inputs, ok := d.GetOk("publisher_inputs"); ok {
+		for key, value := range inputs.(map[string]interface{}) {
+			publisherInputs[key] = value.(string)
+		}
+	}
+
+	consumerInputs := make(map[string]string)
+	if inputs, ok := d.GetOk("consumer_inputs"); ok {
+		for key, value := range inputs.(map[string]interface{}) {
+			consumerInputs[key] = value.(string)
+		}
+	}
+
+	status := convertStatus(d.Get("status").(string))
+
+	return &servicehooks.Subscription{
+		PublisherId:      converter.String(d.Get("publisher_id").(string)),
+		EventType:        converter.String(d.Get("event_type").(string)),
+		ConsumerId:       converter.String(d.Get("consumer_id").(string)),
+		ConsumerActionId: converter.String(d.Get("consumer_action_id").(string)),
+		PublisherInputs:  &publisherInputs,
+		ConsumerInputs:   &consumerInputs,
+		ResourceVersion:  converter.String(d.Get("resource_version").(string)),
+		Status:           &status,
+	}
+}
+
+func flattenServicehookSubscription(d *schema.ResourceData, subscription *servicehooks.Subscription) error {
+	d.Set("publisher_id", subscription.PublisherId)
+	d.Set("event_type", subscription.EventType)
+	d.Set("consumer_id", subscription.ConsumerId)
+	d.Set("consumer_action_id", subscription.ConsumerActionId)
+	d.Set("resource_version", subscription.ResourceVersion)
+
+	if subscription.Status != nil {
+		d.Set("status", convertStatusFromAPI(*subscription.Status))
+	}
+
+	if subscription.PublisherInputs != nil {
+		publisherInputs := make(map[string]interface{})
+		for key, value := range *subscription.PublisherInputs {
+			// Don't expose projectId as a publisher input if we manage it separately
+			if key != "projectId" {
+				publisherInputs[key] = value
+			} else if key == "projectId" {
+				// Set project_id if it exists in publisher inputs
+				d.Set("project_id", value)
+			}
+		}
+		d.Set("publisher_inputs", publisherInputs)
+	}
+
+	// Note: We don't flatten consumer_inputs as they are sensitive and may contain secrets.
+	// The user needs to manage them in their configuration.
+
+	return nil
+}
+
+func convertStatus(status string) servicehooks.SubscriptionStatus {
+	switch status {
+	case "enabled":
+		return servicehooks.SubscriptionStatusValues.Enabled
+	case "disabled":
+		return servicehooks.SubscriptionStatusValues.DisabledByUser
+	case "disabledByUser":
+		return servicehooks.SubscriptionStatusValues.DisabledByUser
+	case "disabledBySystem":
+		return servicehooks.SubscriptionStatusValues.DisabledBySystem
+	case "onProbation":
+		return servicehooks.SubscriptionStatusValues.OnProbation
+	default:
+		return servicehooks.SubscriptionStatusValues.Enabled
+	}
+}
+
+func convertStatusFromAPI(status servicehooks.SubscriptionStatus) string {
+	switch status {
+	case servicehooks.SubscriptionStatusValues.Enabled:
+		return "enabled"
+	case servicehooks.SubscriptionStatusValues.DisabledByUser:
+		return "disabledByUser"
+	case servicehooks.SubscriptionStatusValues.DisabledBySystem:
+		return "disabledBySystem"
+	case servicehooks.SubscriptionStatusValues.OnProbation:
+		return "onProbation"
+	default:
+		return "enabled"
+	}
+}

--- a/azuredevops/internal/service/servicehook/resource_servicehook_subscription_test.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_subscription_test.go
@@ -1,0 +1,220 @@
+//go:build (all || resource_servicehook_subscription) && !exclude_subscriptions
+
+package servicehook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+var subscriptionID = uuid.New()
+
+var testResourceSubscription = []servicehooks.Subscription{
+	{
+		Id:               &subscriptionID,
+		PublisherId:      converter.String("tfs"),
+		EventType:        converter.String("git.push"),
+		ConsumerId:       converter.String("webHooks"),
+		ConsumerActionId: converter.String("httpRequest"),
+		PublisherInputs: &map[string]string{
+			"projectId":  "myprojectid",
+			"repository": "myrepo",
+		},
+		ConsumerInputs: &map[string]string{
+			"url": "https://example.com/webhook",
+		},
+		ResourceVersion: converter.String("1.0"),
+		Status:          &servicehooks.SubscriptionStatusValues.Enabled,
+	},
+	{
+		Id:               &subscriptionID,
+		PublisherId:      converter.String("pipelines"),
+		EventType:        converter.String("ms.vss-pipelines.run-state-changed-event"),
+		ConsumerId:       converter.String("azureServiceBus"),
+		ConsumerActionId: converter.String("serviceBusQueueMessage"),
+		PublisherInputs: &map[string]string{
+			"projectId":  "myprojectid",
+			"pipelineId": "mypipelineid",
+		},
+		ConsumerInputs: &map[string]string{
+			"connectionString": "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testkey",
+			"queueName":        "myqueue",
+		},
+		ResourceVersion: converter.String("2.0-preview.1"),
+		Status:          &servicehooks.SubscriptionStatusValues.Enabled,
+	},
+}
+
+func TestServicehookSubscription_FlattenExpandRoundTrip(t *testing.T) {
+	for _, subscription := range testResourceSubscription {
+		resourceData := schema.TestResourceDataRaw(t, ResourceServicehookSubscription().Schema, nil)
+
+		// First flatten the subscription
+		err := flattenServicehookSubscription(resourceData, &subscription)
+		require.NoError(t, err)
+
+		// Set the consumer inputs (they aren't flattened for security)
+		resourceData.Set("consumer_inputs", *subscription.ConsumerInputs)
+
+		// Then expand it back
+		subscriptionAfterRoundTrip := expandServicehookSubscription(resourceData)
+		subscriptionAfterRoundTrip.Id = subscription.Id
+
+		require.Equal(t, subscription, *subscriptionAfterRoundTrip)
+	}
+}
+
+func TestServicehookSubscription_Create_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServicehookSubscription()
+	for _, subscription := range testResourceSubscription {
+		resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+		err := flattenServicehookSubscription(resourceData, &subscription)
+		require.NoError(t, err)
+		resourceData.Set("consumer_inputs", *subscription.ConsumerInputs)
+
+		mockClient := azdosdkmocks.NewMockServicehooksClient(ctrl)
+		clients := &client.AggregatedClient{ServiceHooksClient: mockClient, Ctx: context.Background()}
+
+		subscription.Id = nil
+		expectedArgs := servicehooks.CreateSubscriptionArgs{Subscription: &subscription}
+
+		mockClient.
+			EXPECT().
+			CreateSubscription(clients.Ctx, expectedArgs).
+			Return(nil, errors.New("CreateSubscription() Failed")).
+			Times(1)
+
+		err = r.Create(resourceData, clients)
+		require.Contains(t, err.Error(), "CreateSubscription() Failed")
+	}
+}
+
+func TestServicehookSubscription_Update_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServicehookSubscription()
+	for _, subscription := range testResourceSubscription {
+		resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+		resourceData.SetId(subscription.Id.String())
+		err := flattenServicehookSubscription(resourceData, &subscription)
+		require.NoError(t, err)
+		resourceData.Set("consumer_inputs", *subscription.ConsumerInputs)
+
+		mockClient := azdosdkmocks.NewMockServicehooksClient(ctrl)
+		clients := &client.AggregatedClient{ServiceHooksClient: mockClient, Ctx: context.Background()}
+
+		expectedArgs := servicehooks.ReplaceSubscriptionArgs{
+			Subscription:   &subscription,
+			SubscriptionId: subscription.Id,
+		}
+
+		mockClient.
+			EXPECT().
+			ReplaceSubscription(clients.Ctx, expectedArgs).
+			Return(nil, errors.New("ReplaceSubscription() Failed")).
+			Times(1)
+
+		err = r.Update(resourceData, clients)
+		require.Contains(t, err.Error(), "ReplaceSubscription() Failed")
+	}
+}
+
+func TestServicehookSubscription_Read_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServicehookSubscription()
+	for _, subscription := range testResourceSubscription {
+		resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+		resourceData.SetId(subscription.Id.String())
+
+		mockClient := azdosdkmocks.NewMockServicehooksClient(ctrl)
+		clients := &client.AggregatedClient{ServiceHooksClient: mockClient, Ctx: context.Background()}
+
+		expectedArgs := servicehooks.GetSubscriptionArgs{SubscriptionId: subscription.Id}
+
+		mockClient.
+			EXPECT().
+			GetSubscription(clients.Ctx, expectedArgs).
+			Return(nil, errors.New("GetSubscription() Failed")).
+			Times(1)
+
+		err := r.Read(resourceData, clients)
+		require.Contains(t, err.Error(), "GetSubscription() Failed")
+	}
+}
+
+func TestServicehookSubscription_Delete_DoesNotSwallowError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := ResourceServicehookSubscription()
+	for _, subscription := range testResourceSubscription {
+		resourceData := schema.TestResourceDataRaw(t, r.Schema, nil)
+		resourceData.SetId(subscription.Id.String())
+
+		mockClient := azdosdkmocks.NewMockServicehooksClient(ctrl)
+		clients := &client.AggregatedClient{ServiceHooksClient: mockClient, Ctx: context.Background()}
+
+		expectedArgs := servicehooks.DeleteSubscriptionArgs{SubscriptionId: subscription.Id}
+
+		mockClient.
+			EXPECT().
+			DeleteSubscription(clients.Ctx, expectedArgs).
+			Return(errors.New("DeleteSubscription() Failed")).
+			Times(1)
+
+		err := r.Delete(resourceData, clients)
+		require.Contains(t, err.Error(), "DeleteSubscription() Failed")
+	}
+}
+
+func TestServicehookSubscription_StatusConversion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected servicehooks.SubscriptionStatus
+	}{
+		{"enabled", servicehooks.SubscriptionStatusValues.Enabled},
+		{"disabled", servicehooks.SubscriptionStatusValues.DisabledByUser},
+		{"disabledByUser", servicehooks.SubscriptionStatusValues.DisabledByUser},
+		{"disabledBySystem", servicehooks.SubscriptionStatusValues.DisabledBySystem},
+		{"onProbation", servicehooks.SubscriptionStatusValues.OnProbation},
+		{"invalid", servicehooks.SubscriptionStatusValues.Enabled}, // default
+	}
+
+	for _, test := range tests {
+		result := convertStatus(test.input)
+		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestServicehookSubscription_StatusConversionFromAPI(t *testing.T) {
+	tests := []struct {
+		input    servicehooks.SubscriptionStatus
+		expected string
+	}{
+		{servicehooks.SubscriptionStatusValues.Enabled, "enabled"},
+		{servicehooks.SubscriptionStatusValues.DisabledByUser, "disabledByUser"},
+		{servicehooks.SubscriptionStatusValues.DisabledBySystem, "disabledBySystem"},
+		{servicehooks.SubscriptionStatusValues.OnProbation, "onProbation"},
+	}
+
+	for _, test := range tests {
+		result := convertStatusFromAPI(test.input)
+		require.Equal(t, test.expected, result)
+	}
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -136,6 +136,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_visualstudiomarketplace":     serviceendpoint.ResourceServiceEndpointMarketplace(),
 			"azuredevops_servicehook_permissions":                     permissions.ResourceServiceHookPermissions(),
 			"azuredevops_servicehook_storage_queue_pipelines":         servicehook.ResourceServicehookStorageQueuePipelines(),
+			"azuredevops_servicehook_subscription":                    servicehook.ResourceServicehookSubscription(),
 			"azuredevops_service_principal_entitlement":               memberentitlementmanagement.ResourceServicePrincipalEntitlement(),
 			"azuredevops_tagging_permissions":                         permissions.ResourceTaggingPermissions(),
 			"azuredevops_team":                                        core.ResourceTeam(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -106,6 +106,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_visualstudiomarketplace",
 		"azuredevops_servicehook_permissions",
 		"azuredevops_servicehook_storage_queue_pipelines",
+		"azuredevops_servicehook_subscription",
 		"azuredevops_service_principal_entitlement",
 		"azuredevops_tagging_permissions",
 		"azuredevops_team",

--- a/examples/azdo-based-cicd/main.tf
+++ b/examples/azdo-based-cicd/main.tf
@@ -175,3 +175,47 @@ resource "azuredevops_serviceendpoint_kubernetes" "serviceendpoint" {
     ca_cert = "Mzk1MjgkdmRnN0pi[...]mHHRUH14gw4Q=="
   }
 }
+
+# Example Service Hook: Webhook for work item creation
+resource "azuredevops_servicehook_subscription" "workitem_created_webhook" {
+  project_id         = azuredevops_project.project.id
+  publisher_id       = "tfs"
+  event_type         = "workitem.created"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    # Filter for Bug work items only
+    workItemType = "Bug"
+  }
+
+  consumer_inputs = {
+    # Replace with your webhook URL
+    url = "https://webhook.example.com/workitem-created"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}
+
+# Example Service Hook: Webhook for build completion
+resource "azuredevops_servicehook_subscription" "build_complete_webhook" {
+  project_id         = azuredevops_project.project.id
+  publisher_id       = "tfs"
+  event_type         = "build.complete"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    # Filter for builds from our build definition
+    buildDefinition = azuredevops_build_definition.build.id
+  }
+
+  consumer_inputs = {
+    # Replace with your webhook URL
+    url = "https://webhook.example.com/build-complete"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}

--- a/examples/github-based-cicd-simple/main.tf
+++ b/examples/github-based-cicd-simple/main.tf
@@ -41,3 +41,47 @@ resource "azuredevops_build_definition" "nightly_build" {
     service_connection_id = azuredevops_serviceendpoint_github.github_serviceendpoint.id
   }
 }
+
+# Example Service Hook: Webhook for Git push events
+resource "azuredevops_servicehook_subscription" "git_push_webhook" {
+  project_id         = azuredevops_project.project.id
+  publisher_id       = "tfs"
+  event_type         = "git.push"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    # Filter for pushes to master branch only
+    branch = "refs/heads/master"
+  }
+
+  consumer_inputs = {
+    # Replace with your webhook URL
+    url = "https://webhook.example.com/git-push"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}
+
+# Example Service Hook: Webhook for build completion
+resource "azuredevops_servicehook_subscription" "build_complete_webhook" {
+  project_id         = azuredevops_project.project.id
+  publisher_id       = "tfs"
+  event_type         = "build.complete"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    # Filter for builds from our build definition
+    buildDefinition = azuredevops_build_definition.nightly_build.id
+  }
+
+  consumer_inputs = {
+    # Replace with your webhook URL
+    url = "https://webhook.example.com/build-complete"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -338,6 +338,9 @@
                   <a href="/docs/providers/azuredevops/r/servicehook_storage_queue_pipelines.html">azuredevops_servicehook_storage_queue_pipelines</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/servicehook_subscription.html">azuredevops_servicehook_subscription</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/tagging_permissions.html">azuredevops_tagging_permissions</a>
                 </li>
                 <li>

--- a/website/docs/r/servicehook_subscription.html.markdown
+++ b/website/docs/r/servicehook_subscription.html.markdown
@@ -1,0 +1,188 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_servicehook_subscription"
+description: |-
+  Manages a Service Hook subscription.
+---
+
+# azuredevops_servicehook_subscription
+
+Manages a Service Hook subscription in Azure DevOps. Service Hooks provide a way to subscribe to events that occur in Azure DevOps and have those events invoke a service endpoint.
+
+## Example Usage
+
+### WebHook Subscription for Git Push Events
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "example-project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_servicehook_subscription" "webhook_git_push" {
+  project_id          = azuredevops_project.example.id
+  publisher_id        = "tfs"
+  event_type          = "git.push"
+  consumer_id         = "webHooks"
+  consumer_action_id  = "httpRequest"
+
+  publisher_inputs = {
+    repository = "MyRepository"
+    branch     = "refs/heads/main"
+  }
+
+  consumer_inputs = {
+    url = "https://example.com/webhook"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}
+```
+
+### Azure Service Bus Subscription for Build Complete Events
+
+```hcl
+resource "azuredevops_servicehook_subscription" "servicebus_build" {
+  project_id          = azuredevops_project.example.id
+  publisher_id        = "tfs"
+  event_type          = "build.complete"
+  consumer_id         = "azureServiceBus"
+  consumer_action_id  = "serviceBusQueueMessage"
+
+  publisher_inputs = {
+    buildStatus = "Succeeded"
+  }
+
+  consumer_inputs = {
+    connectionString = "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your-key"
+    queueName       = "build-notifications"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}
+```
+
+### Azure Storage Queue Subscription for Pipeline Events
+
+```hcl
+resource "azuredevops_servicehook_subscription" "storage_pipeline" {
+  project_id          = azuredevops_project.example.id
+  publisher_id        = "pipelines"
+  event_type          = "ms.vss-pipelines.run-state-changed-event"
+  consumer_id         = "azureStorageQueue"
+  consumer_action_id  = "enqueue"
+
+  publisher_inputs = {
+    pipelineId  = "123"
+    runStateId  = "Completed"
+    runResultId = "Succeeded"
+  }
+
+  consumer_inputs = {
+    accountName = "mystorageaccount"
+    accountKey  = "your-storage-account-key"
+    queueName   = "pipeline-notifications"
+  }
+
+  resource_version = "5.1-preview.1"
+  status          = "enabled"
+}
+```
+
+### Organization-level Subscription
+
+```hcl
+resource "azuredevops_servicehook_subscription" "org_webhook" {
+  # No project_id specified - organization-level subscription
+  publisher_id       = "tfs"
+  event_type         = "workitem.created"
+  consumer_id        = "webHooks"
+  consumer_action_id = "httpRequest"
+
+  publisher_inputs = {
+    workItemType = "Bug"
+  }
+
+  consumer_inputs = {
+    url = "https://example.com/org-webhook"
+  }
+
+  resource_version = "1.0"
+  status          = "enabled"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `publisher_id` - (Required) The publisher ID that identifies the event source. Common values include:
+  * `tfs` - Team Foundation Server (for Git, Work Items, Builds, etc.)
+  * `pipelines` - Azure Pipelines  
+  * `boards` - Azure Boards
+
+* `event_type` - (Required) The event type to subscribe to. Examples:
+  * `git.push` - Git push events
+  * `git.pullrequest.created` - Pull request created
+  * `build.complete` - Build completed
+  * `workitem.created` - Work item created
+  * `ms.vss-pipelines.run-state-changed-event` - Pipeline run state changed
+
+* `consumer_id` - (Required) The consumer ID that identifies the target service. Common values:
+  * `webHooks` - HTTP webhooks
+  * `azureServiceBus` - Azure Service Bus
+  * `azureStorageQueue` - Azure Storage Queue
+
+* `consumer_action_id` - (Required) The action ID for the consumer. Examples:
+  * `httpRequest` - For webhooks
+  * `serviceBusQueueMessage` - For Service Bus queues
+  * `enqueue` - For Storage queues
+
+* `consumer_inputs` - (Required) A map of consumer-specific configuration inputs. This field is sensitive as it may contain secrets like connection strings or API keys.
+
+---
+
+* `project_id` - (Optional) The ID of the project. If not provided, the subscription will be created at the organization level.
+
+* `publisher_inputs` - (Optional) A map of publisher-specific configuration inputs for filtering events.
+
+* `resource_version` - (Optional) The resource version for the subscription. Default: `1.0`
+
+* `status` - (Optional) The status of the subscription. Possible values: `enabled`, `disabled`, `disabledByUser`, `disabledBySystem`, `onProbation`. Default: `enabled`
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the service hook subscription
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 minutes) Used when creating the Service Hook subscription.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Hook subscription.
+* `update` - (Defaults to 10 minutes) Used when updating the Service Hook subscription.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Service Hook subscription.
+
+## Import
+
+Service Hook subscriptions can be imported using the subscription ID:
+
+```shell
+terraform import azuredevops_servicehook_subscription.example 12345678-1234-5678-9012-123456789012
+```
+
+## PAT Permissions Required
+
+- **Service Hooks**: Read & Write - Grants the ability to create and manage service hook subscriptions.
+
+## Relevant Links
+
+* [Azure DevOps Service Hooks](https://docs.microsoft.com/en-us/azure/devops/service-hooks/)
+* [Azure DevOps Service REST API 7.0 - Service Hooks](https://docs.microsoft.com/en-us/rest/api/azure/devops/hooks/?view=azure-devops-rest-7.0)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

This PR adds a new resource to manage Azure DevOps Service Hooks generically:

- Summary: Introduces azuredevops_servicehook_subscription, a generic resource for managing service hook subscriptions. This enables users to declare and manage service hook subscribers in Terraform across event types.
- Motivation: The provider previously lacked a generic resource for service hook subscriptions. This addition lets teams manage webhooks/service hook integrations declaratively for CI/CD and integrations.
- Scope:
  - New resource: azuredevops_servicehook_subscription
  - Documentation and examples added for the new resource
  - Acceptance tests added, including verification of deletion via the Azure DevOps API

Issue Number:
-  #203 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Impact and Migration:
- N/A. This adds a new resource without changing existing schemas or behaviors.

## Any relevant logs, error output, etc?

N/A

## Other information

- Testing:
  - Includes acceptance tests for create/read/update/delete of azuredevops_servicehook_subscription, with explicit API verification on deletion.
- Documentation:
  - New resource docs and usage examples are included.
- Notes for Reviewers:
  - The resource is intentionally generic to accommodate multiple event types and endpoints supported by Azure DevOps Service Hooks.
  - Please review the acceptance test coverage and example configurations for completeness.