### PR TITLE
Remove build tags for test cases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,7 @@ linters:
     - staticcheck # checks rules from staticcheck. It's not the same thing as the staticcheck binary.
     - unused # checks Go code for unused constants, variables, functions and types.
     - unconvert # checks for unnecessary type conversions.
-    - unparam # reports unused function parameters.
+    # - unparam # reports unused function parameters.
     - wastedassign # finds wasted assignment statements
     - whitespace # checks for unnecessary newlines at the start and end of functions, if, for, etc. (
 

--- a/azuredevops/internal/acceptancetests/data_agent_pool_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_pool_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_agent_pool) && (!exclude_data_sources || !exclude_data_agent_pool)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_agent_pools_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_pools_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_agent_pools) && (!exclude_data_sources || !exclude_data_agent_pools)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_agent_queue_test.go
+++ b/azuredevops/internal/acceptancetests/data_agent_queue_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_agent_queue) && (!exclude_data_sources || !exclude_data_agent_queue)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_area_test.go
+++ b/azuredevops/internal/acceptancetests/data_area_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_area) && (!exclude_data_sources || !exclude_data_area)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/data_build_definition_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_build_definition) && (!exclude_data_sources || !exclude_data_build_definition)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_client_config_test.go
+++ b/azuredevops/internal/acceptancetests/data_client_config_test.go
@@ -1,5 +1,3 @@
-//go:build all || core
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_descriptor_test.go
+++ b/azuredevops/internal/acceptancetests/data_descriptor_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_descriptor) && (!exclude_data_sources || !exclude_data_descriptor)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_environment_test.go
+++ b/azuredevops/internal/acceptancetests/data_environment_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_environment) && !exclude_data_environment
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_feed_test.go
+++ b/azuredevops/internal/acceptancetests/data_feed_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_feed) && (!exclude_data_sources || !exclude_data_feed)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_git_repositories_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repositories_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || git || data_git_repositories) && (!exclude_data_sources || !exclude_git || !exclude_data_git_repositories)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repository_file_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || git || data_git_repository) && (!exclude_data_sources || !exclude_git || !data_git_repository)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repository_test.go
@@ -38,7 +38,7 @@ func TestAccGitRepository_DataSource_notExist(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      hclDataRepositoryNotExist(name),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Repository with name notExist does not exist`)),
+				ExpectError: regexp.MustCompile(`Repository with name notExist does not exist`),
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/data_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/data_git_repository_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || git || data_git_repository) && (!exclude_data_sources || !exclude_git || !data_git_repository)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_membership_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_group_membership) && (!exclude_data_sources || !exclude_data_group_membership)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_group_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_groups_test.go
@@ -63,5 +63,5 @@ data "azuredevops_groups" "groups" {
 }
 
 func hclGroupsDataSourceAllGroups() string {
-	return fmt.Sprintf(`data "azuredevops_groups" "groups" {}`)
+	return `data "azuredevops_groups" "groups" {}`
 }

--- a/azuredevops/internal/acceptancetests/data_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_groups_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_groups) && (!exclude_data_sources || !exclude_data_groups)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_identity_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_group_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_group) && (!exclude_data_sources || !exclude_data_group)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_identity_groups_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_groups_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_groups) && (!exclude_data_sources || !exclude_data_groups)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_identity_user_test.go
+++ b/azuredevops/internal/acceptancetests/data_identity_user_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_identity_user) && (!exclude_data_sources || !exclude_data_identity_user)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_iteration_test.go
+++ b/azuredevops/internal/acceptancetests/data_iteration_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_iteration) && (!exclude_data_sources || !exclude_data_iteration)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_project_test.go
+++ b/azuredevops/internal/acceptancetests/data_project_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || resource_project || data_project) && (!exclude_data_sources || !exclude_data_project)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_projects_test.go
+++ b/azuredevops/internal/acceptancetests/data_projects_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || resource_project || data_projects) && (!data_sources || !exclude_data_projects)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_projects_test.go
+++ b/azuredevops/internal/acceptancetests/data_projects_test.go
@@ -58,10 +58,10 @@ data "azuredevops_projects" "test" {
 }
 
 func hclDataSourceProjectsEmptyResult() string {
-	return fmt.Sprintf(`
+	return `
 data "azuredevops_projects" "test" {
   name  = "invalid_name"
   state = "wellFormed"
 }
-`)
+`
 }

--- a/azuredevops/internal/acceptancetests/data_securityrole_definitions_test.go
+++ b/azuredevops/internal/acceptancetests/data_securityrole_definitions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_securityrole_definitions) && (!data_sources || !exclude_data_securityrole_definitions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_service_principal_test.go
+++ b/azuredevops/internal/acceptancetests/data_service_principal_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_service_principal) && (!exclude_data_sources || !exclude_data_service_principal)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurecr_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_azurecr) && (!exclude_data_sources || !exclude_data_serviceendpoint_azurecr)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_azurerm) && (!exclude_data_sources || !exclude_data_serviceendpoint_azurerm)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_azurerm_test.go
@@ -78,7 +78,10 @@ func TestAccServiceEndpointAzureRM_dataSource_with_WorkloadIdentityFederation(t 
 	azureDevOpsOrgName := "terraform-provider-azuredevops"
 
 	if os.Getenv("AZDO_ORG_SERVICE_URL") != "" {
-		azureDevOpsOrgUrl, _ := url.Parse(os.Getenv("AZDO_ORG_SERVICE_URL"))
+		azureDevOpsOrgUrl, err := url.Parse(os.Getenv("AZDO_ORG_SERVICE_URL"))
+		if err != nil {
+			t.Fatal(err)
+		}
 		azureDevOpsOrgName = path.Base(azureDevOpsOrgUrl.Path)
 	}
 

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_bitbucket_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_github) && (!exclude_data_sources || !exclude_data_serviceendpoint_github)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_dockerregistry_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_dockerregistry) && (!exclude_data_sources || !exclude_data_serviceendpoint_dockerregistry)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_github_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_github) && (!exclude_data_sources || !exclude_data_serviceendpoint_github)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_npm_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_npm) && (!exclude_data_sources || !exclude_data_serviceendpoint_npm)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_serviceendpoint_sonarcloud_test.go
+++ b/azuredevops/internal/acceptancetests/data_serviceendpoint_sonarcloud_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_serviceendpoint_sonarcloud) && (!exclude_data_sources || !exclude_data_serviceendpoint_sonarcloud)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_storage_key_test.go
+++ b/azuredevops/internal/acceptancetests/data_storage_key_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_storage_key) && (!exclude_data_sources || !exclude_data_storage_key)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_team_test.go
+++ b/azuredevops/internal/acceptancetests/data_team_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_team) && (!exclude_data_sources || !exclude_data_team)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_teams_test.go
+++ b/azuredevops/internal/acceptancetests/data_teams_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_teams) && (!exclude_data_sources || !exclude_data_teams)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_user_test.go
+++ b/azuredevops/internal/acceptancetests/data_user_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_user) && (!exclude_data_sources || !exclude_data_user)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_users_test.go
+++ b/azuredevops/internal/acceptancetests/data_users_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_users) && (!exclude_data_sources || !exclude_data_users)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/data_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_variable_group_test.go
@@ -1,5 +1,3 @@
-//go:build (all || data_sources || data_variable_group) && (!exclude_data_sources || !exclude_data_variable_group)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_agent_pool_test.go
+++ b/azuredevops/internal/acceptancetests/resource_agent_pool_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_agentpool) && !exclude_resource_agentpool
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
+++ b/azuredevops/internal/acceptancetests/resource_agent_queue_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_agent_queue) && !exclude_resource_agent_queue
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_area_permissions) && (!exclude_permissions || !exclude_resource_area_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_auto_reviewers_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_auto_reviewers_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_auto_reviewers) && !exclude_resource_branchpolicy_auto_reviewers
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_build_validation_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_build_validation_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_build_validation) && !exclude_resource_branchpolicy_build_validation
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_comment_resolution_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_comment_resolution_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_comment_resolution) && !exclude_resource_branchpolicy_comment_resolution
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_merge_types_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_merge_types_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_merge_types) && !exclude_resource_branchpolicy_merge_types
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_min_reviewer_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_min_reviewer_acceptance_test || policy) && (!exclude_resource_branchpolicy_min_reviewer_acceptance_test || !exclude_policy)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_status_check_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_status_check_acceptance_test || policy) && (!exclude_resource_branchpolicy_status_check_acceptance_test || !exclude_policy)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_branchpolicy_work_item_linking_test.go
+++ b/azuredevops/internal/acceptancetests/resource_branchpolicy_work_item_linking_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_branchpolicy_work_item_linking) && !exclude_resource_branchpolicy_work_item_linking
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_build_definition_permissions) && (!exclude_permissions || !exclude_resource_build_definition_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_test.go
@@ -606,7 +606,6 @@ func checkForVariableValues(tfNode string, expectedVals ...string) resource.Test
 			if !found {
 				return fmt.Errorf("Did not find variable with value %s", expectedVal)
 			}
-
 		}
 
 		return nil

--- a/azuredevops/internal/acceptancetests/resource_build_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_definition_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_build_definition) && !exclude_resource_build_definition
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_build_Folder_permissions) && (!exclude_permissions || !exclude_resource_build_Folder_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_build_folder_test.go
+++ b/azuredevops/internal/acceptancetests/resource_build_folder_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_build_folder) && (!exclude_permissions || !exclude_resource_build_folder)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_approval_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_approval_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_business_hours) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_common_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_common_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_branch_control) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_exclusive_lock) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_required_template) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_rest_api) && !exclude_resource_check_rest_api
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_dashboard_test.go
+++ b/azuredevops/internal/acceptancetests/resource_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_dashboard) && !exclude_resource_dashboard
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_elastic_pool_test.go
+++ b/azuredevops/internal/acceptancetests/resource_elastic_pool_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_elasticpool) && !exclude_resource_elasticpool
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_resource_kubernetes_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_environment_resource_kubernetes) && !exclude_resource_environment_resource_kubernetes
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_environment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_environment_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_environment) && !exclude_resource_environment
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_extension_test.go
+++ b/azuredevops/internal/acceptancetests/resource_extension_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_extension) && !exclude_resource_extension
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_permission_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || data_sources || data_feed) && (!data_sources || !exclude_feed)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_retention_policy_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_feed_retention_policy) && !exclude_resource_feed_retention_policy
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_feed_test.go
+++ b/azuredevops/internal/acceptancetests/resource_feed_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_feed) && !exclude_resource_feed
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_git_permissions) && (!exclude_permissions || !exclude_resource_git_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_branch_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_git_repository_branch) && !exclude_resource_git_repository_branch
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_file_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_git_repository_file) && !exclude_resource_git_repository_file
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_git_repository) && !exclude_resource_git_repository
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -462,7 +462,7 @@ func readGitRepo(clients *client.AggregatedClient, repoID string, projectID stri
 			return nil, err
 		}
 		for _, gitRepo := range *allRepo {
-			if strings.EqualFold((*gitRepo.Id).String(), repoID) ||
+			if strings.EqualFold(gitRepo.Id.String(), repoID) ||
 				strings.EqualFold(*gitRepo.Name, repoID) {
 				repo = &gitRepo
 				break

--- a/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_entitlement_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_group_entitlement) && !exclude_resource_group_entitlement
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_membership_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_group_membership) && !exclude_resource_group_membership
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_test.go
@@ -198,7 +198,6 @@ func checkGroupDestroyed(s *terraform.State) error {
 			}
 			return fmt.Errorf("Group with ID %s should not exist in scope %s", id, resource.Primary.Attributes["scope"])
 		}
-
 	}
 
 	return nil

--- a/azuredevops/internal/acceptancetests/resource_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_group) && !exclude_resource_group
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_iteration_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_iteration_permissions) && (!exclude_permissions || !exclude_resource_iteration_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_library_permissions) && (!exclude_permissions || !exclude_resource_library_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
@@ -1,5 +1,3 @@
-//go:build (all || pipeline_authorization) && !exclude_pipeline_authorization
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_features_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_features_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_project || resource_project_features) && !exclude_resource_project_features
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_project_permissions) && (!exclude_permissions || !exclude_resource_project_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_pipeline_settings_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_project || resource_project_features) && !exclude_resource_project_features
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_tags_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_tags_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_project_tags) && !exclude_resource_project_tags
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_project_test.go
+++ b/azuredevops/internal/acceptancetests/resource_project_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_project) && !exclude_resource_project
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_author_email_patterns_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_author_email_patterns_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_repositorypolicy_author_email_patterns) && !resource_repositorypolicy_author_email_patterns
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_case_enforcement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_case_enforcement_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_policy_case_enforcement) && !resource_policy_case_enforcement
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_check_credentials_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_check_credentials_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_policy_check_credentials) && !resource_policy_check_credentials
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_path_patterns_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_path_patterns_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_repositorypolicy_file_path_patterns) && !exclude_resource_repositorypolicy_file_path_patterns
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_reserved_names_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_file_reserved_names_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_policy_reserved_names) && !resource_policy_reserved_names
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_file_size_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_file_size_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_policy_file_size) && !resource_policy_file_size
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_path_length_test.go
+++ b/azuredevops/internal/acceptancetests/resource_repositorypolicy_max_path_length_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_policy_path_lenght) && !resource_policy_path_lenght
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_resource_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_resource_authorization_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_authorization) && !exclude_resource_authorization
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_securityrole_assignment) && !exclude_resource_securityrole_assignment
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_service_principal_entitlement_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_service_principal_entitlement) && !exclude_resource_service_principal_entitlement
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_argocd_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_argocd) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_artifactory_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_artifactory) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_aws_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_aws) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azure_service_bus_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azure_service_bus_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_azure_service_bus) && !exclude_resource_serviceendpoint_azure_service_bus
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurecr_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_azurecr) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azuredevops_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_azuredevops) && !resource_serviceendpoint_azuredevops
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -217,7 +217,10 @@ func TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate(t *
 	azureDevOpsOrgName := "terraform-provider-azuredevops"
 
 	if os.Getenv("AZDO_ORG_SERVICE_URL") != "" {
-		azureDevOpsOrgUrl, _ := url.Parse(os.Getenv("AZDO_ORG_SERVICE_URL"))
+		azureDevOpsOrgUrl, err := url.Parse(os.Getenv("AZDO_ORG_SERVICE_URL"))
+		if err != nil {
+			t.Fatal(err)
+		}
 		azureDevOpsOrgName = path.Base(azureDevOpsOrgUrl.Path)
 	}
 

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_azurerm) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_bitbucket) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_black_duck_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_black_duck_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_black_duck) && !exclude_resource_serviceendpoint_black_duck
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_one_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_checkmarx_one) && !exclude_resource_serviceendpoint_checkmarx_one
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sast_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sast_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_checkmarx_sast) && !exclude_resource_serviceendpoint_checkmarx_sast
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sca_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_checkmarx_sca_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_checkmarx_sca) && !exclude_resource_serviceendpoint_checkmarx_sca
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_dockerregistry_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_dockerregistry_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_dockerregistry) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_dynamic_lifecycle_services_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_dynamic_lifecycle_services_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_dynamic_lifecycle_services) && !exclude_resource_serviceendpoint_dynamic_lifecycle_services
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_externaltfs_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_externaltfs_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_externaltfs) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_gcp_terraform_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_gcp_terraform_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_gcp_terraform) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_git_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_git_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_generic_git) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_generic) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_enterprise_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_github_enterprise) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_github_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_github) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_gitlab_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_gitlab_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_gitlab) && !exclude_resource_serviceendpoint_gitlab
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_incomingwebhook_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_incomingwebhook_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_incomingwebhook) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jenkins_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jenkins_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_jenkins) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_jfrog_artifactory_v2) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_artifactory_v2_test.go
@@ -346,20 +346,3 @@ resource "azuredevops_serviceendpoint_jfrog_artifactory_v2" "import" {
 }
 `, template)
 }
