### PR TITLE
Add import support for all check resources

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_check_approval_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_approval_test.go
@@ -30,6 +30,12 @@ func TestAccCheckApproval_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "approvers.#", "1"),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -55,6 +61,12 @@ func TestAccCheckApproval_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "timeout", "40000"),
 					resource.TestCheckResourceAttr(tfCheckNode, "approvers.#", "2"),
 				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_branch_control_test.go
@@ -30,6 +30,12 @@ func TestAccCheckBranchControl_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "timeout", "1440"),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -57,6 +63,12 @@ func TestAccCheckBranchControl_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "verify_branch_protection", "true"),
 					resource.TestCheckResourceAttr(tfCheckNode, "ignore_unknown_protection_status", "false"),
 				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_business_hours_test.go
@@ -32,6 +32,12 @@ func TestAccCheckBusinessHours_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "end_time", end_time),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -76,6 +82,12 @@ func TestAccCheckBusinessHours_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "sunday", "false"),
 					resource.TestCheckResourceAttr(tfCheckNode, "timeout", "1440"),
 				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_exclusive_lock_test.go
@@ -38,6 +38,12 @@ func TestAccCheckExclusiveLock_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "timeout", fmt.Sprintf("%d", newTimeout)),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_required_template_test.go
@@ -30,6 +30,12 @@ func TestAccCheckRequiredTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.template_path", templatePath),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -57,6 +63,12 @@ func TestAccCheckRequiredTemplate_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.repository_ref", repositoryRef),
 					resource.TestCheckResourceAttr(tfCheckNode, "required_template.0.template_path", templatePath),
 				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_rest_api_test.go
@@ -28,6 +28,12 @@ func TestAccCheckRestAPI_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "method", "GET"),
 				),
 			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -60,6 +66,12 @@ func TestAccCheckRestAPI_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfCheckNode, "variable_group_name", variableGroupName),
 					resource.TestCheckResourceAttr(tfCheckNode, "timeout", "40000"),
 				),
