### PR TITLE
New resource: `azuredevops_variable_group_variable`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_variable_group_variable_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_variable_test.go
@@ -1,0 +1,211 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	taskagentsvc "github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/taskagent"
+)
+
+func TestAccVariableGroupVariable_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	vgName := testutils.GenerateResourceName()
+	node := "azuredevops_variable_group_variable.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkVariableGroupVariableDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclVariableGroupVariableBasic(projectName, vgName, "foo"),
+				Check: resource.ComposeTestCheckFunc(
+					checkVariableGroupVariableExists(node),
+				),
+			},
+			{
+				ResourceName:      node,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: hclVariableGroupVariableBasic(projectName, vgName, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					checkVariableGroupVariableExists(node),
+				),
+			},
+			{
+				ResourceName:      node,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVariableGroupVariable_secret(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	vgName := testutils.GenerateResourceName()
+	node := "azuredevops_variable_group_variable.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkVariableGroupVariableDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclVariableGroupVariableSecret(projectName, vgName, "foo"),
+				Check: resource.ComposeTestCheckFunc(
+					checkVariableGroupVariableExists(node),
+				),
+			},
+			{
+				ResourceName:            node,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_value"},
+			},
+			{
+				Config: hclVariableGroupVariableSecret(projectName, vgName, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					checkVariableGroupVariableExists(node),
+				),
+			},
+			{
+				ResourceName:            node,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_value"},
+			},
+		},
+	})
+}
+
+func checkVariableGroupVariableDestroyed(s *terraform.State) error {
+	for _, res := range s.RootModule().Resources {
+		if res.Type != "azuredevops_variable_group_variable" {
+			continue
+		}
+
+		ok, err := checkVariableGroupVariableFromState(res)
+		if err == nil && ok {
+			return fmt.Errorf("variable still exists")
+		}
+	}
+
+	return nil
+}
+
+func checkVariableGroupVariableExists(node string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		state, ok := s.RootModule().Resources[node]
+		if !ok {
+			return fmt.Errorf("Did not find a variable group in the TF state")
+		}
+
+		ok, err := checkVariableGroupVariableFromState(state)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%q doesn't exist", node)
+		}
+		return nil
+	}
+}
+
+func checkVariableGroupVariableFromState(resource *terraform.ResourceState) (bool, error) {
+	projectId, groupId, name, err := taskagentsvc.ResourceVariableGroupVariableParseId(resource.Primary.ID)
+	if err != nil {
+		return false, err
+	}
+
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+	resp, err := clients.TaskAgentClient.GetVariableGroup(
+		clients.Ctx,
+		taskagent.GetVariableGroupArgs{
+			GroupId: &groupId,
+			Project: &projectId,
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if resp.Variables == nil {
+		return false, fmt.Errorf("unexpected null variables in group response")
+	}
+
+	vars := *resp.Variables
+	_, ok := vars[name]
+	return ok, nil
+}
+
+func hclVariableGroupVariableBasic(projectName, variableGroupName, val string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+resource "azuredevops_variable_group" "test" {
+  project_id   = azuredevops_project.test.id
+  name         = "%s"
+  description  = "test description"
+  allow_access = false
+  variable {
+    name  = "key1"
+    value = "value1"
+  }
+  variable {
+    name         = "skey1"
+    secret_value = "svalue1"
+    is_secret    = true
+  }
+  lifecycle {
+    ignore_changes = [variable]
+  }
+}
+resource "azuredevops_variable_group_variable" "test" {
+  project_id        = azuredevops_project.test.id
+  variable_group_id = azuredevops_variable_group.test.id
+  name              = "test-key"
+  value             = "%s"
+}
+`, projectName, variableGroupName, val)
+}
+
+func hclVariableGroupVariableSecret(projectName, variableGroupName, val string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+resource "azuredevops_variable_group" "test" {
+  project_id   = azuredevops_project.test.id
+  name         = "%s"
+  description  = "test description"
+  allow_access = false
+  variable {
+    name  = "key1"
+    value = "value1"
+  }
+  variable {
+    name         = "skey1"
+    secret_value = "svalue1"
+    is_secret    = true
+  }
+  lifecycle {
+    ignore_changes = [variable]
+  }
+}
+resource "azuredevops_variable_group_variable" "test" {
+  project_id        = azuredevops_project.test.id
+  variable_group_id = azuredevops_variable_group.test.id
+  name              = "test-key"
+  secret_value      = "%s"
+}
+`, projectName, variableGroupName, val)
+}

--- a/azuredevops/internal/service/taskagent/resource_variable_group_variable.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group_variable.go
@@ -92,7 +92,7 @@ func resourceVariableGroupVariableCreateUpdate(d *schema.ResourceData, m interfa
 	name := d.Get("name").(string)
 	id := fmt.Sprintf("%s/%d/%s", projectId, variableGroupId, name)
 
-	// Existance check
+	// Existence check
 	if d.IsNewResource() {
 		if _, ok := vars[name]; ok {
 			return tfhelper.ImportAsExistsError(VariableGroupVariable, id)

--- a/azuredevops/internal/service/taskagent/resource_variable_group_variable.go
+++ b/azuredevops/internal/service/taskagent/resource_variable_group_variable.go
@@ -1,0 +1,259 @@
+package taskagent
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+const VariableGroupVariable = "azuredevops_variable_group_variable"
+
+func ResourceVariableGroupVariable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVariableGroupVariableCreateUpdate,
+		Read:   resourceVariableGroupVariableRead,
+		Update: resourceVariableGroupVariableCreateUpdate,
+		Delete: resourceVariableGroupVariableDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"variable_group_id": {
+				// TODO: Ideally this shall be an int, but the existing group id is a string.
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"value": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"value", "secret_value"},
+			},
+			"secret_value": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"value", "secret_value"},
+			},
+		},
+	}
+}
+
+func resourceVariableGroupVariableCreateUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectId := d.Get("project_id").(string)
+	variableGroupId, err := strconv.Atoi(d.Get("variable_group_id").(string))
+	if err != nil {
+		return fmt.Errorf("parsing `variable_group_id` as an integer: %v", err)
+	}
+
+	resp, err := clients.TaskAgentClient.GetVariableGroup(
+		clients.Ctx,
+		taskagent.GetVariableGroupArgs{
+			GroupId: &variableGroupId,
+			Project: &projectId,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("Looking up variable group given ID (%v) and project ID (%v): %+v", variableGroupId, projectId, err)
+	}
+	if resp.Variables == nil {
+		return fmt.Errorf("unexpected null existing variables")
+	}
+	vars := *resp.Variables
+	name := d.Get("name").(string)
+	id := fmt.Sprintf("%s/%d/%s", projectId, variableGroupId, name)
+
+	// Existance check
+	if d.IsNewResource() {
+		if _, ok := vars[name]; ok {
+			return tfhelper.ImportAsExistsError(VariableGroupVariable, id)
+		}
+	}
+
+	// Upsert the variable
+	params := taskagent.VariableGroupParameters{
+		Description:                    resp.Description,
+		Name:                           resp.Name,
+		ProviderData:                   resp.ProviderData,
+		Type:                           resp.Type,
+		VariableGroupProjectReferences: resp.VariableGroupProjectReferences,
+	}
+
+	var (
+		value    string
+		isSecret bool
+	)
+	cfgMap := d.GetRawConfig().AsValueMap()
+	if val := cfgMap["value"]; !val.IsNull() {
+		value = val.AsString()
+	} else if val := cfgMap["secret_value"]; !val.IsNull() {
+		value = val.AsString()
+		isSecret = true
+	}
+	vars[name] = map[string]any{
+		"value":    value,
+		"isSecret": isSecret,
+	}
+	params.Variables = &vars
+
+	if _, err := updateVariableGroup(clients, &params, &variableGroupId); err != nil {
+		return err
+	}
+
+	d.SetId(id)
+
+	return resourceVariableGroupVariableRead(d, m)
+}
+
+func resourceVariableGroupVariableRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectId, variableGroupId, varName, err := ResourceVariableGroupVariableParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := clients.TaskAgentClient.GetVariableGroup(
+		clients.Ctx,
+		taskagent.GetVariableGroupArgs{
+			GroupId: &variableGroupId,
+			Project: &projectId,
+		},
+	)
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Looking up variable group given ID (%v) and project ID (%v): %+v", variableGroupId, projectId, err)
+	}
+
+	if resp.Variables == nil {
+		d.SetId("")
+		return nil
+	}
+
+	vars := *resp.Variables
+
+	varVal, ok := vars[varName]
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	var (
+		value    string
+		isSecret bool
+	)
+	if varMap, ok := varVal.(map[string]any); ok {
+		if v, ok := varMap["value"].(string); ok {
+			value = v
+		}
+		if v, ok := varMap["isSecret"].(bool); ok {
+			isSecret = v
+		}
+	}
+	if isSecret {
+		// Azure doesn't store the secret value, read it from state
+		value = d.Get("secret_value").(string)
+	}
+
+	d.Set("project_id", projectId)
+	d.Set("variable_group_id", strconv.Itoa(variableGroupId))
+	d.Set("name", varName)
+	if isSecret {
+		d.Set("secret_value", value)
+	} else {
+		d.Set("value", value)
+	}
+	return nil
+}
+
+func resourceVariableGroupVariableDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectId := d.Get("project_id").(string)
+	variableGroupId, err := strconv.Atoi(d.Get("variable_group_id").(string))
+	if err != nil {
+		return fmt.Errorf("parsing `variable_group_id` as an integer: %v", err)
+	}
+
+	resp, err := clients.TaskAgentClient.GetVariableGroup(
+		clients.Ctx,
+		taskagent.GetVariableGroupArgs{
+			GroupId: &variableGroupId,
+			Project: &projectId,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("Looking up variable group given ID (%v) and project ID (%v): %+v", variableGroupId, projectId, err)
+	}
+	if resp.Variables == nil {
+		return fmt.Errorf("unexpected null existing variables")
+	}
+	vars := *resp.Variables
+
+	name := d.Get("name").(string)
+	if _, ok := vars[name]; !ok {
+		// If the var doesn't exist, just return
+		return nil
+	}
+
+	// Delete the variable
+	delete(vars, name)
+	params := taskagent.VariableGroupParameters{
+		Description:                    resp.Description,
+		Name:                           resp.Name,
+		ProviderData:                   resp.ProviderData,
+		Type:                           resp.Type,
+		VariableGroupProjectReferences: resp.VariableGroupProjectReferences,
+		Variables:                      &vars,
+	}
+
+	if _, err := updateVariableGroup(clients, &params, &variableGroupId); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ResourceVariableGroupVariableParseId(id string) (string, int, string, error) {
+	segs := strings.SplitN(id, "/", 3)
+	if len(segs) != 3 {
+		return "", 0, "", fmt.Errorf("invalid resource id, expect length=3, got=%d", len(segs))
+	}
+	projectId, variableGroupIdStr, varName := segs[0], segs[1], segs[2]
+	variableGroupId, err := strconv.Atoi(variableGroupIdStr)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("converting the variable group id as integer: %v", err)
+	}
+	return projectId, variableGroupId, varName, nil
+}

