### PR TITLE
New resource: `azuredevops_deployment_group`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
@@ -163,15 +163,22 @@ func hclDeploymentGroupWithPoolId(projectName string, deploymentGroupName string
 	return fmt.Sprintf(`
 %s
 
+resource "azuredevops_project" "project2" {
+  name               = "%s-2"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
 resource "azuredevops_deployment_group" "pool_source" {
   project_id = azuredevops_project.project.id
   name       = "%s-source"
 }
 
 resource "azuredevops_deployment_group" "test" {
-  project_id = azuredevops_project.project.id
+  project_id = azuredevops_project.project2.id
   name       = "%s"
   pool_id    = azuredevops_deployment_group.pool_source.pool_id
 }
-`, projectResource, deploymentGroupName, deploymentGroupName)
+`, projectResource, projectName, deploymentGroupName, deploymentGroupName)
 }

--- a/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
@@ -1,0 +1,143 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+// TestAccDeploymentGroup_basic verifies that a deployment group can be created and updated
+func TestAccDeploymentGroup_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	deploymentGroupNameFirst := testutils.GenerateResourceName()
+	deploymentGroupNameSecond := testutils.GenerateResourceName()
+	tfNode := "azuredevops_deployment_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkDeploymentGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclDeploymentGroupResource(projectName, deploymentGroupNameFirst, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "name", deploymentGroupNameFirst),
+					resource.TestCheckResourceAttr(tfNode, "description", ""),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					checkDeploymentGroupExists(deploymentGroupNameFirst),
+				),
+			},
+			{
+				Config: hclDeploymentGroupResource(projectName, deploymentGroupNameSecond, "Updated description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "name", deploymentGroupNameSecond),
+					resource.TestCheckResourceAttr(tfNode, "description", "Updated description"),
+					checkDeploymentGroupExists(deploymentGroupNameSecond),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccDeploymentGroup_withDescription verifies that a deployment group with description can be created
+func TestAccDeploymentGroup_withDescription(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	deploymentGroupName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_deployment_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkDeploymentGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclDeploymentGroupResource(projectName, deploymentGroupName, "Test description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "name", deploymentGroupName),
+					resource.TestCheckResourceAttr(tfNode, "description", "Test description"),
+					checkDeploymentGroupExists(deploymentGroupName),
+				),
+			},
+		},
+	})
+}
+
+func checkDeploymentGroupExists(expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.RootModule().Resources["azuredevops_deployment_group.test"]
+		if !ok {
+			return fmt.Errorf("Did not find a deployment group in the TF state")
+		}
+
+		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+		deploymentGroupId, err := strconv.Atoi(res.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Parse ID error, ID: %v. Error= %v", res.Primary.ID, err)
+		}
+		projectID := res.Primary.Attributes["project_id"]
+
+		deploymentGroup, err := clients.TaskAgentClient.GetDeploymentGroup(clients.Ctx, taskagent.GetDeploymentGroupArgs{
+			Project:           &projectID,
+			DeploymentGroupId: &deploymentGroupId,
+		})
+		if err != nil {
+			return fmt.Errorf("Deployment group with ID=%d cannot be found. Error=%v", deploymentGroupId, err)
+		}
+
+		if *deploymentGroup.Name != expectedName {
+			return fmt.Errorf("Deployment group with ID=%d has Name=%s, but expected Name=%s", deploymentGroupId, *deploymentGroup.Name, expectedName)
+		}
+
+		return nil
+	}
+}
+
+func checkDeploymentGroupDestroyed(s *terraform.State) error {
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+
+	for _, res := range s.RootModule().Resources {
+		if res.Type != "azuredevops_deployment_group" {
+			continue
+		}
+
+		deploymentGroupId, err := strconv.Atoi(res.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Deployment group ID=%s cannot be parsed. Error=%v", res.Primary.ID, err)
+		}
+		projectID := res.Primary.Attributes["project_id"]
+
+		if _, err := clients.TaskAgentClient.GetDeploymentGroup(clients.Ctx, taskagent.GetDeploymentGroupArgs{
+			Project:           &projectID,
+			DeploymentGroupId: &deploymentGroupId,
+		}); err == nil {
+			return fmt.Errorf("Deployment group ID %d should not exist", deploymentGroupId)
+		}
+	}
+
+	return nil
+}
+
+func hclDeploymentGroupResource(projectName string, deploymentGroupName string, description string) string {
+	projectResource := testutils.HclProjectResource(projectName)
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_deployment_group" "test" {
+  project_id  = azuredevops_project.project.id
+  name        = "%s"
+  description = "%s"
+}
+`, projectResource, deploymentGroupName, description)
+}

