### PR TITLE
Fix `serviceendpoint_generic_v2` to let the api throw the failure and properly update the authentication parameters.

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_v2_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_generic_v2_test.go
@@ -43,7 +43,7 @@ func TestAccServiceEndpointGenericV2_Basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfSvcEpNode),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"authorization_parameters"},
+				ImportStateVerifyIgnore: []string{"authorization_parameters", "validate_input"},
 			},
 		},
 	})
@@ -114,7 +114,7 @@ func TestAccServiceEndpointGenericV2_UsernamePassword(t *testing.T) {
 				ImportState:             true,
 				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfSvcEpNode),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"authorization_parameters"},
+				ImportStateVerifyIgnore: []string{"authorization_parameters", "validate_input"},
 			},
 		},
 	})
@@ -149,7 +149,7 @@ func TestAccServiceEndpointGenericV2_SharedProjects(t *testing.T) {
 				ImportState:             true,
 				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfSvcEpNode),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"authorization_parameters"},
+				ImportStateVerifyIgnore: []string{"authorization_parameters", "validate_input"},
 			},
 		},
 	})
@@ -273,6 +273,8 @@ resource "azuredevops_serviceendpoint_generic_v2" "test" {
   description = "Managed by Terraform"
   type        = "%s"
   server_url  = "https://github.com"
+
+  validate_input = true
 
   authorization_scheme = "Token"
   authorization_parameters = {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
@@ -109,6 +109,12 @@ func ResourceServiceEndpointGenericV2() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"validate_input": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to validate the provided service endpoint configuration against the service endpoint type definition. Enabling this will cause the provider to return an error if the configuration is invalid.",
+			},
 		},
 	}
 }
