### PR TITLE
`azuredevops_variable_group` - Split the `variable` block to `variable` and `secret_variable`

### DIFF
--- a/azuredevops/internal/acceptancetests/data_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_variable_group_test.go
@@ -30,6 +30,7 @@ func TestAccVariableGroupDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
 					resource.TestCheckResourceAttrSet(tfNode, "variable.#"),
 					resource.TestCheckResourceAttr(tfNode, "variable.#", "3"),
+					resource.TestCheckResourceAttr(tfNode, "secret_variable.#", "3"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -34,10 +34,6 @@ func TestAccVariableGroup_basic(t *testing.T) {
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
-					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "test description"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -65,9 +61,6 @@ func TestAccVariableGroup_update(t *testing.T) {
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
-					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -80,10 +73,6 @@ func TestAccVariableGroup_update(t *testing.T) {
 				Config: hclVariableGroupUpdate(projectName, vgName2),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName2, true),
-					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName2),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "3"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "update description"),
 				),
 			},
 			{
@@ -91,15 +80,12 @@ func TestAccVariableGroup_update(t *testing.T) {
 				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"variable.2.secret_value"},
+				ImportStateVerifyIgnore: []string{"secret_variable.0.value", "secret_variable.1.value", "secret_variable.2.value"},
 			},
 			{
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
-					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -107,39 +93,6 @@ func TestAccVariableGroup_update(t *testing.T) {
 				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccVariableGroup_secretValue(t *testing.T) {
-	projectName := testutils.GenerateResourceName()
-	vgName := testutils.GenerateResourceName()
-	tfVarGroupNode := "azuredevops_variable_group.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: checkVariableGroupDestroyed,
-		Steps: []resource.TestStep{
-			{
-				Config: hclVariableGroupSecretValue(projectName, vgName),
-				Check: resource.ComposeTestCheckFunc(
-					checkVariableGroupExists(vgName, true),
-					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "test description"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.0.is_secret", "true"),
-					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.0.secret_value", "value1"),
-				),
-			},
-			{
-				ResourceName:            tfVarGroupNode,
-				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"variable.0.secret_value"},
 			},
 		},
 	})
@@ -301,37 +254,27 @@ resource "azuredevops_variable_group" "test" {
   description  = "update description"
   allow_access = true
   variable {
-    name         = "key1"
-    secret_value = "value1"
-    is_secret    = true
+    name  = "key1"
+    value = "value1"
   }
-
   variable {
     name  = "key2"
     value = "value2"
   }
-
   variable {
     name = "key3"
   }
-}`, projectName, variableGroupName)
-}
 
-func hclVariableGroupSecretValue(projectName, variableGroupName string) string {
-	return fmt.Sprintf(`
-resource "azuredevops_project" "test" {
-  name = "%s"
-}
-
-resource "azuredevops_variable_group" "test" {
-  project_id   = azuredevops_project.test.id
-  name         = "%s"
-  description  = "test description"
-  allow_access = true
-  variable {
-    name         = "key1"
-    secret_value = "value1"
-    is_secret    = true
+  secret_variable {
+    name  = "skey1"
+    value = "value1"
+  }
+  secret_variable {
+    name  = "skey2"
+    value = "value2"
+  }
+  secret_variable {
+    name = "skey3"
   }
 }`, projectName, variableGroupName)
 }

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -374,18 +374,27 @@ resource "azuredevops_variable_group" "vg" {
 	description = "A sample variable group."
 	allow_access = %t
 	variable {
-		name      = "key1"
-		secret_value  = "value1"
-		is_secret = true
+		name   = "key1"
+		value  = "value1"
 	}
-
 	variable {
 		name  = "key2"
 		value = "value2"
 	}
-
 	variable {
 		name = "key3"
+	}
+
+	secret_variable {
+		name   = "skey1"
+		value  = "value1"
+	}
+	secret_variable {
+		name  = "skey2"
+		value = "value2"
+	}
+	secret_variable {
+		name = "skey3"
 	}
 }`, variableGroupName, allowAccess)
 }

--- a/azuredevops/internal/service/taskagent/data_variable_group.go
+++ b/azuredevops/internal/service/taskagent/data_variable_group.go
@@ -50,14 +50,36 @@ func DataVariableGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"secret_value": {
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
+						"content_type": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
-						"is_secret": {
+						"enabled": {
 							Type:     schema.TypeBool,
 							Computed: true,
+						},
+						"expires": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: getVariableHash,
+			},
+
+			"secret_variable": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Computed:  true,
 						},
 						"content_type": {
 							Type:     schema.TypeString,

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -507,7 +507,7 @@ func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableG
 		)
 
 		if isKeyVaultVariableGroupType(variableGroup.Type) {
-			variable, isSecret, err = flattenKeyVaultVariable(variableAsJSON, varName)
+			variable, err = flattenKeyVaultVariable(variableAsJSON, varName)
 		} else {
 			variable, isSecret, err = flattenVariable(d, variableAsJSON, varName)
 		}
@@ -524,11 +524,11 @@ func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableG
 	return variables, secretVariables, nil
 }
 
