### PR TITLE
Revert #1434

### DIFF
--- a/azuredevops/internal/acceptancetests/data_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/data_variable_group_test.go
@@ -28,7 +28,6 @@ func TestAccVariableGroupDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
 					resource.TestCheckResourceAttrSet(tfNode, "variable.#"),
 					resource.TestCheckResourceAttr(tfNode, "variable.#", "3"),
-					resource.TestCheckResourceAttr(tfNode, "secret_variable.#", "3"),
 				),
 			},
 		},

--- a/azuredevops/internal/acceptancetests/resource_variable_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_test.go
@@ -32,6 +32,10 @@ func TestAccVariableGroup_basic(t *testing.T) {
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "test description"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -59,6 +63,9 @@ func TestAccVariableGroup_update(t *testing.T) {
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -71,6 +78,10 @@ func TestAccVariableGroup_update(t *testing.T) {
 				Config: hclVariableGroupUpdate(projectName, vgName2),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName2, true),
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName2),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "3"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "update description"),
 				),
 			},
 			{
@@ -78,12 +89,15 @@ func TestAccVariableGroup_update(t *testing.T) {
 				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"secret_variable.0.value", "secret_variable.1.value", "secret_variable.2.value"},
+				ImportStateVerifyIgnore: []string{"variable.2.secret_value"},
 			},
 			{
 				Config: hclVariableGroupBasic(projectName, vgName),
 				Check: resource.ComposeTestCheckFunc(
 					checkVariableGroupExists(vgName, false),
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
 				),
 			},
 			{
@@ -91,6 +105,39 @@ func TestAccVariableGroup_update(t *testing.T) {
 				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVariableGroup_secretValue(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	vgName := testutils.GenerateResourceName()
+	tfVarGroupNode := "azuredevops_variable_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkVariableGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclVariableGroupSecretValue(projectName, vgName),
+				Check: resource.ComposeTestCheckFunc(
+					checkVariableGroupExists(vgName, true),
+					resource.TestCheckResourceAttrSet(tfVarGroupNode, "project_id"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "name", vgName),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "description", "test description"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.#", "1"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.0.is_secret", "true"),
+					resource.TestCheckResourceAttr(tfVarGroupNode, "variable.0.secret_value", "value1"),
+				),
+			},
+			{
+				ResourceName:            tfVarGroupNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfVarGroupNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"variable.0.secret_value"},
 			},
 		},
 	})
@@ -250,27 +297,37 @@ resource "azuredevops_variable_group" "test" {
   description  = "update description"
   allow_access = true
   variable {
-    name  = "key1"
-    value = "value1"
+    name         = "key1"
+    secret_value = "value1"
+    is_secret    = true
   }
+
   variable {
     name  = "key2"
     value = "value2"
   }
+
   variable {
     name = "key3"
   }
+}`, projectName, variableGroupName)
+}
 
-  secret_variable {
-    name  = "skey1"
-    value = "value1"
-  }
-  secret_variable {
-    name  = "skey2"
-    value = "value2"
-  }
-  secret_variable {
-    name = "skey3"
+func hclVariableGroupSecretValue(projectName, variableGroupName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_variable_group" "test" {
+  project_id   = azuredevops_project.test.id
+  name         = "%s"
+  description  = "test description"
+  allow_access = true
+  variable {
+    name         = "key1"
+    secret_value = "value1"
+    is_secret    = true
   }
 }`, projectName, variableGroupName)
 }

