### PR TITLE
Fix an issue that early return in `GetAccessControlList()`

### DIFF
--- a/azuredevops/internal/service/permissions/utils/namespaces.go
+++ b/azuredevops/internal/service/permissions/utils/namespaces.go
@@ -240,19 +240,17 @@ func (sn *SecurityNamespace) GetActionDefinitions() (*map[string]security.Action
 }
 
 func (sn *SecurityNamespace) GetAccessControlList(descriptorList *[]string) (*security.AccessControlList, error) {
-	if descriptorList == nil || len(*descriptorList) == 0 {
-		return nil, nil
+	var descriptors *string = nil
+	if descriptorList != nil && len(*descriptorList) > 0 {
+		val := linq.From(*descriptorList).
+			Aggregate(func(r interface{}, i interface{}) interface{} {
+				if r.(string) == "" {
+					return i
+				}
+				return r.(string) + "," + i.(string)
+			}).(string)
+		descriptors = &val
 	}
-
-	var descriptors *string
-	val := linq.From(*descriptorList).
-		Aggregate(func(r interface{}, i interface{}) interface{} {
-			if r.(string) == "" {
-				return i
-			}
-			return r.(string) + "," + i.(string)
-		}).(string)
-	descriptors = &val
 
 	bTrue := true
 	acl, err := sn.securityClient.QueryAccessControlLists(sn.context, security.QueryAccessControlListsArgs{


### PR DESCRIPTION
Reverting a change introduced in https://github.com/microsoft/terraform-provider-azuredevops/pull/1434, which unexpectedly cause a regression that affects quite a few resources.

Fix #1464