### PR TITLE
Provider: Supports env vars for `AZURE_TENANT_ID` and `AZURE_CLIENT_SECRET`

### DIFF
--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -249,7 +249,7 @@ func Provider() *schema.Provider {
 			"tenant_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("ARM_TENANT_ID", nil),
+				DefaultFunc:  schema.MultiEnvDefaultFunc([]string{"ARM_TENANT_ID", "AZURE_TENANT_ID"}, nil),
 				Description:  "The service principal tenant id which should be used for AAD auth.",
 				ValidateFunc: validation.IsUUID,
 			},
@@ -287,7 +287,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_SECRET", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_CLIENT_SECRET", "AZURE_CLIENT_SECRET"}, nil),
 				Description: "Client secret for authenticating to  a service principal.",
 			},
 			"client_secret_path": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -76,12 +76,12 @@ the `ARM_CLIENT_ID` or `AZURE_CLIENT_ID` environment variable.
 - `client_id_file_path` - The path to a file containing a client id to authenticate. It can also be sourced from the `ARM_CLIENT_ID_FILE_PATH` environment variable.
 
 - `tenant_id` - The tenant id used when authenticating to a service principal.
-It can also be sourced from the `ARM_TENANT_ID` environment variable.
+It can also be sourced from the `ARM_TENANT_ID` or `AZURE_TENANT_ID` environment variable.
 
 - `auxiliary_tenant_ids` - List of auxiliary Tenant IDs required for multi-tenancy and cross-tenant scenarios. This can also be sourced from the `ARM_AUXILIARY_TENANT_IDS` environment variable.
 
 - `client_secret` - The client secret used to authenticate to a service principal.
-It can also be sourced from the `ARM_CLIENT_SECRET` environment variable.
+It can also be sourced from the `ARM_CLIENT_SECRET` or `AZURE_CLIENT_SECRET` environment variable.
 
 - `client_secret_path` - The path to a file containing a client secret to authenticate to a service principal.
 It can also be sourced from the `ARM_CLIENT_SECRET_PATH` or `ARM_CLIENT_SECRET_FILE_PATH` environment variable.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

I found it to be a bug that the provider can take in "AZURE_CLIENT_SECRET" but NOT take in "AZURE_CLIENT_SECRET" or "AZURE_TENANT_ID". That's really inconsistent. This PR makes it accept those.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Related Issue(s)

I didn't bother opening an issue in favor of just fixing the problem myself.