### PR TITLE
Add azuredevops_servicehook_webhook_pipelines resource

### DIFF
--- a/azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines.go
@@ -1,0 +1,254 @@
+package servicehook
+
+import (
+	"fmt"
+	"log"
+	"maps"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// ResourceServicehookWebhookPipelines schemas a service hook subscription that
+// uses the `pipelines` publisher and the `webHooks` (HTTP POST) consumer.
+//
+// It mirrors ResourceServicehookWebhookTfs but composes the pipelines publisher
+// schema (`stage_state_changed_event`, `run_state_changed_event`) defined in
+// pipelines_publisher.go instead of the TFS publisher schema.
+func ResourceServicehookWebhookPipelines() *schema.Resource {
+	resourceSchema := map[string]*schema.Schema{
+		"project_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsUUID,
+			Description:  "The ID of the project",
+		},
+		"url": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+			Description:  "The URL to send HTTP POST to",
+		},
+		"accept_untrusted_certs": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Accept untrusted SSL certificates",
+		},
+		"basic_auth_username": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Basic authentication username",
+		},
+		"basic_auth_password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Basic authentication password",
+		},
+		"http_headers": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "HTTP headers as key-value pairs",
+		},
+		"resource_details_to_send": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "all",
+			ValidateFunc: validation.StringInSlice([]string{"all", "minimal", "none"}, false),
+			Description:  "Resource details to send - all, minimal, or none",
+		},
+		"messages_to_send": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "all",
+			ValidateFunc: validation.StringInSlice([]string{"all", "text", "html", "markdown", "none"}, false),
+			Description:  "Messages to send - all, text, html, markdown or none",
+		},
+		"detailed_messages_to_send": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "all",
+			ValidateFunc: validation.StringInSlice([]string{"all", "text", "html", "markdown", "none"}, false),
+			Description:  "Detailed messages to send - all, text, html, markdown or none",
+		},
+		"resource_version": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "5.1-preview.1",
+			Description: "The resource version for the webhook subscription. The pipelines publisher events require a preview API version (default: 5.1-preview.1).",
+		},
+	}
+
+	maps.Copy(resourceSchema, genPipelinesPublisherSchema())
+
+	return &schema.Resource{
+		Create: resourceServicehookWebhookPipelinesCreate,
+		Read:   resourceServicehookWebhookPipelinesRead,
+		Update: resourceServicehookWebhookPipelinesUpdate,
+		Delete: resourceServicehookWebhookPipelinesDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: resourceSchema,
+	}
+}
+
+func resourceServicehookWebhookPipelinesCreate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscription := expandServicehookWebhookPipelines(d)
+	createdSubscription, err := createSubscription(d, clients, subscription)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createdSubscription.Id.String())
+	return resourceServicehookWebhookPipelinesRead(d, m)
+}
+
+func resourceServicehookWebhookPipelinesRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscriptionId := converter.UUID(d.Id())
+	subscription, err := getSubscription(clients, subscriptionId)
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			log.Printf("[INFO] Service hook subscription not found. ID: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	flattenServicehookWebhookPipelines(d, subscription)
+	return nil
+}
+
+func resourceServicehookWebhookPipelinesUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscription := expandServicehookWebhookPipelines(d)
+	parsedID, err := uuid.Parse(d.Id())
+	if err != nil {
+		return err
+	}
+	subscription.Id = &parsedID
+
+	if _, err := updateSubscription(clients, subscription); err != nil {
+		return err
+	}
+
+	return resourceServicehookWebhookPipelinesRead(d, m)
+}
+
+func resourceServicehookWebhookPipelinesDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+	subscriptionID := converter.UUID(d.Id())
+	return deleteSubscription(clients, subscriptionID)
+}
+
+func expandServicehookWebhookPipelines(d *schema.ResourceData) *servicehooks.Subscription {
+	publisherInputs, eventType := expandPipelinesEventConfig(d)
+
+	consumerInputs := map[string]string{
+		"url":                    d.Get("url").(string),
+		"acceptUntrustedCerts":   strconv.FormatBool(d.Get("accept_untrusted_certs").(bool)),
+		"resourceDetailsToSend":  d.Get("resource_details_to_send").(string),
+		"messagesToSend":         d.Get("messages_to_send").(string),
+		"detailedMessagesToSend": d.Get("detailed_messages_to_send").(string),
+	}
+
+	if username := d.Get("basic_auth_username").(string); username != "" {
+		consumerInputs["basicAuthUsername"] = username
+	}
+	if password := d.Get("basic_auth_password").(string); password != "" {
+		consumerInputs["basicAuthPassword"] = password
+	}
+
+	if headersRaw, ok := d.GetOk("http_headers"); ok {
+		headers := headersRaw.(map[string]interface{})
+		keys := make([]string, 0, len(headers))
+		for key := range headers {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		var headerString string
+		for _, key := range keys {
+			if headerString != "" {
+				headerString += "\n"
+			}
+			headerString += fmt.Sprintf("%s:%s", key, headers[key].(string))
+		}
+		if headerString != "" {
+			consumerInputs["httpHeaders"] = headerString
+		}
+	}
+
+	return &servicehooks.Subscription{
+		ConsumerActionId: converter.String("httpRequest"),
+		ConsumerId:       converter.String("webHooks"),
+		ConsumerInputs:   &consumerInputs,
+		EventType:        &eventType,
+		PublisherId:      converter.String("pipelines"),
+		PublisherInputs:  &publisherInputs,
+		ResourceVersion:  converter.String(d.Get("resource_version").(string)),
+	}
+}
+
+func flattenServicehookWebhookPipelines(d *schema.ResourceData, subscription *servicehooks.Subscription) {
+	eventType, eventConfig := flattenPipelinesEventConfig(subscription)
+	d.Set(eventType, eventConfig)
+	d.Set("project_id", (*subscription.PublisherInputs)["projectId"])
+	d.Set("url", (*subscription.ConsumerInputs)["url"])
+	if subscription.ResourceVersion != nil {
+		d.Set("resource_version", *subscription.ResourceVersion)
+	}
+
+	if acceptUntrustedCerts, exists := (*subscription.ConsumerInputs)["acceptUntrustedCerts"]; exists {
+		if acceptBool, err := strconv.ParseBool(acceptUntrustedCerts); err == nil {
+			d.Set("accept_untrusted_certs", acceptBool)
+		}
+	}
+
+	if v, exists := (*subscription.ConsumerInputs)["resourceDetailsToSend"]; exists {
+		d.Set("resource_details_to_send", v)
+	}
+	if v, exists := (*subscription.ConsumerInputs)["messagesToSend"]; exists {
+		d.Set("messages_to_send", v)
+	}
+	if v, exists := (*subscription.ConsumerInputs)["detailedMessagesToSend"]; exists {
+		d.Set("detailed_messages_to_send", v)
+	}
+
+	if headersString, exists := (*subscription.ConsumerInputs)["httpHeaders"]; exists && headersString != "" {
+		headers := make(map[string]string)
+		for _, line := range strings.Split(headersString, "\n") {
+			if line == "" {
+				continue
+			}
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			}
+		}
+		if len(headers) > 0 {
+			d.Set("http_headers", headers)
+		}
+	}
+}