-func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {
+func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, error) {
 	var variable taskagent.AzureKeyVaultVariableValue
 	err := json.Unmarshal(variableAsJSON, &variable)
 	if err != nil {
-		return nil, false, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
+		return nil, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
 	}
 
 	variableMap := map[string]interface{}{
@@ -540,7 +540,7 @@ func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]
 	if variable.Expires != nil {
 		variableMap["expires"] = variable.Expires.String()
 	}
-	return variableMap, false, nil
+	return variableMap, nil
 }
 
 func flattenVariable(d *schema.ResourceData, variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {

--- a/website/docs/d/variable_group.html.markdown
+++ b/website/docs/d/variable_group.html.markdown
@@ -48,6 +48,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `variable` - One or more `variable` blocks as documented below.
 
+* `secret_variable` - One or more `secret_variable` blocks as documented below.
+
 * `key_vault` - A list of `key_vault` blocks as documented below.
 
 ---
@@ -58,9 +60,13 @@ A `variable` block supports the following:
 
 * `value` - The value of the variable.
 
-* `secret_value` - The secret value of the variable.
+---
 
-* `is_secret` - A boolean flag describing if the variable value is sensitive.
+A `secret_variable` block supports the following:
+
+* `name` - The key value used for the secret variable.
+
+* `value` - The value of the secret variable, which is always `null` as the API won't return it.
 
 ---
 

--- a/website/docs/r/variable_group.html.markdown
+++ b/website/docs/r/variable_group.html.markdown
@@ -36,10 +36,9 @@ resource "azuredevops_variable_group" "example" {
     value = "val1"
   }
 
-  variable {
-    name         = "key2"
-    secret_value = "val2"
-    is_secret    = true
+  secret_variable {
+    name  = "skey1"
+    value = "sval1"
   }
 }
 ```
@@ -99,7 +98,9 @@ The following arguments are supported:
 
 * `allow_access` - (Required) Boolean that indicate if this variable group is shared by all pipelines of this project.
 
-* `variable` - (Required) One or more `variable` blocks as documented below.
+* `variable` - (Optional) One or more `variable` blocks as documented below.
+
+* `secret_variable` - (Optional) One or more `secret_variable` blocks as documented below.
 
 ---
 
@@ -111,15 +112,17 @@ The following arguments are supported:
 
 A `variable` block supports the following:
 
-!> **Warning** variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes
-
 * `name` - (Required) The key value used for the variable. Must be unique within the Variable Group.
 
 * `value` - (Optional) The value of the variable. If omitted, it will default to empty string.
 
-* `secret_value` - (Optional) The secret value of the variable. If omitted, it will default to empty string. Used when `is_secret` set to `true`.
+---
 
-* `is_secret` - (Optional) A boolean flag describing if the variable value is sensitive. Defaults to `false`.
+A `secret_variable` block supports the following:
+
+* `name` - (Required) The key value used for the secret variable. Must be unique within the Variable Group.
+
+* `value` - (Optional) The value of the secret variable. If omitted, it will default to empty string.
 
 ---
 


### PR DESCRIPTION
This PR splits the `variable` block into `variable` and `secret_varaible` for `azuredevops_variable_group`.

As a result, the `secret_value` and `is_secret` attributes are removed from the original `variable` block, which is a breaking change at the schema level. Since there is no obvious way to resolve this in a graceful way, a config update together with an import should mitigate this breaking change.

Fix #1391

## Test

```shell
terraform-provider-azuredevops on  main via 🐹 v1.25.0 took 58s
💤  TF_ACC=1 go test -v -tags=all -run='TestAccVariableGroup_|TestAccVariableGroupDataSource_' ./azuredevops/internal/acceptancetests
=== RUN   TestAccVariableGroupDataSource_Basic
=== PAUSE TestAccVariableGroupDataSource_Basic
=== RUN   TestAccVariableGroupDataSource_KeyVault
    data_variable_group_test.go:41: Skipping test TestAccVariableGroup_DataSourceKeyVault: azure key vault not provisioned on test infrastructure
--- SKIP: TestAccVariableGroupDataSource_KeyVault (0.00s)
=== RUN   TestAccVariableGroup_basic
=== PAUSE TestAccVariableGroup_basic
=== RUN   TestAccVariableGroup_update
=== PAUSE TestAccVariableGroup_update
=== RUN   TestAccVariableGroup_keyVault_basic
    resource_variable_group_test.go:105: Skip test as `TEST_SERVICE_PRINCIPAL_ID` or `TEST_SERVICE_PRINCIPAL_KEY` or `TEST_ARM_TENANT_ID` or `TEST_ARM_SUBSCRIPTION_ID` or `TEST_ARM_SUBSCRIPTION_NAME` or `TEST_ARM_KV_NAME` is not set
--- SKIP: TestAccVariableGroup_keyVault_basic (0.00s)
=== CONT  TestAccVariableGroupDataSource_Basic
=== CONT  TestAccVariableGroup_update
=== CONT  TestAccVariableGroup_basic
--- PASS: TestAccVariableGroupDataSource_Basic (55.79s)
--- PASS: TestAccVariableGroup_basic (56.26s)
--- PASS: TestAccVariableGroup_update (67.60s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        67.622s
```