### PR TITLE
`azurredevops_elastic_pool` - supress casing diff for `azure_resource_id`

### DIFF
--- a/azuredevops/internal/service/taskagent/resource_elastic_pool.go
+++ b/azuredevops/internal/service/taskagent/resource_elastic_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/suppress"
 )
 
 func ResourceAgentPoolVMSS() *schema.Resource {
@@ -41,6 +42,9 @@ func ResourceAgentPoolVMSS() *schema.Resource {
 			"azure_resource_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				// The casing of Azure Resources ID might change, but the ADO API is case-sensitive.
+				// When `DiffSuppressFunc` is set and matched, `.d.Get()` returns value from state.
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"service_endpoint_id": {


### PR DESCRIPTION
The azure resource id might be returned in different casing by the service, but the ADO API is case-sensitive, which may cause apply failure.
add a diffSuppress for it.

## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result


<!-- A screenshot or text pasted here to show the acctest result. -->

## Related Issue(s)

Fix #0000

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
