### PR TITLE
Added optional skip_destroy meta argument for azuredevops_group resource

### DIFF
--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -56,6 +56,9 @@ The following arguments are supported:
 
   ~> **NOTE:** It's possible to define group members both within the `azuredevops_group` resource via the members block and by using the `azuredevops_group_membership` resource. However it's not possible to use both methods to manage group members, since there'll be conflicts.
 
+* `skip_destroy` - (Optional) Meta argument to skip group destroy API call. Might be useful when deployment identity does not have
+sufficient organization permissions to do so. Only works in conjunction with `origin_id`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
## What about the current behavior has changed?

This pull request adds `skip_destroy` option for resource `azuredevops_group`.

This option is useful for cases when you need to sync Entra ID backed group to Azure DevOps with identity which might not have sufficient organization level privileges to delete the group afterwards.

Issue: https://github.com/microsoft/terraform-provider-azuredevops/issues/1431

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [*] No

## Does this introduce a breaking change?

- [ ] Yes
- [*] No