--- a/azuredevops/internal/acceptancetests/testutils/hcl.go
+++ b/azuredevops/internal/acceptancetests/testutils/hcl.go
@@ -374,27 +374,18 @@ resource "azuredevops_variable_group" "vg" {
 	description = "A sample variable group."
 	allow_access = %t
 	variable {
-		name   = "key1"
-		value  = "value1"
+		name      = "key1"
+		secret_value  = "value1"
+		is_secret = true
 	}
+
 	variable {
 		name  = "key2"
 		value = "value2"
 	}
+
 	variable {
 		name = "key3"
-	}
-
-	secret_variable {
-		name   = "skey1"
-		value  = "value1"
-	}
-	secret_variable {
-		name  = "skey2"
-		value = "value2"
-	}
-	secret_variable {
-		name = "skey3"
 	}
 }`, variableGroupName, allowAccess)
 }

--- a/azuredevops/internal/service/taskagent/data_variable_group.go
+++ b/azuredevops/internal/service/taskagent/data_variable_group.go
@@ -50,36 +50,14 @@ func DataVariableGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"content_type": {
-							Type:     schema.TypeString,
-							Computed: true,
+						"secret_value": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
-						"enabled": {
+						"is_secret": {
 							Type:     schema.TypeBool,
 							Computed: true,
-						},
-						"expires": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-				Set: getVariableHash,
-			},
-
-			"secret_variable": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"value": {
-							Type:      schema.TypeString,
-							Sensitive: true,
-							Computed:  true,
 						},
 						"content_type": {
 							Type:     schema.TypeString,

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -507,7 +507,7 @@ func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableG
 		)
 
 		if isKeyVaultVariableGroupType(variableGroup.Type) {
-			variable, err = flattenKeyVaultVariable(variableAsJSON, varName)
+			variable, isSecret, err = flattenKeyVaultVariable(variableAsJSON, varName)
 		} else {
 			variable, isSecret, err = flattenVariable(d, variableAsJSON, varName)
 		}
@@ -524,11 +524,11 @@ func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableG
 	return variables, secretVariables, nil
 }
 
-func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, error) {
+func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {
 	var variable taskagent.AzureKeyVaultVariableValue
 	err := json.Unmarshal(variableAsJSON, &variable)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
+		return nil, false, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
 	}
 
 	variableMap := map[string]interface{}{
@@ -540,7 +540,7 @@ func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]
 	if variable.Expires != nil {
 		variableMap["expires"] = variable.Expires.String()
 	}
-	return variableMap, nil
+	return variableMap, false, nil
 }
 
 func flattenVariable(d *schema.ResourceData, variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {

--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
@@ -82,9 +82,9 @@ func ResourceVariableGroup() *schema.Resource {
 				Default:  false,
 			},
 			"variable": {
-				Type:         schema.TypeSet,
-				Optional:     true,
-				AtLeastOneOf: []string{"variable", "secret_variable"},
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -97,36 +97,17 @@ func ResourceVariableGroup() *schema.Resource {
 							Default:       "",
 							ConflictsWith: []string{"key_vault"},
 						},
-						"content_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"enabled": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"expires": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"secret_variable": {
-				Type:         schema.TypeSet,
-				Optional:     true,
-				AtLeastOneOf: []string{"variable", "secret_variable"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"value": {
+						"secret_value": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							Sensitive:     true,
 							Default:       "",
+							ConflictsWith: []string{"key_vault"},
+						},
+						"is_secret": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							Default:       false,
 							ConflictsWith: []string{"key_vault"},
 						},
 						"content_type": {
@@ -375,20 +356,39 @@ func expandVariableGroupParameters(clients *client.AggregatedClient, d *schema.R
 	projectID := converter.String(d.Get("project_id").(string))
 	name := converter.String(d.Get("name").(string))
 	description := converter.String(d.Get("description").(string))
+	variables := d.Get("variable").(*schema.Set).List()
 
-	variableMap := make(map[string]interface{})
-	for _, variable := range d.Get("variable").(*schema.Set).List() {
-		asMap := variable.(map[string]interface{})
-		variableMap[asMap["name"].(string)] = taskagent.VariableValue{
-			Value:    converter.String(asMap["value"].(string)),
-			IsSecret: converter.Bool(false),
+	// needed to detect if the secret_value attribute is set in the config
+	// see https://github.com/hashicorp/terraform-plugin-sdk/issues/741
+	for it := d.GetRawConfig().AsValueMap()["variable"].ElementIterator(); it.Next(); {
+		_, ctyVariable := it.Element()
+		ctyVariableAsMap := ctyVariable.AsValueMap()
+		name := ctyVariableAsMap["name"].AsString()
+		valueSet := !ctyVariableAsMap["value"].IsNull()
+		secretValueSet := !ctyVariableAsMap["secret_value"].IsNull()
+		isSecret := !ctyVariableAsMap["is_secret"].IsNull()
+
+		if valueSet && (secretValueSet || isSecret) || secretValueSet != isSecret {
+			return nil, nil, fmt.Errorf("`%s` variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes", name)
 		}
 	}
-	for _, variable := range d.Get("secret_variable").(*schema.Set).List() {
+
+	variableMap := make(map[string]interface{})
+
+	for _, variable := range variables {
 		asMap := variable.(map[string]interface{})
-		variableMap[asMap["name"].(string)] = taskagent.VariableValue{
-			Value:    converter.String(asMap["value"].(string)),
-			IsSecret: converter.Bool(true),
+
+		isSecret := converter.Bool(asMap["is_secret"].(bool))
+		if *isSecret {
+			variableMap[asMap["name"].(string)] = taskagent.VariableValue{
+				Value:    converter.String(asMap["secret_value"].(string)),
+				IsSecret: isSecret,
+			}
+		} else {
+			variableMap[asMap["name"].(string)] = taskagent.VariableValue{
+				Value:    converter.String(asMap["value"].(string)),
+				IsSecret: isSecret,
+			}
 		}
 	}
 
@@ -433,7 +433,7 @@ func expandVariableGroupParameters(clients *client.AggregatedClient, d *schema.R
 		}
 
 		variableGroup.Type = converter.String(azureKeyVaultType)
-		kvVariables, invalidVariables, err := searchAzureKVSecrets(clients, *projectID, kvName, serviceEndpointID, variableMap, depth)
+		kvVariables, invalidVariables, err := searchAzureKVSecrets(clients, *projectID, kvName, serviceEndpointID, variables, depth)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -456,16 +456,12 @@ func flattenVariableGroup(d *schema.ResourceData, variableGroup *taskagent.Varia
 	d.Set("description", converter.ToString(variableGroup.Description, ""))
 	d.Set("project_id", projectID)
 
-	variables, secretVariables, err := flattenVariables(d, variableGroup)
+	variables, err := flattenVariables(d, variableGroup)
 	if err != nil {
 		return err
 	}
 
 	if err = d.Set("variable", variables); err != nil {
-		return err
-	}
-
-	if err = d.Set("secret_variable", secretVariables); err != nil {
 		return err
 	}
 
@@ -491,78 +487,74 @@ func isKeyVaultVariableGroupType(variableGrouptype *string) bool {
 // Note: The AzDO API does not return the value for variables marked as a secret. For this reason
 //
 //	variables marked as secret will need to be pulled from the state itself
-func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableGroup) (interface{}, interface{}, error) {
-	variables := []map[string]interface{}{}
-	secretVariables := []map[string]interface{}{}
+func flattenVariables(d *schema.ResourceData, variableGroup *taskagent.VariableGroup) (interface{}, error) {
+	variables := make([]map[string]interface{}, len(*variableGroup.Variables))
 
+	index := 0
 	for varName, varVal := range *variableGroup.Variables {
 		variableAsJSON, err := json.Marshal(varVal)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to marshal variable into JSON: %+v", err)
+			return nil, fmt.Errorf("Unable to marshal variable into JSON: %+v", err)
 		}
-
-		var (
-			variable map[string]interface{}
-			isSecret bool
-		)
 
 		if isKeyVaultVariableGroupType(variableGroup.Type) {
-			variable, isSecret, err = flattenKeyVaultVariable(variableAsJSON, varName)
+			variables[index], err = flattenKeyVaultVariable(variableAsJSON, varName)
 		} else {
-			variable, isSecret, err = flattenVariable(d, variableAsJSON, varName)
-		}
-		if err != nil {
-			return nil, nil, err
+			variables[index], err = flattenVariable(d, variableAsJSON, varName)
 		}
 
-		if isSecret {
-			secretVariables = append(secretVariables, variable)
-		} else {
-			variables = append(variables, variable)
+		if err != nil {
+			return nil, err
 		}
+
+		index++
 	}
-	return variables, secretVariables, nil
+
+	return variables, nil
 }
 
-func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {
+func flattenKeyVaultVariable(variableAsJSON []byte, varName string) (map[string]interface{}, error) {
 	var variable taskagent.AzureKeyVaultVariableValue
 	err := json.Unmarshal(variableAsJSON, &variable)
 	if err != nil {
-		return nil, false, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
+		return nil, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
 	}
 
 	variableMap := map[string]interface{}{
 		"name":         varName,
 		"value":        nil,
+		"secret_value": nil,
+		"is_secret":    false,
 		"enabled":      converter.ToBool(variable.Enabled, false),
 		"content_type": converter.ToString(variable.ContentType, ""),
 	}
 	if variable.Expires != nil {
 		variableMap["expires"] = variable.Expires.String()
 	}
-	return variableMap, false, nil
+	return variableMap, nil
 }
 
-func flattenVariable(d *schema.ResourceData, variableAsJSON []byte, varName string) (map[string]interface{}, bool, error) {
+func flattenVariable(d *schema.ResourceData, variableAsJSON []byte, varName string) (map[string]interface{}, error) {
 	var variable taskagent.AzureKeyVaultVariableValue
 	err := json.Unmarshal(variableAsJSON, &variable)
 	if err != nil {
-		return nil, false, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
+		return nil, fmt.Errorf("Unable to unmarshal variable (%+v): %+v", variable, err)
 	}
 
 	isSecret := converter.ToBool(variable.IsSecret, false)
 	val := map[string]interface{}{
-		"name":  varName,
-		"value": converter.ToString(variable.Value, ""),
+		"name":      varName,
+		"value":     converter.ToString(variable.Value, ""),
+		"is_secret": isSecret,
 	}
 
 	// read secret variables from state if exist
 	if isSecret {
-		if stateVal := tfhelper.FindMapInSetWithGivenKeyValue(d, "secret_variable", "name", varName); stateVal != nil {
+		if stateVal := tfhelper.FindMapInSetWithGivenKeyValue(d, "variable", "name", varName); stateVal != nil {
 			val = stateVal
 		}
 	}
-	return val, isSecret, nil
+	return val, nil
 }
 
 func flattenKeyVault(d *schema.ResourceData, variableGroup *taskagent.VariableGroup) (interface{}, error) {
@@ -661,14 +653,15 @@ func flattenAllowAccess(d *schema.ResourceData, definitionResource *[]build.Defi
 	d.Set("allow_access", allowAccess)
 }
 
-func searchAzureKVSecrets(clients *client.AggregatedClient, projectID, kvName, serviceEndpointID string, variableMap map[string]interface{}, depth int) (kvSecrets map[string]interface{}, invalidSecrets []string, err error) {
+func searchAzureKVSecrets(clients *client.AggregatedClient, projectID, kvName, serviceEndpointID string, variables []interface{}, depth int) (kvSecrets map[string]interface{}, invalidSecrets []string, err error) {
 	var azkvSecretsRaw *KeyVaultSecretResult
 	token, loop := "", 0
 	kvSecrets = make(map[string]interface{})
 	invalidSecrets = make([]string, 0)
 
 	secretNames := make(map[string]string)
-	for name := range variableMap {
+	for _, val := range variables {
+		name := val.(map[string]interface{})["name"].(string)
 		secretNames[name] = name
 	}
 	for {

--- a/website/docs/d/variable_group.html.markdown
+++ b/website/docs/d/variable_group.html.markdown
@@ -48,8 +48,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `variable` - One or more `variable` blocks as documented below.
 
-* `secret_variable` - One or more `secret_variable` blocks as documented below.
-
 * `key_vault` - A list of `key_vault` blocks as documented below.
 
 ---
@@ -60,13 +58,9 @@ A `variable` block supports the following:
 
 * `value` - The value of the variable.
 
----
+* `secret_value` - The secret value of the variable.
 
-A `secret_variable` block supports the following:
-
-* `name` - The key value used for the secret variable.
-
-* `value` - The value of the secret variable, which is always `null` as the API won't return it.
+* `is_secret` - A boolean flag describing if the variable value is sensitive.
 
 ---
 

--- a/website/docs/r/variable_group.html.markdown
+++ b/website/docs/r/variable_group.html.markdown
@@ -36,9 +36,10 @@ resource "azuredevops_variable_group" "example" {
     value = "val1"
   }
 
-  secret_variable {
-    name  = "skey1"
-    value = "sval1"
+  variable {
+    name         = "key2"
+    secret_value = "val2"
+    is_secret    = true
   }
 }
 ```
