### PR TITLE
`azuredevops_servicehook_webhook_tfs` - Support `resource_version`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_servicehook_webhook_tfs_test.go
+++ b/azuredevops/internal/acceptancetests/resource_servicehook_webhook_tfs_test.go
@@ -92,6 +92,22 @@ resource "azuredevops_servicehook_webhook_tfs" "test" {
 `, projectResource, url)
 }
 
+// HclServicehookWebhookTfsResourceWithResourceVersion creates a HCL representation of a TFS webhook with a custom resource version
+func HclServicehookWebhookTfsResourceWithResourceVersion(projectName, url, resourceVersion string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_servicehook_webhook_tfs" "test" {
+  project_id       = azuredevops_project.project.id
+  url              = "%s"
+  resource_version = "%s"
+
+  git_push {}
+}
+`, projectResource, url, resourceVersion)
+}
+
 func TestAccServicehookWebhookTfs_basic(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	url := "https://example.com/webhook"
@@ -259,6 +275,35 @@ func TestAccServicehookWebhookTfs_WithResourceDetails(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "resource_details_to_send", "minimal"),
 					resource.TestCheckResourceAttr(tfCheckNode, "messages_to_send", "text"),
 					resource.TestCheckResourceAttr(tfCheckNode, "detailed_messages_to_send", "html"),
+				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  checkImportProject(),
+			},
+		},
+	})
+}
+
+func TestAccServicehookWebhookTfs_WithResourceVersion(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	url := "https://example.com/webhook"
+	resourceVersion := "7.1"
+
+	resourceType := "azuredevops_servicehook_webhook_tfs"
+	tfCheckNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: CheckServicehookWebhookTfsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: HclServicehookWebhookTfsResourceWithResourceVersion(projectName, url, resourceVersion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfCheckNode, "url", url),
+					resource.TestCheckResourceAttr(tfCheckNode, "resource_version", resourceVersion),
 				),
 			},
 			{

--- a/azuredevops/internal/service/servicehook/resource_servicehook_webhook_tfs.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_webhook_tfs.go
@@ -77,6 +77,12 @@ func ResourceServicehookWebhookTfs() *schema.Resource {
 			ValidateFunc: validation.StringInSlice([]string{"all", "text", "html", "markdown", "none"}, false),
 			Description:  "Detailed messages to send - all, text, html, markdown or none",
 		},
+		"resource_version": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "latest",
+			Description: "The resource version for the webhook subscription",
+		},
 	}
 
 	maps.Copy(resourceSchema, genTfsPublisherSchema())
@@ -201,7 +207,7 @@ func expandServicehookWebhookTfs(d *schema.ResourceData) *servicehooks.Subscript
 		EventType:        &eventType,
 		PublisherId:      converter.String("tfs"),
 		PublisherInputs:  &publisherInputs,
-		ResourceVersion:  converter.String("7.1"),
+		ResourceVersion:  converter.String(d.Get("resource_version").(string)),
 	}
 }
 
@@ -210,6 +216,7 @@ func flattenServicehookWebhookTfs(d *schema.ResourceData, subscription *serviceh
 	d.Set(eventType, eventConfig)
 	d.Set("project_id", (*subscription.PublisherInputs)["projectId"])
 	d.Set("url", (*subscription.ConsumerInputs)["url"])
+	d.Set("resource_version", *subscription.ResourceVersion)
 
 	// Parse acceptUntrustedCerts
 	if acceptUntrustedCerts, exists := (*subscription.ConsumerInputs)["acceptUntrustedCerts"]; exists {

--- a/azuredevops/internal/service/servicehook/resource_servicehook_webhook_tfs_test.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_webhook_tfs_test.go
@@ -48,7 +48,7 @@ var testResourceSubscriptionWebhookTfs = []servicehooks.Subscription{
 			"branch":     "main",
 			"pushedBy":   "myuser",
 		},
-		ResourceVersion: converter.String("7.1"),
+		ResourceVersion: converter.String("latest"),
 	},
 	{
 		Id:               &subscriptionWebhookID,
@@ -72,7 +72,7 @@ var testResourceSubscriptionWebhookTfs = []servicehooks.Subscription{
 			"pullrequestCreatedBy":         "myuser",
 			"pullrequestReviewersContains": "reviewergroup",
 		},
-		ResourceVersion: converter.String("7.1"),
+		ResourceVersion: converter.String("latest"),
 	},
 	{
 		Id:               &subscriptionWebhookID,
@@ -93,7 +93,7 @@ var testResourceSubscriptionWebhookTfs = []servicehooks.Subscription{
 			"areaPath":     "MyProject\\MyArea",
 			"tag":          "urgent",
 		},
-		ResourceVersion: converter.String("7.1"),
+		ResourceVersion: converter.String("latest"),
 	},
 	{
 		Id:               &subscriptionWebhookID,
@@ -113,7 +113,7 @@ var testResourceSubscriptionWebhookTfs = []servicehooks.Subscription{
 			"definitionName": "MyBuildDefinition",
 			"buildStatus":    "Succeeded",
 		},
-		ResourceVersion: converter.String("7.1"),
+		ResourceVersion: converter.String("latest"),
 	},
 }
 

--- a/website/docs/r/servicehook_webhook_tfs.markdown
+++ b/website/docs/r/servicehook_webhook_tfs.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
 
 * `detailed_messages_to_send` - (Optional) Detailed messages to send - `all`, `text`, `html`, `markdown`, or `none`. Defaults to `all`.
 
+* `resource_version` - (Optional) The resource version for the webhook subscription. Defaults to `latest`.
+
 ---
 
 ### Event Types


### PR DESCRIPTION
# Description

This PR enables setting of the `ResourceVersion` on a `servicehook_webhook_tfs` resource type, which is currently hard-coded.

## 1. Updated resource `azuredevops_servicehook_webhook_tfs` to allow customisation of `resource_version`

**Purpose:** To allow service hook resource version setting to be set by used, rather than defaulting to hard-coded version

## 2. Documentation update

Resource documentation has been updated to reflect this new input and it's new default value

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Current behaviour: Service hook resources are created with hard-coded version
New behaviour: Users can set the resource version as an input

Issue Number: No current Issue, just a fix

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

N/A


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->