+			},
+			{
+				ResourceName:      tfCheckNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfCheckNode),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azuredevops/internal/service/approvalsandchecks/common_check.go
+++ b/azuredevops/internal/service/approvalsandchecks/common_check.go
@@ -1,10 +1,13 @@
 package approvalsandchecks
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -63,6 +66,26 @@ func genBaseCheckResource(f flatFunc, e expandFunc) *schema.Resource {
 		Read:   genCheckReadFunc(f),
 		Update: genCheckUpdateFunc(f, e),
 		Delete: genCheckDeleteFunc(),
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 {
+					return nil, fmt.Errorf("unexpected ID format (%q), expected: <projectId>/<checkId>", d.Id())
+				}
+
+				if _, err := uuid.Parse(idParts[0]); err != nil {
+					return nil, fmt.Errorf("project ID must be a UUID, got: %s", idParts[0])
+				}
+
+				if _, err := strconv.Atoi(idParts[1]); err != nil {
+					return nil, fmt.Errorf("check ID must be an integer, got: %s", idParts[1])
+				}
+
+				d.Set("project_id", idParts[0])
+				d.SetId(idParts[1])
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(2 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_approval.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_approval.go
@@ -73,6 +73,8 @@ func flattenCheckApproval(d *schema.ResourceData, check *pipelineschecksextras.C
 
 	if requesterCannotBeApprover, found := settings["requesterCannotBeApprover"]; found {
 		d.Set("requester_can_approve", !requesterCannotBeApprover.(bool))
+	} else {
+		d.Set("requester_can_approve", true)
 	}
 
 	if approversRaw, found := settings["approvers"]; found {

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control.go
@@ -119,6 +119,8 @@ func flattenBranchControlCheck(d *schema.ResourceData, branchControlCheck *pipel
 				return err
 			}
 			d.Set("ignore_unknown_protection_status", value)
+		} else {
+			d.Set("ignore_unknown_protection_status", false)
 		}
 	} else {
 		return fmt.Errorf("inputs not found")

--- a/azuredevops/internal/service/approvalsandchecks/resource_check_rest_api.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_rest_api.go
@@ -178,6 +178,10 @@ func flattenRestAPI(d *schema.ResourceData, check *pipelineschecksextras.CheckCo
 			if v, exist := inputs["successCriteria"]; exist {
 				d.Set("success_criteria", v.(string))
 			}
+
+			if v, exist := inputs["urlSuffix"]; exist {
+				d.Set("url_suffix", v.(string))
+			}
 		}
 	}
 	return nil

--- a/website/docs/r/check_approval.html.markdown
+++ b/website/docs/r/check_approval.html.markdown
@@ -113,4 +113,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_approval.example 00000000-0000-0000-0000-000000000000/0
+```

--- a/website/docs/r/check_branch_control.html.markdown
+++ b/website/docs/r/check_branch_control.html.markdown
@@ -186,4 +186,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_branch_control.example 00000000-0000-0000-0000-000000000000/0
+```

--- a/website/docs/r/check_business_hours.html.markdown
+++ b/website/docs/r/check_business_hours.html.markdown
@@ -222,7 +222,11 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_business_hours.example 00000000-0000-0000-0000-000000000000/0
+```
 
 ## Supported Time Zones
 

--- a/website/docs/r/check_exclusive_lock.html.markdown
+++ b/website/docs/r/check_exclusive_lock.html.markdown
@@ -114,4 +114,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_exclusive_lock.example 00000000-0000-0000-0000-000000000000/0
+```

--- a/website/docs/r/check_required_template.html.markdown
+++ b/website/docs/r/check_required_template.html.markdown
@@ -114,4 +114,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_required_template.example 00000000-0000-0000-0000-000000000000/0
+```

--- a/website/docs/r/check_rest_api.html.markdown
+++ b/website/docs/r/check_rest_api.html.markdown
@@ -126,4 +126,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Importing this resource is not supported.
+Importing this resource is supported. The resource ID format is `<projectId>/<checkId>`.
+
+```shell
+terraform import azuredevops_check_rest_api.example 00000000-0000-0000-0000-000000000000/0
+```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
Added import support for all check resources. Since the check resources share a common file, instead of adding import support for just one resource, it is added to all the check resources instead.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Test Result
```
=== RUN   TestAccCheckApproval_basic
=== PAUSE TestAccCheckApproval_basic
=== RUN   TestAccCheckApproval_complete
=== PAUSE TestAccCheckApproval_complete
=== RUN   TestAccCheckApproval_update
=== PAUSE TestAccCheckApproval_update
=== RUN   TestAccCheckBranchControl_basic
=== PAUSE TestAccCheckBranchControl_basic
=== RUN   TestAccCheckBranchControl_complete
=== PAUSE TestAccCheckBranchControl_complete
=== RUN   TestAccCheckBranchControl_update
=== PAUSE TestAccCheckBranchControl_update
=== RUN   TestAccCheckBusinessHours_basic
=== PAUSE TestAccCheckBusinessHours_basic
=== RUN   TestAccCheckBusinessHours_complete
=== PAUSE TestAccCheckBusinessHours_complete
=== RUN   TestAccCheckBusinessHours_update
=== PAUSE TestAccCheckBusinessHours_update
=== RUN   TestAccCheckEndpoint
=== PAUSE TestAccCheckEndpoint
=== RUN   TestAccCheckEnvironment
=== PAUSE TestAccCheckEnvironment
=== RUN   TestAccCheckQueue
=== PAUSE TestAccCheckQueue
=== RUN   TestAccCheckRepo
=== PAUSE TestAccCheckRepo
=== RUN   TestAccCheckVariableGroup
=== PAUSE TestAccCheckVariableGroup
=== RUN   TestAccCheckExclusiveLock_basic
=== PAUSE TestAccCheckExclusiveLock_basic
=== RUN   TestAccCheckRequiredTemplate_basic
=== PAUSE TestAccCheckRequiredTemplate_basic
=== RUN   TestAccCheckRequiredTemplate_complete
=== PAUSE TestAccCheckRequiredTemplate_complete
=== RUN   TestAccCheckRequiredTemplate_update
=== PAUSE TestAccCheckRequiredTemplate_update
=== RUN   TestAccCheckRestAPI_basic
=== PAUSE TestAccCheckRestAPI_basic
=== RUN   TestAccCheckRestAPI_complete
=== PAUSE TestAccCheckRestAPI_complete
=== RUN   TestAccCheckRestAPI_update
=== PAUSE TestAccCheckRestAPI_update
=== CONT  TestAccCheckApproval_basic
=== CONT  TestAccCheckQueue
=== CONT  TestAccCheckBusinessHours_basic
=== CONT  TestAccCheckBranchControl_update
=== CONT  TestAccCheckEndpoint
=== CONT  TestAccCheckRequiredTemplate_basic
=== CONT  TestAccCheckExclusiveLock_basic
=== CONT  TestAccCheckVariableGroup
=== CONT  TestAccCheckRestAPI_update
=== CONT  TestAccCheckRestAPI_complete
=== CONT  TestAccCheckRepo
=== CONT  TestAccCheckRequiredTemplate_complete
--- PASS: TestAccCheckQueue (25.69s)
=== CONT  TestAccCheckRestAPI_basic
--- PASS: TestAccCheckRepo (37.98s)
=== CONT  TestAccCheckRequiredTemplate_update
--- PASS: TestAccCheckVariableGroup (39.31s)
=== CONT  TestAccCheckEnvironment
--- PASS: TestAccCheckRequiredTemplate_basic (45.95s)
=== CONT  TestAccCheckBranchControl_basic
--- PASS: TestAccCheckBranchControl_update (46.90s)
=== CONT  TestAccCheckBranchControl_complete
--- PASS: TestAccCheckEndpoint (54.17s)
=== CONT  TestAccCheckApproval_update
--- PASS: TestAccCheckRequiredTemplate_complete (54.62s)
=== CONT  TestAccCheckApproval_complete
--- PASS: TestAccCheckRestAPI_complete (59.59s)
=== CONT  TestAccCheckBusinessHours_update
--- PASS: TestAccCheckEnvironment (22.74s)
=== CONT  TestAccCheckBusinessHours_complete
--- PASS: TestAccCheckBusinessHours_basic (64.81s)
--- PASS: TestAccCheckExclusiveLock_basic (66.39s)
--- PASS: TestAccCheckApproval_basic (67.24s)
--- PASS: TestAccCheckRestAPI_basic (43.91s)
--- PASS: TestAccCheckRestAPI_update (71.91s)
--- PASS: TestAccCheckRequiredTemplate_update (45.90s)
--- PASS: TestAccCheckBranchControl_basic (43.82s)
--- PASS: TestAccCheckBranchControl_complete (43.40s)
--- PASS: TestAccCheckApproval_complete (46.18s)
--- PASS: TestAccCheckApproval_update (48.50s)
--- PASS: TestAccCheckBusinessHours_update (44.41s)
--- PASS: TestAccCheckBusinessHours_complete (43.35s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        105.420s
```

## Related Issue(s)

Fix #1557 

