### PR TITLE
`azuredevops_group_membership` - Fix a create time `overwrite` mode bug

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_membership_test.go
@@ -2,16 +2,10 @@ package acceptancetests
 
 import (
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/graph"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 )
 
 func TestAccGroupMembership_overwrite(t *testing.T) {
@@ -41,57 +35,6 @@ func TestAccGroupMembership_overwrite(t *testing.T) {
 				),
 			},
 		},
-	})
-}
-
-// Verifies that the group membership in AzDO matches the group membership specified by the state
-func checkGroupMembershipMatchesState() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		memberDescriptor := s.RootModule().Outputs["user_descriptor"].Value.(string)
-		groupDescriptor := s.RootModule().Outputs["group_descriptor"].Value.(string)
-		_, expectingMembership := s.RootModule().Resources["azuredevops_group_membership.test"]
-
-		// The sleep here is to take into account some propagation delay that can happen with Group Membership APIs.
-		// If we want to go inspect the behavior of the service after a Terraform Apply, we'll need to wait a little bit
-		// before making the API call.
-		//
-		// Note: some thought was put behind keeping the time.sleep here vs in the provider implementation. After consideration,
-		// I decided to keep it here. Moving to the provider would (1) provide no functional benefit to the end user, (2) increase
-		// complexity and (3) be inconsistent with the UI and CLI behavior for the same operation.
-		time.Sleep(5 * time.Second)
-		memberships, err := getMembersOfGroup(groupDescriptor)
-		if err != nil {
-			return err
-		}
-
-		if !expectingMembership && len(*memberships) == 0 {
-			return nil
-		}
-
-		if !expectingMembership && len(*memberships) > 0 {
-			return fmt.Errorf("unexpectedly found group members: %+v", memberships)
-		}
-
-		if expectingMembership && len(*memberships) == 0 {
-			return fmt.Errorf("unexpectedly did not find memberships")
-		}
-
-		actualMemberDescriptor := *(*memberships)[0].MemberDescriptor
-		if !strings.EqualFold(strings.ToLower(actualMemberDescriptor), strings.ToLower(memberDescriptor)) {
-			return fmt.Errorf("expected member with descriptor %s but member had descriptor %s", memberDescriptor, actualMemberDescriptor)
-		}
-
-		return nil
-	}
-}
-
-// call AzDO API to query for group members
-func getMembersOfGroup(groupDescriptor string) (*[]graph.GraphMembership, error) {
-	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
-	return clients.GraphClient.ListMemberships(clients.Ctx, graph.ListMembershipsArgs{
-		SubjectDescriptor: &groupDescriptor,
-		Direction:         &graph.GraphTraversalDirectionValues.Down,
-		Depth:             converter.Int(1),
 	})
 }
 

--- a/azuredevops/internal/acceptancetests/resource_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_membership_test.go
@@ -107,9 +107,9 @@ resource "azuredevops_group" "test" {
 }
 
 resource "azuredevops_group_membership" "test" {
-  group      = azuredevops_group.test.id
-  mode       = "overwrite"
-  members    = []
+  group   = azuredevops_group.test.id
+  mode    = "overwrite"
+  members = []
 }
 `, name)
 }
@@ -131,9 +131,9 @@ resource "azuredevops_group" "member" {
 }
 
 resource "azuredevops_group_membership" "test" {
-  group      = azuredevops_group.test.id
-  mode       = "overwrite"
-  members    = [azuredevops_group.member.id]
+  group   = azuredevops_group.test.id
+  mode    = "overwrite"
+  members = [azuredevops_group.member.id]
 }
 `, name)
 }

--- a/azuredevops/internal/service/graph/resource_group_membership.go
+++ b/azuredevops/internal/service/graph/resource_group_membership.go
@@ -70,10 +70,7 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 			return fmt.Errorf("Reading group memberships during read: %+v", err)
 		}
 		actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-		if err != nil {
-			return fmt.Errorf("Converting membership list to set: %+v", err)
-		}
-		membersToRemove = membersToAdd.Difference(actualMembershipsSet)
+		membersToRemove = actualMembershipsSet.Difference(membersToAdd)
 	} else {
 		membersToRemove = getGroupMembershipSet(nil)
 	}
@@ -96,9 +93,6 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if err != nil {
-				return nil, "", fmt.Errorf("Converting membership list to set: %+v", err)
-			}
 			if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() <= 0) &&
 				(membersToRemove == nil || actualMembershipsSet.Intersection(membersToRemove).Len() <= 0) {
 				state = "Synched"


### PR DESCRIPTION
This PR fixes an obvious bug for the `azuredevops_group_membership` that it incorrectly evaluate the memberships to delete during create time, in `overwrite` mode.

Meanwhile, I've added a new acctest to verify:

```shell
💢 TF_ACC=1 go test -v -run='TestAccGroupMembership_overwrite' ./azuredevops/internal/acceptancetests
=== RUN   TestAccGroupMembership_overwrite
=== PAUSE TestAccGroupMembership_overwrite
=== CONT  TestAccGroupMembership_overwrite
--- PASS: TestAccGroupMembership_overwrite (161.16s)
PASS
ok  	github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests	161.168s
```

Also, an existing but non-working test case is removed, which is for testing the `add` mode, which I don't recognize it as a proper terraform managed resource use case. The `mode` is introduced in https://github.com/microsoft/terraform-provider-azuredevops/commit/c71a331817e4cd58ce7a1fdf2c43892c0dd98105#diff-c5f65540614b83bb91422f82d2573de281df9ec8af8dd4f1227d37c64ba39fe9, without further context about the motivation.

Fix #291.