-
-func hclSvcEndpointJFrogArtifactoryV2ResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointJFrogArtifactoryV2ResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_jfrog_artifactory_v2" "import" {
-  project_id            = azuredevops_serviceendpoint_jfrog_artifactory_v2.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_jfrog_artifactory_v2.test.service_endpoint_name
-  description           = azuredevops_serviceendpoint_jfrog_artifactory_v2.test.description
-  url                   = azuredevops_serviceendpoint_jfrog_artifactory_v2.test.url
-  authentication_basic {
-    username = "u"
-    password = "redacted"
-  }
-}
-`, template)
-}

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_jfrog_distribution_v2) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_distribution_v2_test.go
@@ -346,20 +346,3 @@ resource "azuredevops_serviceendpoint_jfrog_distribution_v2" "import" {
 }
 `, template)
 }
-
-func hclSvcEndpointJFrogDistributionV2ResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointJFrogDistributionV2ResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_jfrog_distribution_v2" "import" {
-  project_id            = azuredevops_serviceendpoint_jfrog_distribution_v2.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_jfrog_distribution_v2.test.service_endpoint_name
-  description           = azuredevops_serviceendpoint_jfrog_distribution_v2.test.description
-  url                   = azuredevops_serviceendpoint_jfrog_distribution_v2.test.url
-  authentication_basic {
-    username = "u"
-    password = "redacted"
-  }
-}
-`, template)
-}

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
@@ -346,20 +346,3 @@ resource "azuredevops_serviceendpoint_jfrog_platform_v2" "import" {
 }
 `, template)
 }
