### PR TITLE
Add support for import blocks in azuredevops_pipeline_authorization resource

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
+++ b/azuredevops/internal/acceptancetests/resource_pipeline_authorization_test.go
@@ -253,6 +253,23 @@ func TestAccPipelineAuthorization_pipeline_cross_project_repository(t *testing.T
 					resource.TestCheckResourceAttrSet(node, "resource_id"),
 				),
 			},
+			{
+				ResourceName:      node,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[node]
+					if !ok {
+						return "", fmt.Errorf("resource not found in state: %s", node)
+					}
+
+					if rs.Primary == nil || rs.Primary.ID == "" {
+						return "", fmt.Errorf("no primary instance or ID found for resource: %s", node)
+					}
+
+					return rs.Primary.ID, nil
+				},
+			},
 		},
 	})
 }

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -1,7 +1,9 @@
 package build
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,6 +56,58 @@ func ResourcePipelineAuthorization() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				parts := strings.Split(d.Id(), "/")
+				if len(parts) != 3 && len(parts) != 4 {
+					return nil, fmt.Errorf(
+						"unexpected import ID format %q, expected project_id/type/resource_id[/pipeline_id]",
+						d.Id(),
+					)
+				}
+
+				projectID := parts[0]
+				typ := strings.ToLower(parts[1])
+				resourceID := parts[2]
+
+				if projectID == "" || typ == "" || resourceID == "" {
+					return nil, fmt.Errorf("import ID contains empty segment: %q", d.Id())
+				}
+
+				if err := d.Set("project_id", projectID); err != nil {
+					return nil, err
+				}
+				if err := d.Set("type", typ); err != nil {
+					return nil, err
+				}
+				if err := d.Set("resource_id", resourceID); err != nil {
+					return nil, err
+				}
+
+				if len(parts) == 4 {
+					pipelineIDStr := parts[3]
+					if pipelineIDStr == "" {
+						return nil, fmt.Errorf("pipeline_id segment is empty in import ID: %q", d.Id())
+					}
+
+					pipelineID, err := strconv.Atoi(pipelineIDStr)
+					if err != nil || pipelineID < 1 {
+						return nil, fmt.Errorf("pipeline_id must be a positive integer, got %q in %q", pipelineIDStr, d.Id())
+					}
+
+					if err := d.Set("pipeline_id", pipelineID); err != nil {
+						return nil, err
+					}
+
+					d.SetId(fmt.Sprintf("%s/%s/%s/%d", projectID, typ, resourceID, pipelineID))
+				} else {
+					d.SetId(fmt.Sprintf("%s/%s/%s", projectID, typ, resourceID))
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 	}
 }
 
@@ -93,7 +147,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 		}
 	}
 
-	response, err := clients.PipelinePermissionsClient.UpdatePipelinePermisionsForResource(
+	_, err := clients.PipelinePermissionsClient.UpdatePipelinePermisionsForResource(
 		clients.Ctx,
 		pipePermissionParams,
 	)
@@ -116,9 +170,18 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 		return fmt.Errorf("waiting for pipeline authorization ready. %v ", err)
 	}
 
-	d.SetId(*response.Resource.Id)
+	idProject := d.Get("project_id").(string)
+	idType := d.Get("type").(string)
+	idRes := d.Get("resource_id").(string)
+
+	if v, ok := d.GetOk("pipeline_id"); ok {
+		d.SetId(fmt.Sprintf("%s/%s/%s/%d", idProject, idType, idRes, v.(int)))
+	} else {
+		d.SetId(fmt.Sprintf("%s/%s/%s", idProject, idType, idRes))
+	}
 
 	return resourcePipelineAuthorizationRead(d, m)
+
 }
 
 func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) error {
@@ -147,29 +210,56 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 		return fmt.Errorf("%+v", err)
 	}
 
