### PR TITLE
`azuredevops_workitemtrackingprocess_inherited_control`: Fix a bug that some inherited control types cannot be inferred

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_inherited_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_inherited_control_test.go
@@ -161,7 +161,6 @@ func TestAccWorkitemtrackingprocessInheritedControl_Hide(t *testing.T) {
 						Config: hideInheritedControlConfig(processName, witName, tc.groupID, tc.controlID),
 						Check: resource.ComposeTestCheckFunc(
 							resource.TestCheckResourceAttrSet(tfNode, "id"),
-							resource.TestCheckResourceAttr(tfNode, "visible", "false"),
 						),
 					},
 				},

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_inherited_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_inherited_control_test.go
@@ -127,6 +127,71 @@ func TestAccWorkitemtrackingprocessInheritedControl_Revert(t *testing.T) {
 	})
 }
 
+// https://github.com/microsoft/terraform-provider-azuredevops/issues/1549
+func TestAccWorkitemtrackingprocessInheritedControl_Hide(t *testing.T) {
+	testCases := []struct {
+		name      string
+		groupID   string
+		controlID string
+	}{
+		{
+			name:      "DeploymentsControl",
+			groupID:   "Agile.Bug.Bug.Deployment",
+			controlID: "Deployments",
+		},
+		{
+			name:      "LinksControl",
+			groupID:   "Agile.Bug.Bug.Development",
+			controlID: "Development",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			processName := testutils.GenerateResourceName()
+			witName := testutils.GenerateWorkItemTypeName()
+			tfNode := "azuredevops_workitemtrackingprocess_inherited_control.test"
+
+			resource.ParallelTest(t, resource.TestCase{
+				PreCheck:          func() { testutils.PreCheck(t, nil) },
+				ProviderFactories: testutils.GetProviderFactories(),
+				CheckDestroy:      testutils.CheckProcessDestroyed,
+				Steps: []resource.TestStep{
+					{
+						Config: hideInheritedControlConfig(processName, witName, tc.groupID, tc.controlID),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttrSet(tfNode, "id"),
+							resource.TestCheckResourceAttr(tfNode, "visible", "false"),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func hideInheritedControlConfig(processName, witName, groupID, controlID string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_workitemtrackingprocess_process" "test" {
+  parent_process_type_id = "%s"
+  name                   = "%s"
+}
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  process_id = azuredevops_workitemtrackingprocess_process.test.id
+  name       = "%s"
+}
+
+resource "azuredevops_workitemtrackingprocess_inherited_control" "test" {
+  process_id        = azuredevops_workitemtrackingprocess_process.test.id
+  work_item_type_id = azuredevops_workitemtrackingprocess_workitemtype.test.id
+  group_id          = "%s"
+  control_id        = "%s"
+  visible           = false
+}
+`, agileSystemProcessTypeId, processName, witName, groupID, controlID)
+}
+
 func basicInheritedControl(workItemTypeName string, processName string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_workitemtrackingprocess_process" "test" {

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_inherited_control.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_inherited_control.go
@@ -63,6 +63,11 @@ func ResourceInheritedControl() *schema.Resource {
 				Computed:    true,
 				Description: "Label for the control.",
 			},
+			"control_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of control.",
+			},
 			"visible": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -127,6 +132,9 @@ func createResourceInheritedControl(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("control %s is not inherited, use azuredevops_workitemtrackingprocess_control to manage custom controls", controlId)
 	}
 
+	if existingControl.ControlType != nil {
+		d.Set("control_type", *existingControl.ControlType)
+	}
 	d.SetId(controlId)
 
 	return updateResourceInheritedControl(ctx, d, m)
@@ -175,6 +183,9 @@ func readResourceInheritedControl(ctx context.Context, d *schema.ResourceData, m
 	if control.Visible != nil {
 		d.Set("visible", *control.Visible)
 	}
+	if control.ControlType != nil {
+		d.Set("control_type", *control.ControlType)
+	}
 	return nil
 }
 
@@ -184,6 +195,10 @@ func updateResourceInheritedControl(ctx context.Context, d *schema.ResourceData,
 	controlId := d.Id()
 
 	control := workitemtrackingprocess.Control{}
+
+	if v, ok := d.GetOk("control_type"); ok {
+		control.ControlType = converter.String(v.(string))
+	}
 
 	visible, err := getBoolAttributeFromConfig(d, "visible")
 	if err != nil {

--- a/website/docs/r/workitemtrackingprocess_inherited_control.html.markdown
+++ b/website/docs/r/workitemtrackingprocess_inherited_control.html.markdown
@@ -60,6 +60,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the control.
 
+* `control_type` - Type of control.
+
 ## Relevant Links
 
 - [Azure DevOps Service REST API 7.1 - Controls](https://learn.microsoft.com/en-us/rest/api/azure/devops/processes/controls?view=azure-devops-rest-7.1)


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
The downstream API does not seem to be able to infer the control type of some inherited controls making any updates to them fail, see the issue for more information.

It seems it's able to infer this for any field related controls.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result
```
TF_ACC=1 go test -v -run 'TestAccWorkitemtrackingprocessInheritedControl_' ./azuredevops/internal/acceptancetests/... -timeout 120m
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Basic
=== PAUSE TestAccWorkitemtrackingprocessInheritedControl_Basic
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Update
=== PAUSE TestAccWorkitemtrackingprocessInheritedControl_Update
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Revert
=== PAUSE TestAccWorkitemtrackingprocessInheritedControl_Revert
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Hide
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Hide/DeploymentsControl
=== PAUSE TestAccWorkitemtrackingprocessInheritedControl_Hide/DeploymentsControl
=== RUN   TestAccWorkitemtrackingprocessInheritedControl_Hide/LinksControl
=== PAUSE TestAccWorkitemtrackingprocessInheritedControl_Hide/LinksControl
=== CONT  TestAccWorkitemtrackingprocessInheritedControl_Hide/DeploymentsControl
=== CONT  TestAccWorkitemtrackingprocessInheritedControl_Hide/LinksControl
--- PASS: TestAccWorkitemtrackingprocessInheritedControl_Hide (0.00s)
    --- PASS: TestAccWorkitemtrackingprocessInheritedControl_Hide/DeploymentsControl (4.70s)
    --- PASS: TestAccWorkitemtrackingprocessInheritedControl_Hide/LinksControl (6.00s)
=== CONT  TestAccWorkitemtrackingprocessInheritedControl_Basic
=== CONT  TestAccWorkitemtrackingprocessInheritedControl_Revert
=== CONT  TestAccWorkitemtrackingprocessInheritedControl_Update
--- PASS: TestAccWorkitemtrackingprocessInheritedControl_Basic (3.89s)
--- PASS: TestAccWorkitemtrackingprocessInheritedControl_Revert (4.77s)
--- PASS: TestAccWorkitemtrackingprocessInheritedControl_Update (6.94s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        12.958s
?       github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils      [no test files]
```

<!-- A screenshot or text pasted here to show the acctest result. -->

## Related Issue(s)

Fix #1549 

## Other information
N/A