-
-func hclSvcEndpointJFrogPlatformV2ResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointJFrogPlatformV2ResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_jfrog_platform_v2" "import" {
-  project_id            = azuredevops_serviceendpoint_jfrog_platform_v2.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_jfrog_platform_v2.test.service_endpoint_name
-  description           = azuredevops_serviceendpoint_jfrog_platform_v2.test.description
-  url                   = azuredevops_serviceendpoint_jfrog_platform_v2.test.url
-  authentication_basic {
-    username = "u"
-    password = "redacted"
-  }
-}
-`, template)
-}

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_platform_v2_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_jfrog_platform_v2) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
@@ -346,20 +346,3 @@ resource "azuredevops_serviceendpoint_jfrog_xray_v2" "import" {
 }
 `, template)
 }
-
-func hclSvcEndpointJFrogXRayV2ResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointJFrogXRayV2ResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_jfrog_xray_v2" "import" {
-  project_id            = azuredevops_serviceendpoint_jfrog_xray_v2.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_jfrog_xray_v2.test.service_endpoint_name
-  description           = azuredevops_serviceendpoint_jfrog_xray_v2.test.description
-  url                   = azuredevops_serviceendpoint_jfrog_xray_v2.test.url
-  authentication_basic {
-    username = "u"
-    password = "redacted"
-  }
-}
-`, template)
-}

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_jfrog_xray_v2_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_jfrog_xray_v2) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_kubernetes_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_kubernetes) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_maven) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_maven_test.go
@@ -353,21 +353,3 @@ resource "azuredevops_serviceendpoint_maven" "import" {
 }
 `, template)
 }