--- a/azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines_test.go
+++ b/azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines_test.go
@@ -1,0 +1,91 @@
+//go:build all || servicehook
+// +build all servicehook
+
+package servicehook
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/servicehooks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandServicehookWebhookPipelines_StageStateChanged(t *testing.T) {
+	r := ResourceServicehookWebhookPipelines()
+	d := r.TestResourceData()
+
+	projectID := uuid.New().String()
+	require.NoError(t, d.Set("project_id", projectID))
+	require.NoError(t, d.Set("url", "https://example.azurewebsites.net/api/BuildFailed"))
+	require.NoError(t, d.Set("http_headers", map[string]interface{}{
+		"x-functions-key": "secret",
+	}))
+	require.NoError(t, d.Set("stage_state_changed_event", []interface{}{
+		map[string]interface{}{
+			"stage_state_filter":  "Completed",
+			"stage_result_filter": "Canceled",
+		},
+	}))
+
+	sub := expandServicehookWebhookPipelines(d)
+
+	require.Equal(t, "pipelines", *sub.PublisherId)
+	require.Equal(t, "webHooks", *sub.ConsumerId)
+	require.Equal(t, "httpRequest", *sub.ConsumerActionId)
+	require.Equal(t, "ms.vss-pipelines.stage-state-changed-event", *sub.EventType)
+
+	require.NotNil(t, sub.PublisherInputs)
+	require.Equal(t, projectID, (*sub.PublisherInputs)["projectId"])
+	require.Equal(t, "Completed", (*sub.PublisherInputs)["stageStateId"])
+	require.Equal(t, "Canceled", (*sub.PublisherInputs)["stageResultId"])
+
+	require.NotNil(t, sub.ConsumerInputs)
+	require.Equal(t, "https://example.azurewebsites.net/api/BuildFailed", (*sub.ConsumerInputs)["url"])
+	require.Equal(t, "x-functions-key:secret", (*sub.ConsumerInputs)["httpHeaders"])
+}
+
+func TestFlattenServicehookWebhookPipelines_RoundTrip(t *testing.T) {
+	r := ResourceServicehookWebhookPipelines()
+	d := r.TestResourceData()
+
+	projectID := uuid.New().String()
+	sub := &servicehooks.Subscription{
+		ConsumerActionId: converter.String("httpRequest"),
+		ConsumerId:       converter.String("webHooks"),
+		ConsumerInputs: &map[string]string{
+			"url":                    "https://example.com/hook",
+			"acceptUntrustedCerts":   "true",
+			"resourceDetailsToSend":  "all",
+			"messagesToSend":         "all",
+			"detailedMessagesToSend": "all",
+			"httpHeaders":            "x-functions-key:secret\ncustomId:1",
+		},
+		EventType:   converter.String("ms.vss-pipelines.stage-state-changed-event"),
+		PublisherId: converter.String("pipelines"),
+		PublisherInputs: &map[string]string{
+			"projectId":     projectID,
+			"stageStateId":  "Completed",
+			"stageResultId": "Failed",
+		},
+		ResourceVersion: converter.String("5.1-preview.1"),
+	}
+
+	flattenServicehookWebhookPipelines(d, sub)
+
+	require.Equal(t, projectID, d.Get("project_id"))
+	require.Equal(t, "https://example.com/hook", d.Get("url"))
+	require.Equal(t, true, d.Get("accept_untrusted_certs"))
+	require.Equal(t, "5.1-preview.1", d.Get("resource_version"))
+
+	headers := d.Get("http_headers").(map[string]interface{})
+	require.Equal(t, "secret", headers["x-functions-key"])
+	require.Equal(t, "1", headers["customId"])
+
+	stageList := d.Get("stage_state_changed_event").([]interface{})
+	require.Len(t, stageList, 1)
+	stage := stageList[0].(map[string]interface{})
+	require.Equal(t, "Completed", stage["stage_state_filter"])
+	require.Equal(t, "Failed", stage["stage_result_filter"])
+}