@@ -98,9 +99,7 @@ The following arguments are supported:
 
 * `allow_access` - (Required) Boolean that indicate if this variable group is shared by all pipelines of this project.
 
-* `variable` - (Optional) One or more `variable` blocks as documented below.
-
-* `secret_variable` - (Optional) One or more `secret_variable` blocks as documented below.
+* `variable` - (Required) One or more `variable` blocks as documented below.
 
 ---
 
@@ -112,17 +111,15 @@ The following arguments are supported:
 
 A `variable` block supports the following:
 
+!> **Warning** variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes
+
 * `name` - (Required) The key value used for the variable. Must be unique within the Variable Group.
 
 * `value` - (Optional) The value of the variable. If omitted, it will default to empty string.
 
----
+* `secret_value` - (Optional) The secret value of the variable. If omitted, it will default to empty string. Used when `is_secret` set to `true`.
 
-A `secret_variable` block supports the following:
-
-* `name` - (Required) The key value used for the secret variable. Must be unique within the Variable Group.
-
-* `value` - (Optional) The value of the secret variable. If omitted, it will default to empty string.
+* `is_secret` - (Optional) A boolean flag describing if the variable value is sensitive. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
Reverting #1434 to avoid breaking changes.

## Test

```shell
terraform-provider-azuredevops on  revert_1434 via 🐹 v1.25.3
💤 TF_ACC=1 go test -v -tags=all -run='TestAccVariableGroup_|TestAccVariableGroupDataSource_' ./azuredevops/internal/acceptancetests
=== RUN   TestAccVariableGroupDataSource_Basic
=== PAUSE TestAccVariableGroupDataSource_Basic
=== RUN   TestAccVariableGroupDataSource_KeyVault
    data_variable_group_test.go:38: Skipping test TestAccVariableGroup_DataSourceKeyVault: azure key vault not provisioned on test infrastructure
--- SKIP: TestAccVariableGroupDataSource_KeyVault (0.00s)
=== RUN   TestAccVariableGroup_basic
=== PAUSE TestAccVariableGroup_basic
=== RUN   TestAccVariableGroup_update
=== PAUSE TestAccVariableGroup_update
=== RUN   TestAccVariableGroup_secretValue
=== PAUSE TestAccVariableGroup_secretValue
=== RUN   TestAccVariableGroup_keyVault_basic
    resource_variable_group_test.go:150: Skip test as `TEST_SERVICE_PRINCIPAL_ID` or `TEST_SERVICE_PRINCIPAL_KEY` or `TEST_ARM_TENANT_ID` or `TEST_ARM_SUBSCRIPTION_ID` or `TEST_ARM_SUBSCRIPTION_NAME` or `TEST_ARM_KV_NAME` is not set
--- SKIP: TestAccVariableGroup_keyVault_basic (0.00s)
=== CONT  TestAccVariableGroupDataSource_Basic
=== CONT  TestAccVariableGroup_update
=== CONT  TestAccVariableGroup_secretValue
=== CONT  TestAccVariableGroup_basic
--- PASS: TestAccVariableGroupDataSource_Basic (50.77s)
--- PASS: TestAccVariableGroup_basic (50.85s)
--- PASS: TestAccVariableGroup_secretValue (51.15s)
--- PASS: TestAccVariableGroup_update (54.53s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        54.551s
```