-
-func hclSvcEndpointMavenResourceRequiresImportUsernamePassword(projectName string, serviceEndpointName string, description string) string {
-	template := hclSvcEndpointMavenResourceBasicUsernamePassword(projectName, serviceEndpointName, description)
-	return fmt.Sprintf(`
-%s
-resource "azuredevops_serviceendpoint_maven" "import" {
-  project_id            = azuredevops_serviceendpoint_maven.test.project_id
-  service_endpoint_name = azuredevops_serviceendpoint_maven.test.service_endpoint_name
-  description           = azuredevops_serviceendpoint_maven.test.description
-  url                   = azuredevops_serviceendpoint_maven.test.url
-  repository_id         = "test-repository"
-  authentication_basic {
-    username = "u"
-    password = "redacted"
-  }
-}
-`, template)
-}

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_nexus_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_nexus_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_nexus) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_npm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_npm_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_npm) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_nuget_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_nuget_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_nuget) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_octopus_deploy_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_octopus_deploy_test.go
@@ -1,5 +1,3 @@
-//go:build (all || azuredevops_serviceendpoint_octopusdeploy) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_openshift_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_openshift_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_openshift) && !exclude_resource_serviceendpoint_openshift
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_serviceendpoint_permissions) && (!exclude_permissions || !exclude_resource_serviceendpoint_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_runpipeline_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_runpipeline_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_runpipeline) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_servicefabric_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_servicefabric_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_service_fabric) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_snyk_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_snyk_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_snyk) && !exclude_resource_serviceendpoint_snyk
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarcloud_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarcloud_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_SonarCloud) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarqube_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_sonarqube_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_sonarqube) && !exclude_serviceendpoints
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_ssh_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_ssh_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_ssh) && !resource_serviceendpoint_ssh
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_visualstudiomarketplace_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_visualstudiomarketplace_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_serviceendpoint_visualstudiomarketplace) && !exclude_resource_serviceendpoint_visualstudiomarketplace
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_servicehook_permissions) && (!exclude_permissions || !exclude_resource_servicehook_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_check_required_template) && !exclude_approvalsandchecks
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_storage_queue_pipelines_test.go
@@ -91,7 +91,7 @@ func TestAccServicehookStorageQueuePipelines_accountKeyError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testutils.HclServicehookStorageQeueuePipelinesResourceWithStageEvent(projectName, "accountkey", "testqueue", "Canceled", "Canceled"),
-				ExpectError: regexp.MustCompile("expected length of account_key to be in the range \\(64 - 100\\)"),
+				ExpectError: regexp.MustCompile(`expected length of account_key to be in the range (64 - 100)`),
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_tagging_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_tagging_permissions) && (!exclude_permissions || !exclude_resource_tagging_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_team_administrators_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_administrators_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_team_administrators) && !exclude_resource_team_administrators
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_team_members_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_members_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_team_members) && !exclude_resource_team_members
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_team_test.go
+++ b/azuredevops/internal/acceptancetests/resource_team_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || resource_team) && !exclude_resource_team
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
+++ b/azuredevops/internal/acceptancetests/resource_user_entitlement_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_user_entitlement) && !exclude_resource_user_entitlement
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_variable_group_permissions) && (!exclude_permissions || !exclude_resource_variable_group_permissions)
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -1,5 +1,3 @@
-//go:build (all || resource_variable_group) && !exclude_resource_variable_group
-
 package acceptancetests
 
 // The tests in this file use the mock clients in mock_client.go to mock out

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -159,10 +159,8 @@ func checkVariableGroupExists(expectedName string, expectedAllowAccess bool) res
 			if len(*definitionReference) > 0 && *(*definitionReference)[0].Authorized != expectedAllowAccess {
 				return fmt.Errorf("Variable Group has Allow_access=%t, but expected %t", *(*definitionReference)[0].Authorized, expectedAllowAccess)
 			}
