### PR TITLE
docs: fix frontmatter formatting issue for azuredevops_team_administrators and azuredevops_team

### DIFF
--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -1,4 +1,4 @@
-*---
+---
 layout: "azuredevops"
 page_title: "AzureDevops: azuredevops_team"
 description: |-
@@ -101,4 +101,4 @@ terraform import azuredevops_team.example 00000000-0000-0000-0000-000000000000/0
 
 ## PAT Permissions Required
 
-- **vso.project_manage**:	Grants the ability to create, read, update, and delete projects and teams. 
+- **vso.project_manage**:	Grants the ability to create, read, update, and delete projects and teams.

--- a/website/docs/r/team_administrators.html.markdown
+++ b/website/docs/r/team_administrators.html.markdown
@@ -1,4 +1,4 @@
-*---
+---
 layout: "azuredevops"
 page_title: "AzureDevops: azuredevops_team_administrators"
 description: |-
@@ -88,4 +88,4 @@ The resource does not support import.
 
 ## PAT Permissions Required
 
-- **vso.project_write**:	Grants the ability to read and update projects and teams. 
+- **vso.project_write**:	Grants the ability to read and update projects and teams.


### PR DESCRIPTION
## All Submissions:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes. **Not applicable, only documentation is updated.**
* [ ] All new and existing tests passed. ** Not applicable, only documentation is updated.**
* [ ] My code follows the code style of this project.  Not applicable, only documentation is updated.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Fix an issue in the front matter formatting of the resource documentation for [azuredevops_team](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/team) and [azuredevops_team_administrators](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/team_administrators):

Remove "*" so that the frontmatter is properly formated and as consequence the resource names displayed as `h1` on the respective web pages.


## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [X] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->