-	if resp == nil || (resp.AllPipelines == nil && len(*resp.Pipelines) == 0) {
+	if resp == nil {
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("type", resp.Resource.Type)
-	d.Set("resource_id", resp.Resource.Id)
-	if strings.EqualFold(*resp.Resource.Type, "repository") {
-		resIds := strings.Split(*resp.Resource.Id, ".")
-		d.Set("resource_id", resIds[1])
+	noPipelines := resp.Pipelines == nil || len(*resp.Pipelines) == 0
+	if resp.AllPipelines == nil && noPipelines {
+		d.SetId("")
+		return nil
 	}
 
-	if resp.Pipelines != nil && len(*resp.Pipelines) > 0 {
-		exist := false
-		for _, pipe := range *resp.Pipelines {
-			if *pipe.Id == d.Get("pipeline_id").(int) {
-				exist = true
+	d.Set("type", *resp.Resource.Type)
+	d.Set("resource_id", *resp.Resource.Id)
+
+	if strings.EqualFold(*resp.Resource.Type, "repository") {
+
+		resIds := strings.Split(*resp.Resource.Id, ".")
+		if len(resIds) == 2 {
+			d.Set("resource_id", resIds[1])
+		}
+
+	}
+
+	if v, ok := d.GetOk("pipeline_id"); ok {
+		want := v.(int)
+		found := false
+		if resp.Pipelines != nil {
+			for _, pipe := range *resp.Pipelines {
+				if pipe.Id != nil && *pipe.Id == want {
+					found = true
+					break
+				}
 			}
 		}
-		if !exist {
-			d.Set("pipeline_id", nil)
+
+		if !found {
+			d.SetId("")
+			return nil
 		}
+
+		d.SetId(fmt.Sprintf("%s/%s/%s/%d", projectId, resType, d.Get("resource_id").(string), want))
+		return nil
 	}
+
+	if resp.AllPipelines == nil || resp.AllPipelines.Authorized == nil || !*resp.AllPipelines.Authorized {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", projectId, resType, d.Get("resource_id").(string)))
 
 	return nil
 }

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -181,7 +181,6 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	}
 
 	return resourcePipelineAuthorizationRead(d, m)
-
 }
 
 func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) error {
@@ -225,12 +224,10 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 	d.Set("resource_id", *resp.Resource.Id)
 
 	if strings.EqualFold(*resp.Resource.Type, "repository") {
-
 		resIds := strings.Split(*resp.Resource.Id, ".")
 		if len(resIds) == 2 {
 			d.Set("resource_id", resIds[1])
 		}
-
 	}
 
 	if v, ok := d.GetOk("pipeline_id"); ok {

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -159,7 +159,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
+	if strings.EqualFold(resType, "repository") {
 		resId = projectId + "." + resId
 	}
 
@@ -211,7 +211,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 		id := pipelineAuthorizationId{
 			projectId:  projectId,
 			typ:        resType,
-			resourceId: resId,
+			resourceId: d.Get("resource_id").(string),
 			pipelineId: nil,
 		}
 		if v := d.Get("pipeline_project_id").(string); v != "" {
@@ -237,7 +237,7 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
+	if strings.EqualFold(resType, "repository") {
 		resId = projectId + "." + resId
 	}
 
@@ -302,7 +302,7 @@ func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
+	if strings.EqualFold(resType, "repository") {
 		resId = projectId + "." + resId
 	}
 
@@ -347,7 +347,7 @@ func checkPipelineAuthorization(clients *client.AggregatedClient, d *schema.Reso
 			pipelineProjectId = d.Get("pipeline_project_id").(string)
 		}
 
-		if strings.EqualFold(resourceType, "repository") && !strings.Contains(resourceId, ".") {
+		if strings.EqualFold(resourceType, "repository") {
 			resourceId = projectId + "." + resourceId
 		}
 

--- a/azuredevops/internal/service/build/resource_pipeline_authorization.go
+++ b/azuredevops/internal/service/build/resource_pipeline_authorization.go
@@ -159,7 +159,7 @@ func resourcePipelineAuthorizationCreateUpdate(d *schema.ResourceData, m interfa
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") {
+	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
 		resId = projectId + "." + resId
 	}
 
@@ -237,7 +237,7 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") {
+	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
 		resId = projectId + "." + resId
 	}
 
@@ -286,8 +286,6 @@ func resourcePipelineAuthorizationRead(d *schema.ResourceData, m interface{}) er
 		if !exist {
 			d.Set("pipeline_id", nil)
 		}
-
-		return nil
 	}
 
 	return nil
@@ -304,7 +302,7 @@ func resourcePipelineAuthorizationDelete(d *schema.ResourceData, m interface{}) 
 	resType := d.Get("type").(string)
 	resId := d.Get("resource_id").(string)
 
-	if strings.EqualFold(resType, "repository") {
+	if strings.EqualFold(resType, "repository") && !strings.Contains(resId, ".") {
 		resId = projectId + "." + resId
 	}
 
@@ -349,7 +347,7 @@ func checkPipelineAuthorization(clients *client.AggregatedClient, d *schema.Reso
 			pipelineProjectId = d.Get("pipeline_project_id").(string)
 		}
 
-		if strings.EqualFold(resourceType, "repository") {
+		if strings.EqualFold(resourceType, "repository") && !strings.Contains(resourceId, ".") {
 			resourceId = projectId + "." + resourceId
 		}
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Implement import for the azuredevops_pipeline_authorization resource. Create/Update and Read function now has a standardized ID format.

Issue Number: #1418 

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->