### PR TITLE
`azuredevops_workitemtrackingprocess_(control|group|rule)`: Retry on TF401349 - Unexpected error

### DIFF
--- a/azuredevops/internal/service/workitemtrackingprocess/resource_control.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_control.go
@@ -209,9 +209,11 @@ func createResourceControl(ctx context.Context, d *schema.ResourceData, m any) d
 
 	var createdControl *workitemtrackingprocess.Control
 	err := utils.RetryOnContributionNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-		var createErr error
-		createdControl, createErr = clients.WorkItemTrackingProcessClient.CreateControlInGroup(ctx, args)
-		return createErr
+		return utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutCreate), func() error {
+			var createErr error
+			createdControl, createErr = clients.WorkItemTrackingProcessClient.CreateControlInGroup(ctx, args)
+			return createErr
+		})
 	})
 	if err != nil {
 		return diag.Errorf(" Creating control. Error %+v", err)
@@ -361,7 +363,10 @@ func updateResourceControl(ctx context.Context, d *schema.ResourceData, m any) d
 		Control:    control,
 	}
 
-	_, err := clients.WorkItemTrackingProcessClient.UpdateControl(ctx, args)
+	err := utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutUpdate), func() error {
+		_, err := clients.WorkItemTrackingProcessClient.UpdateControl(ctx, args)
+		return err
+	})
 	if err != nil {
 		return diag.Errorf(" Update control. Error %+v", err)
 	}

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_control.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_control.go
@@ -208,13 +208,11 @@ func createResourceControl(ctx context.Context, d *schema.ResourceData, m any) d
 	}
 
 	var createdControl *workitemtrackingprocess.Control
-	err := utils.RetryOnContributionNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-		return utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-			var createErr error
-			createdControl, createErr = clients.WorkItemTrackingProcessClient.CreateControlInGroup(ctx, args)
-			return createErr
-		})
-	})
+	err := utils.RetryOn(ctx, d.Timeout(schema.TimeoutCreate), func() error {
+		var createErr error
+		createdControl, createErr = clients.WorkItemTrackingProcessClient.CreateControlInGroup(ctx, args)
+		return createErr
+	}, utils.RetryOnContributionNotFound, utils.RetryOnUnexpectedException)
 	if err != nil {
 		return diag.Errorf(" Creating control. Error %+v", err)
 	}

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
@@ -263,13 +263,11 @@ func createResourceGroup(ctx context.Context, d *schema.ResourceData, m any) dia
 	}
 
 	var createdGroup *workitemtrackingprocess.Group
-	err := utils.RetryOnContributionNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-		return utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-			var createErr error
-			createdGroup, createErr = clients.WorkItemTrackingProcessClient.AddGroup(ctx, args)
-			return createErr
-		})
-	})
+	err := utils.RetryOn(ctx, d.Timeout(schema.TimeoutCreate), func() error {
+		var createErr error
+		createdGroup, createErr = clients.WorkItemTrackingProcessClient.AddGroup(ctx, args)
+		return createErr
+	}, utils.RetryOnContributionNotFound, utils.RetryOnUnexpectedException)
 	if err != nil {
 		return diag.Errorf(" Creating group. Error %+v", err)
 	}

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_group.go
@@ -264,9 +264,11 @@ func createResourceGroup(ctx context.Context, d *schema.ResourceData, m any) dia
 
 	var createdGroup *workitemtrackingprocess.Group
 	err := utils.RetryOnContributionNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-		var createErr error
-		createdGroup, createErr = clients.WorkItemTrackingProcessClient.AddGroup(ctx, args)
-		return createErr
+		return utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutCreate), func() error {
+			var createErr error
+			createdGroup, createErr = clients.WorkItemTrackingProcessClient.AddGroup(ctx, args)
+			return createErr
+		})
 	})
 	if err != nil {
 		return diag.Errorf(" Creating group. Error %+v", err)
@@ -446,7 +448,10 @@ func updateResourceGroup(ctx context.Context, d *schema.ResourceData, m any) dia
 		Group:      updateGroup,
 	}
 
-	_, err := clients.WorkItemTrackingProcessClient.UpdateGroup(ctx, args)
+	err := utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutUpdate), func() error {
+		_, err := clients.WorkItemTrackingProcessClient.UpdateGroup(ctx, args)
+		return err
+	})
 	if err != nil {
 		return diag.Errorf(" Update group. Error %+v", err)
 	}

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_rule.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_rule.go
@@ -179,7 +179,12 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, m any) diag
 		ProcessRuleCreate: ruleRequest,
 	}
 
