### PR TITLE
docs: fix formatting issue for required argument

### DIFF
--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -12,7 +12,7 @@ Manages a git repository within Azure DevOps.
 
 ~>**NOTE** Importing an existing repository and running `terraform plan` will detect a difference on the `initialization` block. The `plan` and `apply` will then attempt to update the repository based on the `initialization` configurations. It may be necessary to ignore the `initialization` block from `plan` and `apply` to support configuring existing repositories imported into Terraform state.<br>
 
-~>**NOTE**   1. `initialization.init_type` is `Uninitialized`: Changing `source_type` or `source_url` will not recreate the repository, but initialize the repository.   <br>2. `initialization.init_type` is not `Uninitialized`:
+~>**NOTE** 1. `initialization.init_type` is `Uninitialized`: Changing `source_type` or `source_url` will not recreate the repository, but initialize the repository.   <br>2. `initialization.init_type` is not `Uninitialized`:
 <br>&nbsp;&nbsp;&nbsp;&nbsp;1) Updating `init_type` will recreate the repository
 <br>&nbsp;&nbsp;&nbsp;&nbsp;2) Updating `source_type` or `source_url` will recreate the repository
 
@@ -234,12 +234,12 @@ The following arguments are supported:
 * `name` - (Required) The name of the git repository.
 
 * `initialization` - (Required) A `initialization` block as documented below.
+
 ---
 
 * `parent_repository_id` - (Optional) The ID of a Git project from which a fork is to be created.
 
 * `disabled` - (Optional) The ability to disable or enable the repository. Defaults to `false`.
-
 
 ---
 


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

The documentation for the resource [`azuredevops_git_repository`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository) contains a formatting issue: the argument [`initialization`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository#-initialization---required-a-initialization-block-as-documented-below) is rendered as heading.

This pull request resolves this issue and also fixes another minor formatting issue (multiple blanks when only one is required)

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [X] No

## Does this introduce a breaking change?

- [X] No


## Any relevant logs, error output, etc?

Not applicable. Only documentation is updated.

## Other information

None.