### PR TITLE
`GetPrincipalPermissions` handle no permissions retrieved

### DIFF
--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -244,7 +244,7 @@ func (sn *SecurityNamespace) GetAccessControlList(descriptorList *[]string) (*se
 		return nil, nil
 	}
 
-	var descriptors *string = nil
+	var descriptors *string
 	val := linq.From(*descriptorList).
 		Aggregate(func(r interface{}, i interface{}) interface{} {
 			if r.(string) == "" {

--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -240,17 +240,19 @@ func (sn *SecurityNamespace) GetActionDefinitions() (*map[string]security.Action
 }
 
 func (sn *SecurityNamespace) GetAccessControlList(descriptorList *[]string) (*security.AccessControlList, error) {
-	var descriptors *string = nil
-	if descriptorList != nil && len(*descriptorList) > 0 {
-		val := linq.From(*descriptorList).
-			Aggregate(func(r interface{}, i interface{}) interface{} {
-				if r.(string) == "" {
-					return i
-				}
-				return r.(string) + "," + i.(string)
-			}).(string)
-		descriptors = &val
+	if descriptorList == nil || len(*descriptorList) == 0 {
+		return nil, nil
 	}
+
+	var descriptors *string = nil
+	val := linq.From(*descriptorList).
+		Aggregate(func(r interface{}, i interface{}) interface{} {
+			if r.(string) == "" {
+				return i
+			}
+			return r.(string) + "," + i.(string)
+		}).(string)
+	descriptors = &val
 
 	bTrue := true
 	acl, err := sn.securityClient.QueryAccessControlLists(sn.context, security.QueryAccessControlListsArgs{
@@ -269,6 +271,37 @@ func (sn *SecurityNamespace) GetAccessControlList(descriptorList *[]string) (*se
 		return nil, fmt.Errorf("Failed to load current ACL for token [%s]. Result set contains more than one ACL", sn.token)
 	}
 	return &(*acl)[0], nil
+}
+
+func (sn *SecurityNamespace) tryGetIdentitiesFromSubjects(principal *[]string) (*[]identity.Identity, error) {
+	descriptors := linq.From(*principal).
+		Aggregate(func(r interface{}, i interface{}) interface{} {
+			if r.(string) == "" {
+				return i
+			}
+			return r.(string) + "," + i.(string)
+		}).(string)
+
+	idlist, err := sn.identityClient.ReadIdentities(sn.context, identity.ReadIdentitiesArgs{
+		SubjectDescriptors: converter.String(descriptors),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var emptyId identity.Identity
+	linq.From(*idlist).Where(func(ele interface{}) bool {
+		if val, ok := ele.(identity.Identity); ok {
+			if val == emptyId {
+				return false
+			}
+			if val.IsActive == nil || val.IsActive != nil && *val.IsActive {
+				return true
+			}
+		}
+		return false
+	}).ToSlice(idlist)
+	return idlist, nil
 }
 
 func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]identity.Identity, error) {
@@ -295,8 +328,12 @@ func (sn *SecurityNamespace) getIdentitiesFromSubjects(principal *[]string) (*[]
 		return nil, fmt.Errorf("No identity information for defined principals [%s]", descriptors)
 	}
 
+	var emptyId identity.Identity
 	linq.From(*idlist).Where(func(ele interface{}) bool {
 		if val, ok := ele.(identity.Identity); ok {
+			if val == emptyId {
+				return false
+			}
 			if val.IsActive == nil || val.IsActive != nil && *val.IsActive {
 				return true
 			}
@@ -444,7 +481,7 @@ func (sn *SecurityNamespace) GetPrincipalPermissions(principal *[]string) (*[]Pr
 		return nil, err
 	}
 
-	idList, err := sn.getIdentitiesFromSubjects(principal)
+	idList, err := sn.tryGetIdentitiesFromSubjects(principal)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`GetPrincipalPermissions()` is called by a few resources during `Read()`. One of the main step it does it to read the *identities* based on the principals (e.g. a user, a team, etc.) specified by the resource. Previously, the identity read logic is quite strict, where it expects the identity read matches the principal specified, with respect to the amount.

In most cases, this is fine. There is an edge case where the ADO org is changed (with the state records the original org), e.g. https://github.com/microsoft/terraform-provider-azuredevops/issues/1437. In this case, the identities read is `[null]`, which will be unmarshalled into an array of an empty identity. This causes a panic later on. To resolve this panic, we shall skip the empty identity, however, this is not enough since the existing identity read logic is strict about the amount,  where it expects the identity list returned can't be empty.

Instead, we shall be *honest* here to return whatever we read, in this case it is an empty list of identity. This allows the outside logic to attest the emptiness of the permission and set the resource as gone accordingly. For this reason, this PR introduces a function `tryGetIdentitiesFromSubjects`, which is similar to `getIdentitiesFromSubjects`, but more forgivable. This function replaces the original one, only in the `GetPrincipalPermissions`'s call site, which is used in the `Read()`. But keep the other call sites in `RemovePrincipalPermissions` and `SetPrincipalPermissions` untouched, to avoid unnecessary changes.

Fix #1437