-	createdRule, err := clients.WorkItemTrackingProcessClient.AddProcessWorkItemTypeRule(ctx, args)
+	var createdRule *workitemtrackingprocess.ProcessRule
+	err := utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutCreate), func() error {
+		var createErr error
+		createdRule, createErr = clients.WorkItemTrackingProcessClient.AddProcessWorkItemTypeRule(ctx, args)
+		return createErr
+	})
 	if err != nil {
 		return diag.Errorf(" Creating rule. Error: %+v", err)
 	}
@@ -267,7 +272,10 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		ProcessRule: ruleUpdate,
 	}
 
-	_, err := clients.WorkItemTrackingProcessClient.UpdateProcessWorkItemTypeRule(ctx, args)
+	err := utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutUpdate), func() error {
+		_, err := clients.WorkItemTrackingProcessClient.UpdateProcessWorkItemTypeRule(ctx, args)
+		return err
+	})
 	if err != nil {
 		return diag.Errorf(" Updating rule %s. Error: %+v", ruleId, err)
 	}
@@ -288,7 +296,9 @@ func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, m any) diag
 		RuleId:     converter.UUID(ruleId),
 	}
 
-	err := clients.WorkItemTrackingProcessClient.DeleteProcessWorkItemTypeRule(ctx, args)
+	err := utils.RetryOnUnexpectedException(ctx, d.Timeout(schema.TimeoutDelete), func() error {
+		return clients.WorkItemTrackingProcessClient.DeleteProcessWorkItemTypeRule(ctx, args)
+	})
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			return nil

--- a/azuredevops/internal/utils/retry.go
+++ b/azuredevops/internal/utils/retry.go
@@ -49,3 +49,17 @@ func RetryOnContributionNotFound(ctx context.Context, timeout time.Duration, f f
 		return ResponseContainsStatusMessage(err, "VS403120")
 	})
 }
+
+type RetryFunc func(ctx context.Context, timeout time.Duration, f func() error) error
+
+// RetryOn can retry the given function using multiple retry functions.
+// The retry functions are chained to each other in reverse order,
+// i.e. the outer most is executed first
+func RetryOn(ctx context.Context, timeout time.Duration, f func() error, retries ...RetryFunc) error {
+	inner := f
+	for i := len(retries) - 1; i >= 0; i-- {
+		r, prev := retries[i], inner
+		inner = func() error { return r(ctx, timeout, prev) }
+	}
+	return inner()
+}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
See the description in the issue.

I considered adding this into a middleware of the `WorkItemTrackingProcessClient`, but it would be a substantial refactor, and affect many more resources, so I simply reused the existing retry functions. 

It's _very_ difficult to test this as it's intermittent and seems to depend on how many operations you do in close proximity and in what way. I have not added any new tests.

The issue only mentions controls and groups, but I have seen this for rules too, so I also included that resource.

```
╷
│ Error:  Deleting rule 6f87f1a5-69f4-41c2-8158-89e9a45500cf. Error: TF401349: An unexpected error has occurred, please verify your request and try again.
│ 
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result

```
$ TF_ACC=1 go test -v -run 'TestAccWorkitemtrackingprocess(Group|Control|Rule)_' ./azuredevops/internal/acceptancetests/... -timeout 120m

