### PR TITLE
test(group): fix failing create group test because of ContinuousTarge…

### DIFF
--- a/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
@@ -20,6 +20,10 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
+// retryMinTimeout is the minimum time to wait between retries for eventual consistency.
+// This can be set to 0 in unit tests to speed up execution.
+var retryMinTimeout = 1 * time.Second
+
 func ResourceGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createResourceGroup,
@@ -287,7 +291,7 @@ func createResourceGroup(ctx context.Context, d *schema.ResourceData, m any) dia
 		Pending:    []string{"waiting"},
 		Target:     []string{"ready", "error"},
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 1 * time.Second,
+		MinTimeout: retryMinTimeout,
 		// Tested with 3 which still causes the issue intermittently
 		ContinuousTargetOccurence: 4,
 		Refresh: func() (interface{}, string, error) {

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_group_test.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_group_test.go
@@ -21,6 +21,11 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	// Disable retry delays in unit tests
+	retryMinTimeout = 0
+}
+
 func getGroupResourceData(t *testing.T, input map[string]any) *schema.ResourceData {
 	r := ResourceGroup()
 	return schema.TestResourceDataRaw(t, r.Schema, input)
@@ -147,7 +152,7 @@ func TestGroup_Create_Successful(t *testing.T) {
 
 			return returnWorkItemType, nil
 		},
-	).Times(1)
+	).Times(4)
 
 	d := getGroupResourceData(t, map[string]any{
 		"process_id":                    processId.String(),


### PR DESCRIPTION
…tOccurence != expected calls to read

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

Fixes a failing test introduced by [5f66daca783b5a1a919e57b7b2113c6dc4902da5](https://github.com/microsoft/terraform-provider-azuredevops/commit/5f66daca783b5a1a919e57b7b2113c6dc4902da5)

Issue Number: N/A

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Any relevant logs, error output, etc?
N/A

## Other information
Other unrelated unit tests are still failing.