@@ -301,9 +307,12 @@ func resourceServiceEndpointGenericV2Create(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	// Validate the service endpoint configuration
-	if err := validateServiceEndpointSchema(clients, *config, false); err != nil {
-		return diag.FromErr(fmt.Errorf("service endpoint validation failed: %w", err))
+	// Validate the service endpoint configuration if validate_input is enabled
+	validateInput := d.Get("validate_input").(bool)
+	if validateInput {
+		if err := validateServiceEndpointSchema(clients, *config, false); err != nil {
+			return diag.FromErr(fmt.Errorf("service endpoint validation failed: %w", err))
+		}
 	}
 
 	// Create the service endpoint
@@ -623,39 +632,33 @@ func resourceServiceEndpointGenericV2Update(ctx context.Context, d *schema.Resou
 	return resourceServiceEndpointGenericV2Read(ctx, d, m)
 }
 
-// updateServiceEndpointFromResourceData updates a service endpoint with values from resource data
+// updateServiceEndpointFromResourceData updates a service endpoint with values from resource data.
+// All fields are always set from the Terraform state rather than conditionally, because the API
+// returns masked/empty values for sensitive fields (e.g. authorization parameters). Relying on
+// the API-fetched endpoint as a base would send those masked values back, clearing the actual
+// credentials and breaking the service endpoint.
 func updateServiceEndpointFromResourceData(d *schema.ResourceData, endpoint *serviceendpoint.ServiceEndpoint) (*serviceendpoint.ServiceEndpoint, error) {
-	// Update fields that have changed
-	if d.HasChange("name") {
-		endpoint.Name = converter.String(d.Get("name").(string))
+	endpoint.Name = converter.String(d.Get("name").(string))
+	endpoint.Description = converter.String(d.Get("description").(string))
+	endpoint.Url = converter.String(d.Get("server_url").(string))
+
+	// Always set authorization from Terraform state – the API returns masked values for
+	// sensitive parameters, so we must never rely on the API response for these.
+	authScheme, authParams, err := getAuthorizationDetails(d)
+	if err != nil {
+		return nil, fmt.Errorf("error processing authorization details: %w", err)
+	}
+	endpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+		Scheme:     converter.String(authScheme),
+		Parameters: &authParams,
 	}
 
-	if d.HasChange("description") {
-		endpoint.Description = converter.String(d.Get("description").(string))
+	// Always set data parameters from Terraform state
+	data, err := toStringMap(d.Get("parameters"), "parameters")
+	if err != nil {
+		return nil, err
 	}
-
-	if d.HasChange("server_url") {
-		endpoint.Url = converter.String(d.Get("server_url").(string))
-	}
-
-	// Handle authorization updates if any auth fields changed
-	if d.HasChange("authorization_scheme") || d.HasChange("authorization_parameters") {
-		authScheme, authParams, err := getAuthorizationDetails(d)
-		if err != nil {
-			return nil, fmt.Errorf("error processing authorization details: %w", err)
-		}
-		endpoint.Authorization = &serviceendpoint.EndpointAuthorization{
-			Scheme:     converter.String(authScheme),
-			Parameters: &authParams,
-		}
-	}
-
-	// Handle data updates if changed
-	if d.HasChange("parameters") {
-		data, err := toStringMap(d.Get("parameters"), "parameters")
-		if err != nil {
-			return nil, err
-		}
+	if len(data) > 0 {
 		endpoint.Data = &data
 	}
 
@@ -786,6 +789,12 @@ func deleteServiceEndpointGenericV2(ctx context.Context, clients *client.Aggrega
 func customizeServiceEndpointGenericV2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 	// Only validate on resource creation changes
 	if d.Id() != "" {
+		return nil
+	}
+
+	// Only validate if validate_input is enabled
+	validateInput := d.Get("validate_input").(bool)
+	if !validateInput {
 		return nil
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
@@ -633,33 +633,48 @@ func resourceServiceEndpointGenericV2Update(ctx context.Context, d *schema.Resou
 }
 
 // updateServiceEndpointFromResourceData updates a service endpoint with values from resource data.
-// All fields are always set from the Terraform state rather than conditionally, because the API
-// returns masked/empty values for sensitive fields (e.g. authorization parameters). Relying on
-// the API-fetched endpoint as a base would send those masked values back, clearing the actual
-// credentials and breaking the service endpoint.
+//
+// Each field is only overwritten on the endpoint returned by the API when the corresponding
+// attribute has actually changed in the Terraform plan. This way, attributes excluded via the
+// `ignore_changes` lifecycle meta-argument are preserved as-is (Terraform reports `HasChange`
+// as false for ignored attributes, so we leave the API value untouched).
+//
+// Authorization is a special case: the API returns masked/empty values for sensitive
+// parameters, so we must always reconstruct the authorization block from the Terraform state
+// (which still holds the real credentials) whenever any auth-related field has changed.
 func updateServiceEndpointFromResourceData(d *schema.ResourceData, endpoint *serviceendpoint.ServiceEndpoint) (*serviceendpoint.ServiceEndpoint, error) {
-	endpoint.Name = converter.String(d.Get("name").(string))
-	endpoint.Description = converter.String(d.Get("description").(string))
-	endpoint.Url = converter.String(d.Get("server_url").(string))
-
-	// Always set authorization from Terraform state – the API returns masked values for
-	// sensitive parameters, so we must never rely on the API response for these.
-	authScheme, authParams, err := getAuthorizationDetails(d)
-	if err != nil {
-		return nil, fmt.Errorf("error processing authorization details: %w", err)
+	if d.HasChange("name") {
+		endpoint.Name = converter.String(d.Get("name").(string))
 	}
-	endpoint.Authorization = &serviceendpoint.EndpointAuthorization{
-		Scheme:     converter.String(authScheme),
-		Parameters: &authParams,
+	if d.HasChange("description") {
+		endpoint.Description = converter.String(d.Get("description").(string))
+	}
+	if d.HasChange("server_url") {
+		endpoint.Url = converter.String(d.Get("server_url").(string))
 	}
 
-	// Always set data parameters from Terraform state
-	data, err := toStringMap(d.Get("parameters"), "parameters")
-	if err != nil {
-		return nil, err
+	// Rebuild authorization from Terraform state when any auth field changed. The API
+	// returns masked values for sensitive parameters, so we never rely on the API response
+	// for these – the state always holds the real credentials.
+	if d.HasChange("authorization_scheme") || d.HasChange("authorization_parameters") {
+		authScheme, authParams, err := getAuthorizationDetails(d)
+		if err != nil {
+			return nil, fmt.Errorf("error processing authorization details: %w", err)
+		}
+		endpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+			Scheme:     converter.String(authScheme),
+			Parameters: &authParams,
+		}
 	}
-	if len(data) > 0 {
-		endpoint.Data = &data
+
+	if d.HasChange("parameters") {
+		data, err := toStringMap(d.Get("parameters"), "parameters")
+		if err != nil {
+			return nil, err
+		}
+		if len(data) > 0 {
+			endpoint.Data = &data
+		}
 	}
 
 	return endpoint, nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
@@ -542,6 +542,11 @@ func resourceServiceEndpointGenericV2Read(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("error setting shared_project_ids: %w", err))
 	}
 
+	// Set validate_input to default value if not explicitly set in state
+	if err := d.Set("validate_input", false); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting validate_input: %w", err))
+	}
+
 	return nil
 }
 

--- a/website/docs/r/serviceendpoint_generic_v2.html.markdown
+++ b/website/docs/r/serviceendpoint_generic_v2.html.markdown
@@ -24,7 +24,7 @@ resource "azuredevops_serviceendpoint_generic_v2" "example" {
   project_id            = azuredevops_project.example.id
   name                  = "Example Generic Service Endpoint"
   description           = "Managed by Terraform"
-  service_endpoint_type = "generic"
+  type                  = "generic"
   server_url            = "https://example.com"
   authorization_scheme  = "UsernamePassword"
   authorization_parameters = {
@@ -33,17 +33,18 @@ resource "azuredevops_serviceendpoint_generic_v2" "example" {
   }
 }
 
-# Token-based authentication
+# Token-based authentication with validation enabled
 resource "azuredevops_serviceendpoint_generic_v2" "token_example" {
   project_id            = azuredevops_project.example.id
   name                  = "Token-based Service Endpoint"
   description           = "Managed by Terraform"
-  service_endpoint_type = "generic"
+  type                  = "generic"
   server_url            = "https://api.example.com"
   authorization_scheme  = "Token"
   authorization_parameters = {
     apitoken = "your-api-token"
   }
+  validate_input = true
 
   parameters = {
     releaseUrl = "https://releases.example.com"
@@ -64,6 +65,7 @@ The following arguments are supported:
 * `authorization_scheme` - (Required) The authorization scheme to use. Common values include "UsernamePassword", "Token", "OAuth", etc.
 * `authorization_parameters` - (Optional) Map of key/value pairs for the specific authorization scheme. These often include sensitive data like tokens, usernames, and passwords.
 * `parameters` - (Optional) Additional data associated with the service endpoint. This is a map of key/value pairs.
+* `validate_input` - (Optional) Whether to validate the provided service endpoint configuration against the service endpoint type definition retrieved from Azure DevOps. When enabled, Terraform will verify that the `type`, `authorization_scheme`, `authorization_parameters`, and `parameters` match the expected schema for the service endpoint type. This helps catch configuration errors during plan/apply. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

The apply time input validation was causing a lot of issues as the code did not reimplement the conditional logic from the service endpoint validation. I have added a toggle that defaults to turn this feature off. This validation is still useful for small service connections but it is unusable for azure service connections for example.

Also there was a bug that skipped the authentication parameters from the update. Fixed that too.

PR 2/2 from #1505

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result


<!-- A screenshot or text pasted here to show the acctest result. -->

## Related Issue(s)

Fix #0000

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