=== RUN   TestAccWorkitemtrackingprocessControl_Basic
=== PAUSE TestAccWorkitemtrackingprocessControl_Basic
=== RUN   TestAccWorkitemtrackingprocessControl_Update
=== PAUSE TestAccWorkitemtrackingprocessControl_Update
=== RUN   TestAccWorkitemtrackingprocessControl_Move
=== PAUSE TestAccWorkitemtrackingprocessControl_Move
=== RUN   TestAccWorkitemtrackingprocessControl_Contribution
=== PAUSE TestAccWorkitemtrackingprocessControl_Contribution
=== RUN   TestAccWorkitemtrackingprocessGroup_Basic
=== PAUSE TestAccWorkitemtrackingprocessGroup_Basic
=== RUN   TestAccWorkitemtrackingprocessGroup_Update
=== PAUSE TestAccWorkitemtrackingprocessGroup_Update
=== RUN   TestAccWorkitemtrackingprocessGroup_Move
=== PAUSE TestAccWorkitemtrackingprocessGroup_Move
=== RUN   TestAccWorkitemtrackingprocessGroup_WithMultipleControlTypes
=== PAUSE TestAccWorkitemtrackingprocessGroup_WithMultipleControlTypes
=== RUN   TestAccWorkitemtrackingprocessRule_Basic
=== PAUSE TestAccWorkitemtrackingprocessRule_Basic
=== RUN   TestAccWorkitemtrackingprocessRule_Update
=== PAUSE TestAccWorkitemtrackingprocessRule_Update
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes/when
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionTypes/when
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNot
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNot
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes/whenChanged
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionTypes/whenChanged
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNotChanged
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNotChanged
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionTypes/whenWas
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionTypes/whenWas
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionTypes/when
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNotChanged
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionTypes/whenWas
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionTypes/whenChanged
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNot
--- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes (0.00s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes/whenChanged (3.52s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNotChanged (3.99s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes/whenNot (4.20s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes/whenWas (4.24s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionTypes/when (4.30s)
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionGroupMembership
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsMemberOfGroup
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsMemberOfGroup
=== RUN   TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsNotMemberOfGroup
=== PAUSE TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsNotMemberOfGroup
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsMemberOfGroup
=== CONT  TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsNotMemberOfGroup
--- PASS: TestAccWorkitemtrackingprocessRule_ConditionGroupMembership (0.00s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsMemberOfGroup (5.42s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ConditionGroupMembership/whenCurrentUserIsNotMemberOfGroup (6.08s)
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/makeRequired
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/makeRequired
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/makeReadOnly
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/makeReadOnly
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultValue
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultValue
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromClock
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromClock
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromField
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromField
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyValue
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyValue
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromClock
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromClock
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromCurrentUser
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromCurrentUser
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromField
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromField
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/setValueToEmpty
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/setValueToEmpty
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerClock
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerClock
=== RUN   TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerCurrentUser
=== PAUSE TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerCurrentUser
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/makeRequired
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromClock
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/setValueToEmpty
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromField
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerCurrentUser
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromCurrentUser
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultValue
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromClock
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyValue
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromField
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/makeReadOnly
=== CONT  TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerClock
--- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes (0.00s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromClock (2.90s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/makeRequired (2.99s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerClock (3.09s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyValue (3.39s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/makeReadOnly (3.40s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/setValueToEmpty (3.57s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromField (3.57s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultValue (3.61s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromCurrentUser (3.67s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromClock (3.74s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/copyFromServerCurrentUser (3.74s)
    --- PASS: TestAccWorkitemtrackingprocessRule_ActionTypes/setDefaultFromField (3.74s)
=== RUN   TestAccWorkitemtrackingprocessRule_HideTargetField
=== PAUSE TestAccWorkitemtrackingprocessRule_HideTargetField
=== RUN   TestAccWorkitemtrackingprocessRule_DisallowValue
=== PAUSE TestAccWorkitemtrackingprocessRule_DisallowValue
=== CONT  TestAccWorkitemtrackingprocessControl_Basic
=== CONT  TestAccWorkitemtrackingprocessGroup_Move
=== CONT  TestAccWorkitemtrackingprocessRule_Update
=== CONT  TestAccWorkitemtrackingprocessControl_Contribution
=== CONT  TestAccWorkitemtrackingprocessGroup_Update
=== CONT  TestAccWorkitemtrackingprocessRule_DisallowValue
=== CONT  TestAccWorkitemtrackingprocessRule_HideTargetField
=== CONT  TestAccWorkitemtrackingprocessGroup_Basic
=== CONT  TestAccWorkitemtrackingprocessControl_Move
=== CONT  TestAccWorkitemtrackingprocessControl_Update
=== CONT  TestAccWorkitemtrackingprocessRule_Basic
=== CONT  TestAccWorkitemtrackingprocessGroup_WithMultipleControlTypes
--- PASS: TestAccWorkitemtrackingprocessRule_Basic (3.28s)
--- PASS: TestAccWorkitemtrackingprocessGroup_Basic (3.28s)
--- PASS: TestAccWorkitemtrackingprocessControl_Basic (3.28s)
--- PASS: TestAccWorkitemtrackingprocessControl_Contribution (3.82s)
--- PASS: TestAccWorkitemtrackingprocessRule_DisallowValue (3.83s)
--- PASS: TestAccWorkitemtrackingprocessRule_HideTargetField (5.18s)
--- PASS: TestAccWorkitemtrackingprocessRule_Update (5.46s)
--- PASS: TestAccWorkitemtrackingprocessGroup_Move (6.01s)
--- PASS: TestAccWorkitemtrackingprocessGroup_WithMultipleControlTypes (7.04s)
--- PASS: TestAccWorkitemtrackingprocessGroup_Update (7.07s)
--- PASS: TestAccWorkitemtrackingprocessControl_Move (7.09s)
--- PASS: TestAccWorkitemtrackingprocessControl_Update (7.72s)
PASS
ok  	github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests	21.879s
?   	github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils	[no test files]
```

## Related Issue(s)

Fix #1533

## Other information
N/A