--- a/azuredevops/internal/utils/tfhelper/error.go
+++ b/azuredevops/internal/utils/tfhelper/error.go
@@ -1,0 +1,8 @@
+package tfhelper
+
+import "fmt"
+
+func ImportAsExistsError(resourceName, id string) error {
+	msg := "a resource with the ID %q already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information"
+	return fmt.Errorf(msg, id, resourceName)
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -147,6 +147,7 @@ func Provider() *schema.Provider {
 			"azuredevops_user_entitlement":                            memberentitlementmanagement.ResourceUserEntitlement(),
 			"azuredevops_variable_group":                              taskagent.ResourceVariableGroup(),
 			"azuredevops_variable_group_permissions":                  permissions.ResourceVariableGroupPermissions(),
+			"azuredevops_variable_group_variable":                     taskagent.ResourceVariableGroupVariable(),
 			"azuredevops_wiki":                                        wiki.ResourceWiki(),
 			"azuredevops_wiki_page":                                   wiki.ResourceWikiPage(),
 			"azuredevops_workitem":                                    workitemtracking.ResourceWorkItem(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -116,6 +116,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_user_entitlement",
 		"azuredevops_variable_group",
 		"azuredevops_variable_group_permissions",
+		"azuredevops_variable_group_variable",
 		"azuredevops_wiki",
 		"azuredevops_wiki_page",
 		"azuredevops_workitem",

--- a/website/docs/r/variable_group_variable.html.markdown
+++ b/website/docs/r/variable_group_variable.html.markdown
@@ -1,0 +1,100 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_variable_group_variable"
+description: |-
+  Manages variable group variables within a variable group.
+---
+
+# azuredevops_variable_group_variable
+
+Manages variable group variables within a variable group.
+
+~> **Note** Variable group variables can also be managed inlined in the `variable` blocks in `azuredevops_variable_group`.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_variable_group" "example" {
+  project_id   = azuredevops_project.example.id
+  name         = "Example Variable Group"
+  description  = "Example Variable Group Description"
+  allow_access = true
+
+  variable {
+    name  = "key1"
+    value = "val1"
+  }
+
+  lifecycle {
+    ignore_changes = [variable]
+  }
+}
+
+
+resource "azuredevops_variable_group_variable" "example" {
+  project_id        = azuredevops_project.example.id
+  variable_group_id = azuredevops_variable_group.example.id
+  name              = "key2"
+  value             = "val2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project.
+
+* `variable_group_id` - (Required) The ID of the variable group.
+
+* `name` - (Required) The name of the variable. Must be unique within the Variable Group.
+
+* `value` - (Optional) The value of the variable.
+
+* `secret_value` - (Optional) The value of the secret variable.
+
+-> **NOTE** Exactly one of `value` and `secret_value` must be specified.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Variable Group returned after creation in Azure DevOps.
+
+## Relevant Links
+
+- [Azure DevOps Service REST API 7.0 - Variable Groups](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/variablegroups?view=azure-devops-rest-7.0)
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 minutes) Used when creating the Variable Group Variable.
+* `read` - (Defaults to 5 minute) Used when retrieving the Variable Group Variable.
+* `update` - (Defaults to 10 minutes) Used when updating the Variable Group Variable.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Variable Group Variable.
+
+## Import
+
+**Secret variable cannot be imported.**
+
+Azure DevOps Variable group variables can be imported using the `project ID/variable group ID/variable name`, e.g.
+
+
+```sh
+terraform import azuredevops_variable_group_variable.example 00000000-0000-0000-0000-000000000000/0/key1
+```
+
+## PAT Permissions Required
+
+- **Variable Groups**: Read, Create, & Manage


### PR DESCRIPTION
This PR adds a new resource: `azuredevops_variable_group_variable`, which allows the users to separately manage variable/secret variable in a standalone way.

Since a `azuredevops_variable_group` must have at least one variable specified when created, it means that if a user wants to manage both the `azuredevops_variable_group` and the `azuredevops_variable_group_variable` at the same time, the `azuredevops_variable_group` must be created with one or multiple `variable` blocks specified, as well as ignore them using `lifecycle`.

This supersedes #650, with a finer grained model.

## Test

```shell
terraform-provider-azuredevops on  azuredevops_variable_group_variable via 🐹 v1.25.5 took 43s
💢 TF_ACC=1 go test -v -run='TestAccVariableGroupVariable_' ./azuredevops/internal/acceptancetests
=== RUN   TestAccVariableGroupVariable_basic
=== PAUSE TestAccVariableGroupVariable_basic
=== RUN   TestAccVariableGroupVariable_secret
=== PAUSE TestAccVariableGroupVariable_secret
=== CONT  TestAccVariableGroupVariable_basic
=== CONT  TestAccVariableGroupVariable_secret
--- PASS: TestAccVariableGroupVariable_basic (39.74s)
--- PASS: TestAccVariableGroupVariable_secret (39.74s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        39.744s
```

## Issues

Fix #231, Fix #1003