--- a/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
+++ b/azuredevops/internal/acceptancetests/resource_deployment_group_test.go
@@ -108,36 +108,6 @@ func TestAccDeploymentGroup_withPoolId(t *testing.T) {
 	})
 }
 
-func checkDeploymentGroupExists(expectedName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		res, ok := s.RootModule().Resources["azuredevops_deployment_group.test"]
-		if !ok {
-			return fmt.Errorf("Did not find a deployment group in the TF state")
-		}
-
-		clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
-		deploymentGroupId, err := strconv.Atoi(res.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("Parse ID error, ID: %v. Error= %v", res.Primary.ID, err)
-		}
-		projectID := res.Primary.Attributes["project_id"]
-
-		deploymentGroup, err := clients.TaskAgentClient.GetDeploymentGroup(clients.Ctx, taskagent.GetDeploymentGroupArgs{
-			Project:           &projectID,
-			DeploymentGroupId: &deploymentGroupId,
-		})
-		if err != nil {
-			return fmt.Errorf("Deployment group with ID=%d cannot be found. Error=%v", deploymentGroupId, err)
-		}
-
-		if *deploymentGroup.Name != expectedName {
-			return fmt.Errorf("Deployment group with ID=%d has Name=%s, but expected Name=%s", deploymentGroupId, *deploymentGroup.Name, expectedName)
-		}
-
-		return nil
-	}
-}
-
 func checkDeploymentGroupDestroyed(s *terraform.State) error {
 	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
 

--- a/azuredevops/internal/service/taskagent/resource_deployment_group.go
+++ b/azuredevops/internal/service/taskagent/resource_deployment_group.go
@@ -1,0 +1,187 @@
+package taskagent
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+// ResourceDeploymentGroup schema and implementation for deployment group resource
+func ResourceDeploymentGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDeploymentGroupCreate,
+		Read:   resourceDeploymentGroupRead,
+		Update: resourceDeploymentGroupUpdate,
+		Delete: resourceDeploymentGroupDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Importer: tfhelper.ImportProjectQualifiedResourceInteger(),
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+				Description:  "The ID of the project.",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Description:  "The name of the deployment group.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The description of the deployment group.",
+			},
+			"pool_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the deployment pool in which deployment agents are registered. If not specified, a new pool will be created.",
+			},
+			"machine_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of deployment targets in the deployment group.",
+			},
+		},
+	}
+}
+
+func resourceDeploymentGroupCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	createParams := &taskagent.DeploymentGroupCreateParameter{
+		Name:        &name,
+		Description: &description,
+	}
+
+	// If pool_id is specified, use it
+	if v, ok := d.GetOk("pool_id"); ok {
+		poolId := v.(int)
+		createParams.PoolId = &poolId
+	}
+
+	deploymentGroup, err := clients.TaskAgentClient.AddDeploymentGroup(clients.Ctx, taskagent.AddDeploymentGroupArgs{
+		Project:         &projectID,
+		DeploymentGroup: createParams,
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating deployment group: %+v", err)
+	}
+
+	d.SetId(strconv.Itoa(*deploymentGroup.Id))
+
+	return resourceDeploymentGroupRead(d, m)
+}
+
+func resourceDeploymentGroupRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	deploymentGroupId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing deployment group ID: %+v", err)
+	}
+
+	deploymentGroup, err := clients.TaskAgentClient.GetDeploymentGroup(clients.Ctx, taskagent.GetDeploymentGroupArgs{
+		Project:           &projectID,
+		DeploymentGroupId: &deploymentGroupId,
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading deployment group: %+v", err)
+	}
+
+	if deploymentGroup.Id == nil {
+		d.SetId("")
+		return nil
+	}
+
+	flattenDeploymentGroup(d, deploymentGroup, &projectID)
+	return nil
+}
+
+func resourceDeploymentGroupUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	deploymentGroupId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing deployment group ID: %+v", err)
+	}
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	updateParams := &taskagent.DeploymentGroupUpdateParameter{
+		Name:        &name,
+		Description: &description,
+	}
+
+	_, err = clients.TaskAgentClient.UpdateDeploymentGroup(clients.Ctx, taskagent.UpdateDeploymentGroupArgs{
+		Project:           &projectID,
+		DeploymentGroupId: &deploymentGroupId,
+		DeploymentGroup:   updateParams,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating deployment group: %+v", err)
+	}
+
+	return resourceDeploymentGroupRead(d, m)
+}
+
+func resourceDeploymentGroupDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	deploymentGroupId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing deployment group ID: %+v", err)
+	}
+
+	err = clients.TaskAgentClient.DeleteDeploymentGroup(clients.Ctx, taskagent.DeleteDeploymentGroupArgs{
+		Project:           &projectID,
+		DeploymentGroupId: &deploymentGroupId,
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting deployment group: %+v", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func flattenDeploymentGroup(d *schema.ResourceData, deploymentGroup *taskagent.DeploymentGroup, projectID *string) {
+	d.SetId(strconv.Itoa(*deploymentGroup.Id))
+	d.Set("project_id", projectID)
+	d.Set("name", converter.ToString(deploymentGroup.Name, ""))
+	d.Set("description", converter.ToString(deploymentGroup.Description, ""))
+	d.Set("machine_count", converter.ToInt(deploymentGroup.MachineCount, 0))
+
+	if deploymentGroup.Pool != nil && deploymentGroup.Pool.Id != nil {
+		d.Set("pool_id", *deploymentGroup.Pool.Id)
+	}
+}

--- a/azuredevops/internal/service/taskagent/resource_deployment_group.go
+++ b/azuredevops/internal/service/taskagent/resource_deployment_group.go
@@ -178,6 +178,5 @@ func resourceDeploymentGroupDelete(d *schema.ResourceData, m interface{}) error 
 		return fmt.Errorf("Error deleting deployment group: %+v", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -63,6 +63,7 @@ func Provider() *schema.Provider {
 			"azuredevops_check_required_template":                     approvalsandchecks.ResourceCheckRequiredTemplate(),
 			"azuredevops_check_rest_api":                              approvalsandchecks.ResourceCheckRestAPI(),
 			"azuredevops_dashboard":                                   dashboard.ResourceDashboard(),
+			"azuredevops_deployment_group":                            taskagent.ResourceDeploymentGroup(),
 			"azuredevops_elastic_pool":                                taskagent.ResourceAgentPoolVMSS(),
 			"azuredevops_environment":                                 taskagent.ResourceEnvironment(),
 			"azuredevops_environment_resource_kubernetes":             taskagent.ResourceEnvironmentKubernetes(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -31,6 +31,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_check_required_template",
 		"azuredevops_check_rest_api",
 		"azuredevops_dashboard",
+		"azuredevops_deployment_group",
 		"azuredevops_elastic_pool",
 		"azuredevops_environment",
 		"azuredevops_environment_resource_kubernetes",

--- a/website/docs/r/deployment_group.html.markdown
+++ b/website/docs/r/deployment_group.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_deployment_group"
+description: |-
+  Manages a Deployment Group.
+---
+
+# azuredevops_deployment_group
+
+Manages a Deployment Group used by classic release pipelines.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_deployment_group" "example" {
+  project_id  = azuredevops_project.example.id
+  name        = "Example Deployment Group"
+  description = "Managed by Terraform"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Deployment Group.
+
+* `project_id` - (Required) The ID of the project. Changing this forces a new Deployment Group to be created.
+
+---
+
+* `description` - (Optional) A description for the Deployment Group. Defaults to `""`.
+
+* `pool_id` - (Optional) The ID of the deployment pool in which deployment agents are registered. If not specified, a new pool will be created. Changing this forces a new Deployment Group to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Deployment Group.
+
+* `machine_count` - The number of deployment targets in the Deployment Group.
+
+## Relevant Links
+
+* [Azure DevOps Service REST API 7.0 - Deployment Groups](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/deployment-groups?view=azure-devops-rest-7.0)
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 minutes) Used when creating the Deployment Group.
+* `read` - (Defaults to 5 minute) Used when retrieving the Deployment Group.
+* `update` - (Defaults to 10 minutes) Used when updating the Deployment Group.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Deployment Group.
+
+## Import
+
+Azure DevOps Deployment Groups can be imported using the project ID and deployment group ID, e.g.:
+
+```sh
+terraform import azuredevops_deployment_group.example 00000000-0000-0000-0000-000000000000/0
+```


### PR DESCRIPTION
## Summary

Adds a new `azuredevops_deployment_group` resource for managing deployment groups used by classic release pipelines.

Supports create, read, update, delete, and import.

## Related PRs

Area/iteration and secure file resources were originally part of this PR but removed to avoid overlap with existing open PRs:
- #1452 — area and iteration resources
- #1380 — secure file resource

## Test plan
- [ ] `TestAccDeploymentGroup_CreateAndUpdate`