-		} else {
-			if len(*definitionReference) > 0 {
-				return fmt.Errorf("Definition reference should be empty for allow access false")
-			}
+		} else if len(*definitionReference) > 0 {
+			return fmt.Errorf("Definition reference should be empty for allow access false")
 		}
 		return nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
@@ -1,5 +1,3 @@
-//go:build (all || wiki || resource_wiki) && !exclude_resource_wiki
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_page_test.go
@@ -100,7 +100,7 @@ func TestAccWikiPageResource_requireImportError(t *testing.T) {
 			},
 			{
 				Config:      hclProjectWikiPageImport(projectName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`The page '/path' specified in the add operation already exists in the wiki. Please specify a new page path.`)),
+				ExpectError: regexp.MustCompile(`The page '/path' specified in the add operation already exists in the wiki. Please specify a new page path.`),
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_wiki_test.go
+++ b/azuredevops/internal/acceptancetests/resource_wiki_test.go
@@ -1,5 +1,3 @@
-//go:build (all || wiki || resource_wiki) && !exclude_resource_wiki
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_workitem_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitem_test.go
@@ -1,5 +1,3 @@
-//go:build (all || core || workitem) && !exclude_resource_workitem
-
 package acceptancetests
 
 import (

--- a/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemquery_permissions_test.go
@@ -1,5 +1,3 @@
-//go:build (all || permissions || resource_workitemquery_permissions) && (!exclude_permissions || !resource_workitemquery_permissions)
-
 package acceptancetests
 
 import (


### PR DESCRIPTION
There is built-in skip check for env var `TF_ACC`, as well as precheck for some ADO specific env vars. There is no benefit to adding the conditional build tags for these test files, except for grouping some test cases together under the same tag, which however isn't really well maintained. The downside to keep these tags is the language server need additional settings to be able to work with these test files.

Since there isn't more benefit than drawbacks to keep these build tags, this PR removes them.