### PR TITLE
Document: Added description for "azuredevops_extension" to extension_id and publisher_id to remove confusion regarding using GUIDs

### DIFF
--- a/azuredevops/internal/service/extension/resource_extension.go
+++ b/azuredevops/internal/service/extension/resource_extension.go
@@ -45,7 +45,7 @@ func ResourceExtension() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
-				Description:  "The Azure DevOps Marketplace extension identifier, for example `vss-code-search`. This value is not a GUID. Azure DevOps extension installation only supports Marketplace identifiers.",
+				Description:  "The Azure DevOps Marketplace extension identifier, for example `vss-code-search`.",
 			},
 			"publisher_id": {
 				Type:             schema.TypeString,

--- a/azuredevops/internal/service/extension/resource_extension.go
+++ b/azuredevops/internal/service/extension/resource_extension.go
@@ -45,6 +45,7 @@ func ResourceExtension() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Description:  "The Azure DevOps Marketplace extension identifier, for example `vss-code-search`. This value is not a GUID. Azure DevOps extension installation only supports Marketplace identifiers.",
 			},
 			"publisher_id": {
 				Type:             schema.TypeString,
@@ -52,6 +53,7 @@ func ResourceExtension() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validation.StringIsNotWhiteSpace,
+				Description:      "The Azure DevOps Marketplace publisher identifier, for example `ms`. This value is not a GUID. Azure DevOps extension installation only supports Marketplace identifiers.",
 			},
 			"disabled": {
 				Type:     schema.TypeBool,

--- a/azuredevops/internal/service/extension/resource_extension.go
+++ b/azuredevops/internal/service/extension/resource_extension.go
@@ -53,7 +53,7 @@ func ResourceExtension() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validation.StringIsNotWhiteSpace,
-				Description:      "The Azure DevOps Marketplace publisher identifier, for example `ms`. This value is not a GUID. Azure DevOps extension installation only supports Marketplace identifiers.",
+				Description:      "The Azure DevOps Marketplace publisher identifier, for example `ms`.",
 			},
 			"disabled": {
 				Type:     schema.TypeBool,

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -23,7 +23,7 @@ resource "azuredevops_extension" "example" {
 
 The following arguments are supported:
 
-* `extension_id` - (Required) The Azure DevOps Marketplace extension identifier, for example `vss-code-search`. This value is not a GUID.
+* `extension_id` - (Required) The Azure DevOps Marketplace extension identifier, for example `vss-code-search`.
 
 * `publisher_id` - (Required) The Azure DevOps Marketplace publisher identifier, for example `ms`. This value is not a GUID.
 

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -23,9 +23,9 @@ resource "azuredevops_extension" "example" {
 
 The following arguments are supported:
 
-* `extension_id` - (Required) The publisher ID of the extension.
+* `extension_id` - (Required) The Azure DevOps Marketplace extension identifier, for example `vss-code-search`. This value is not a GUID.
 
-* `publisher_id` - (Required) The extension ID of the extension.
+* `publisher_id` - (Required) The Azure DevOps Marketplace publisher identifier, for example `ms`. This value is not a GUID.
 
 ---
 

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `extension_id` - (Required) The Azure DevOps Marketplace extension identifier, for example `vss-code-search`.
 
-* `publisher_id` - (Required) The Azure DevOps Marketplace publisher identifier, for example `ms`. This value is not a GUID.
+* `publisher_id` - (Required) The Azure DevOps Marketplace publisher identifier, for example `ms`.
 
 ---
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

As `extension_id` and `publisher_id` uses the Azure DevOps Marketplace extension identifier and the Azure DevOps Marketplace publisher identifier respectively, a description is added to remove confusion on what values should be used on this field.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result

Only documentation changes.