--- a/website/docs/r/servicehook_webhook_pipelines.html.markdown
+++ b/website/docs/r/servicehook_webhook_pipelines.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_servicehook_webhook_pipelines"
+description: |-
+  Manages a Pipelines publisher webhook (HTTP POST) service hook subscription within Azure DevOps.
+---
+
+# azuredevops_servicehook_webhook_pipelines
+
+Manages a service hook subscription that uses the `pipelines` publisher and posts
+events to a webhook (`webHooks` consumer / `httpRequest` action).
+
+This is the webhook counterpart to
+[`azuredevops_servicehook_storage_queue_pipelines`](servicehook_storage_queue_pipelines.html.markdown)
+and the pipelines counterpart to
+[`azuredevops_servicehook_webhook_tfs`](servicehook_webhook_tfs.html.markdown).
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name = "Example Project"
+}
+
+resource "azuredevops_servicehook_webhook_pipelines" "build_failed_canceled" {
+  project_id = azuredevops_project.example.id
+  url        = "https://example.azurewebsites.net/api/BuildFailed"
+
+  http_headers = {
+    "x-functions-key" = var.function_token
+  }
+
+  stage_state_changed_event {
+    stage_state_filter  = "Completed"
+    stage_result_filter = "Canceled"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project. Forces a new resource.
+* `url` - (Required) The URL to which the HTTP POST will be sent.
+* `accept_untrusted_certs` - (Optional) Accept untrusted SSL certificates. Defaults to `false`.
+* `basic_auth_username` - (Optional) Basic authentication username.
+* `basic_auth_password` - (Optional) Basic authentication password.
+* `http_headers` - (Optional) Map of HTTP headers to send with the POST request.
+* `resource_details_to_send` - (Optional) `all`, `minimal`, or `none`. Defaults to `all`.
+* `messages_to_send` - (Optional) `all`, `text`, `html`, `markdown`, or `none`. Defaults to `all`.
+* `detailed_messages_to_send` - (Optional) `all`, `text`, `html`, `markdown`, or `none`. Defaults to `all`.
+* `resource_version` - (Optional) Resource version of the subscription. Defaults to `5.1-preview.1` (required for the pipelines publisher).
+
+Exactly one of the following event blocks must be specified:
+
+* `stage_state_changed_event` - (Optional)
+  * `pipeline_id` - (Optional) Pipeline ID to filter on.
+  * `stage_name` - (Optional) Stage name to filter on.
+  * `stage_state_filter` - (Optional) One of `NotStarted`, `Waiting`, `Running`, `Completed`.
+  * `stage_result_filter` - (Optional) One of `Canceled`, `Failed`, `Rejected`, `Skipped`, `Succeeded`.
+
+* `run_state_changed_event` - (Optional)
+  * `pipeline_id` - (Optional) Pipeline ID to filter on.
+  * `run_state_filter` - (Optional) One of `InProgress`, `Canceling`, `Completed`.
+  * `run_result_filter` - (Optional) One of `Canceled`, `Failed`, `Succeeded`.
+
+## Attributes Reference
+
+* `id` - The ID (UUID) of the service hook subscription.
+
+## Import
+
+Service hook subscriptions can be imported using the subscription ID:
+
+```sh
+terraform import azuredevops_servicehook_webhook_pipelines.example 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
## Summary

Adds a new resource `azuredevops_servicehook_webhook_pipelines` that manages an Azure DevOps service hook subscription with `publisherId = "pipelines"` and `consumerId = "webHooks"` (HTTP POST). This fills a gap in the existing servicehook coverage:

| publisher \ consumer | `webHooks` (HTTP POST) | `azureStorageQueue` |
| --- | --- | --- |
| `tfs` | `azuredevops_servicehook_webhook_tfs` (#1412, #1497) | — |
| `pipelines` | **new in this PR** | `azuredevops_servicehook_storage_queue_pipelines` (#1412) |

Without this resource, users have to fall back to manual REST calls (PowerShell / `http` providers) to register webhooks for `ms.vss-pipelines.stage-state-changed-event` or `ms.vss-pipelines.run-state-changed-event`.

## Implementation notes

* No SDK changes required. Reuses `servicehooks.Subscription` and the shared CRUD helpers in `commons.go`.
* The pipelines publisher schema (`stage_state_changed_event`, `run_state_changed_event`) already exists in `pipelines_publisher.go`; this PR composes it together with the same consumer-side fields exposed by `resource_servicehook_webhook_tfs.go` (`url`, `http_headers`, `basic_auth_*`, `accept_untrusted_certs`, `messages_to_send`, etc.).
* `resource_version` defaults to `5.1-preview.1`, matching the value the `azuredevops_servicehook_storage_queue_pipelines` resource hard-codes for the same publisher.

## Files

* `azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines.go`
* `azuredevops/internal/service/servicehook/resource_servicehook_webhook_pipelines_test.go`
* `website/docs/r/servicehook_webhook_pipelines.html.markdown`

> ⚠️ **Draft – not yet wired into the provider.** A follow-up commit must register the resource in `azuredevops/provider.go` `ResourcesMap` as `"azuredevops_servicehook_webhook_pipelines": servicehook.ResourceServicehookWebhookPipelines()` before this is merge-ready.

## Related

* #1412 — original servicehook webhook (TFS) resource
* #1497 — added `resource_version` to the TFS variant (pattern reused here)