### PR TITLE
`azuredevops_serviceendpoint` resources - Fix drift for user with reader permissions

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -2,9 +2,7 @@ package acceptancetests
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"regexp"
 	"strconv"
 	"testing"
@@ -214,16 +212,6 @@ func TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate(t *
 	serviceprincipalidSecond := uuid.New().String()
 	serviceEndpointAuthenticationScheme := "WorkloadIdentityFederation"
 
-	azureDevOpsOrgName := "terraform-provider-azuredevops"
-
-	if os.Getenv("AZDO_ORG_SERVICE_URL") != "" {
-		azureDevOpsOrgUrl, err := url.Parse(os.Getenv("AZDO_ORG_SERVICE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		azureDevOpsOrgName = path.Base(azureDevOpsOrgUrl.Path)
-	}
-
 	resourceType := "azuredevops_serviceendpoint_azurerm"
 	tfSvcEpNode := resourceType + ".serviceendpointrm"
 	resource.ParallelTest(t, resource.TestCase{
@@ -242,8 +230,8 @@ func TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate(t *
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "azurerm_subscription_name"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "credentials.0.serviceprincipalid", serviceprincipalidFirst),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_authentication_scheme", serviceEndpointAuthenticationScheme),
-					resource.TestMatchResourceAttr(tfSvcEpNode, "workload_identity_federation_issuer", regexp.MustCompile("^https://vstoken.dev.azure.com/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "workload_identity_federation_subject", fmt.Sprintf("sc://%s/%s/%s", azureDevOpsOrgName, projectName, serviceEndpointNameFirst)),
+					resource.TestMatchResourceAttr(tfSvcEpNode, "workload_identity_federation_issuer", regexp.MustCompile(`^https://(vstoken\.dev\.azure\.com|login\.microsoftonline\.com)/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}(/v2\.0)?$`)),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "workload_identity_federation_subject"),
 				),
 			}, {
 				Config: testutils.HclServiceEndpointAzureRMNoKeyResource(projectName, serviceEndpointNameSecond, serviceprincipalidSecond, serviceEndpointAuthenticationScheme),
@@ -256,8 +244,8 @@ func TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate(t *
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameSecond),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "credentials.0.serviceprincipalid", serviceprincipalidSecond),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_authentication_scheme", serviceEndpointAuthenticationScheme),
-					resource.TestMatchResourceAttr(tfSvcEpNode, "workload_identity_federation_issuer", regexp.MustCompile("^https://vstoken.dev.azure.com/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "workload_identity_federation_subject", fmt.Sprintf("sc://%s/%s/%s", azureDevOpsOrgName, projectName, serviceEndpointNameSecond)),
+					resource.TestMatchResourceAttr(tfSvcEpNode, "workload_identity_federation_issuer", regexp.MustCompile(`^https://(vstoken\.dev\.azure\.com|login\.microsoftonline\.com)/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}(/v2\.0)?$`)),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "workload_identity_federation_subject"),
 				),
 			},
 		},

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -218,11 +218,10 @@ func checkServiceEndpointStatus(clients *client.AggregatedClient, projectID *uui
 // 1) Service response 404
 // 2) Service response 200 but service endpoint is null
 // 3) Service response 200 but service endpoint is not null but ID is null
-func isServiceEndpointDeleted(d *schema.ResourceData, err error, serviceEndpoint *serviceendpoint.ServiceEndpoint, args *serviceendpoint.GetServiceEndpointDetailsArgs) (bool, error) {
+func isServiceEndpointDeleted(err error, serviceEndpoint *serviceendpoint.ServiceEndpoint, args *serviceendpoint.GetServiceEndpointDetailsArgs) (bool, error) {
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
-			d.SetId("")
 			return true, nil
 		}
 		return false, fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", args.EndpointId, args.Project, err)
@@ -230,7 +229,6 @@ func isServiceEndpointDeleted(d *schema.ResourceData, err error, serviceEndpoint
 
 	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
 		log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
-		d.SetId("")
 		return true, nil
 	}
 	return false, nil

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -72,7 +72,8 @@ func createServiceEndpoint(d *schema.ResourceData, clients *client.AggregatedCli
 		clients.Ctx,
 		serviceendpoint.CreateServiceEndpointArgs{
 			Endpoint: endpoint,
-		})
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating service endpoint in Azure DevOps: %+v", err)
 	}
@@ -105,7 +106,8 @@ func updateServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceen
 		serviceendpoint.UpdateServiceEndpointArgs{
 			Endpoint:   endpoint,
 			EndpointId: endpoint.Id,
-		})
+		},
+	)
 
 	return updatedServiceEndpoint, err
 }
@@ -119,7 +121,8 @@ func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *se
 				projectID.String(),
 			},
 			EndpointId: serviceEndpoint.Id,
-		}); err != nil {
+		},
+	); err != nil {
 		return fmt.Errorf("Delete service endpoint error %v", err)
 	}
 
@@ -199,12 +202,13 @@ func checkServiceEndpointStatus(clients *client.AggregatedClient, projectID *uui
 			serviceendpoint.GetServiceEndpointDetailsArgs{
 				Project:    converter.String(projectID.String()),
 				EndpointId: endPointID,
-			})
+			},
+		)
 		if err != nil {
 			return nil, opState.Failed, fmt.Errorf(errMsgServiceDelete, endPointID, *projectID, err)
 		}
 		if serviceEndpoint != nil && serviceEndpoint.OperationStatus != nil {
-			opStatus := (serviceEndpoint.OperationStatus).(map[string]interface{})["state"]
+			opStatus := serviceEndpoint.OperationStatus.(map[string]interface{})["state"]
 			if opStatus == opState.Failed {
 				return nil, opState.Failed, fmt.Errorf(errMsgServiceDelete, endPointID, *projectID, serviceEndpoint.OperationStatus)
 			}
@@ -213,8 +217,6 @@ func checkServiceEndpointStatus(clients *client.AggregatedClient, projectID *uui
 		return serviceendpoint.ServiceEndpoint{}, opState.Ready, nil
 	}
 }
-
-
 
 func getServiceEndpoint(client *client.AggregatedClient, serviceEndpointID *uuid.UUID, projectID *uuid.UUID) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
@@ -232,7 +234,7 @@ func getServiceEndpoint(client *client.AggregatedClient, serviceEndpointID *uuid
 		if *serviceEndpoint.IsReady {
 			return serviceEndpoint, opState.Ready, nil
 		} else if serviceEndpoint.OperationStatus != nil {
-			opStatus := (serviceEndpoint.OperationStatus).(map[string]interface{})["state"]
+			opStatus := serviceEndpoint.OperationStatus.(map[string]interface{})["state"]
 			if opStatus == opState.Failed {
 				return nil, opState.Failed, fmt.Errorf(errMsgServiceCreate, serviceEndpointID, *projectID, serviceEndpoint.OperationStatus)
 			}

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -218,24 +218,22 @@ func checkServiceEndpointStatus(clients *client.AggregatedClient, projectID *uui
 // 1) Service response 404
 // 2) Service response 200 but service endpoint is null
 // 3) Service response 200 but service endpoint is not null but ID is null
-// 4) Service response 200 but service endpoint is not null and ID is null but other data is null
-// 5) Service response 200 with state property? deleted = true/false or state = deleted/success/updating
-func isServiceEndpointDeleted(d *schema.ResourceData, err error, serviceEndpoint *serviceendpoint.ServiceEndpoint, args *serviceendpoint.GetServiceEndpointDetailsArgs) bool {
+func isServiceEndpointDeleted(d *schema.ResourceData, err error, serviceEndpoint *serviceendpoint.ServiceEndpoint, args *serviceendpoint.GetServiceEndpointDetailsArgs) (bool, error) {
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
 			d.SetId("")
-			return true
+			return true, nil
 		}
-		return false
+		return false, fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", args.EndpointId, args.Project, err)
 	}
 
 	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
 		log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
 		d.SetId("")
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 func getServiceEndpoint(client *client.AggregatedClient, serviceEndpointID *uuid.UUID, projectID *uuid.UUID) retry.StateRefreshFunc {
@@ -462,8 +460,4 @@ func checkServiceConnection(endpoint *serviceendpoint.ServiceEndpoint) error {
 		return fmt.Errorf("Service connection not fully returned, this appears to be a permission issue with PAT/SPN/identity etc.")
 	}
 	return nil
-}
-
-func isServiceEndpointPartiallyReturned(endpoint *serviceendpoint.ServiceEndpoint) bool {
-	return endpoint != nil && endpoint.Id != nil && (endpoint.Data == nil || endpoint.Type == nil)
 }

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -230,8 +230,7 @@ func isServiceEndpointDeleted(d *schema.ResourceData, err error, serviceEndpoint
 		return false
 	}
 
-	if serviceEndpoint == nil || serviceEndpoint.Id == nil ||
-		(serviceEndpoint.Id != nil && serviceEndpoint.Authorization == nil) {
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
 		log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
 		d.SetId("")
 		return true
@@ -463,4 +462,8 @@ func checkServiceConnection(endpoint *serviceendpoint.ServiceEndpoint) error {
 		return fmt.Errorf("Service connection not fully returned, this appears to be a permission issue with PAT/SPN/identity etc.")
 	}
 	return nil
+}
+
+func isServiceEndpointPartiallyReturned(endpoint *serviceendpoint.ServiceEndpoint) bool {
+	return endpoint != nil && endpoint.Id != nil && (endpoint.Data == nil || endpoint.Type == nil)
 }

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -214,25 +214,7 @@ func checkServiceEndpointStatus(clients *client.AggregatedClient, projectID *uui
 	}
 }
 
-// Check if the service endpoint has been deleted
-// 1) Service response 404
-// 2) Service response 200 but service endpoint is null
-// 3) Service response 200 but service endpoint is not null but ID is null
-func isServiceEndpointDeleted(err error, serviceEndpoint *serviceendpoint.ServiceEndpoint, args *serviceendpoint.GetServiceEndpointDetailsArgs) (bool, error) {
-	if err != nil {
-		if utils.ResponseWasNotFound(err) {
-			log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
-			return true, nil
-		}
-		return false, fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", args.EndpointId, args.Project, err)
-	}
 
-	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
-		log.Printf(" [INFO] Service endpoint not found. ID: (%v)", args.EndpointId)
-		return true, nil
-	}
-	return false, nil
-}
 
 func getServiceEndpoint(client *client.AggregatedClient, serviceEndpointID *uuid.UUID, projectID *uuid.UUID) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -110,16 +109,12 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointArgoCD(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -109,11 +110,15 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -116,8 +117,9 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointArgoCD(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_argocd.go
@@ -109,7 +109,10 @@ func resourceServiceEndpointArgoCDRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -109,11 +110,15 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -116,8 +117,9 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 
 	flattenServiceEndpointArtifactory(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -109,7 +109,10 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_artifactory.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -110,16 +109,12 @@ func resourceServiceEndpointArtifactoryRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 
 	flattenServiceEndpointArtifactory(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -109,16 +108,12 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 
 	return flattenServiceEndpointAws(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -115,8 +116,9 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 
 	return flattenServiceEndpointAws(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -108,7 +108,10 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_aws.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -108,11 +109,15 @@ func resourceServiceEndpointAwsRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azure_service_bus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azure_service_bus.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"context"
-	"log"
 	"maps"
 	"time"
 
@@ -77,9 +76,8 @@ func resourceServiceEndpointAzureServiceBusRead(ctx context.Context, d *schema.R
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 	flattenServiceEndpointAzureServiceBus(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azure_service_bus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azure_service_bus.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"context"
+	"log"
 	"maps"
 	"time"
 
@@ -76,8 +77,9 @@ func resourceServiceEndpointAzureServiceBusRead(ctx context.Context, d *schema.R
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return diag.FromErr(err)
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointAzureServiceBus(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -160,11 +161,15 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -161,16 +160,12 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointAzureCR(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -167,8 +168,9 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointAzureCR(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurecr.go
@@ -160,7 +160,10 @@ func resourceServiceEndpointAzureCRRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -79,16 +78,12 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointAzureDevOps(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -85,8 +86,9 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointAzureDevOps(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -78,11 +79,15 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azuredevops.go
@@ -78,7 +78,10 @@ func resourceServiceEndpointAzureDevOpsRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/migration"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
@@ -231,11 +232,15 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	d.Set("features", d.Get("features"))

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint/migration"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -213,7 +213,8 @@ func resourceServiceEndpointAzureRMCreate(d *schema.ResourceData, m interface{})
 						(*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String(),
 					},
 					EndpointId: resp.Id,
-				}); delErr != nil {
+				},
+			); delErr != nil {
 				return fmt.Errorf("Delete service endpoint error %v", delErr)
 			}
 			return err

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -231,7 +231,10 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -232,22 +231,14 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
-		d.SetId("")
-		return nil
-	}
 	d.Set("features", d.Get("features"))
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointAzureRM(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -244,8 +245,9 @@ func resourceServiceEndpointAzureRMRead(d *schema.ResourceData, m interface{}) e
 	}
 	d.Set("features", d.Get("features"))
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointAzureRM(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm_test.go
@@ -344,10 +344,11 @@ func TestServiceEndpointAzureRM_CreateWithValidate_DoesNotSwallowError(t *testin
 		returnedServiceEndpoint.IsReady = converter.Bool(true)
 		buildClient.
 			EXPECT().
-			GetServiceEndpointDetails(clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
-				Project:    converter.String(azurermRandomServiceEndpointAzureRMProjectID.String()),
-				EndpointId: resource.Id,
-			},
+			GetServiceEndpointDetails(
+				clients.Ctx, serviceendpoint.GetServiceEndpointDetailsArgs{
+					Project:    converter.String(azurermRandomServiceEndpointAzureRMProjectID.String()),
+					EndpointId: resource.Id,
+				},
 			).
 			Return(&returnedServiceEndpoint, nil).
 			Times(1)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/model"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
@@ -69,11 +70,15 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -69,7 +69,10 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
-	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/model"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -76,8 +77,9 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointBitBucket(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -70,16 +69,12 @@ func resourceServiceEndpointBitbucketRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointBitBucket(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -73,8 +74,9 @@ func resourceServiceEndpointBlackDuckRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointBlackDuck(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -66,11 +67,15 @@ func resourceServiceEndpointBlackDuckRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
@@ -66,7 +66,10 @@ func resourceServiceEndpointBlackDuckRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_black_duck.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -67,16 +66,12 @@ func resourceServiceEndpointBlackDuckRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointBlackDuck(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -93,16 +92,12 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointCheckMarxOneService(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -92,7 +92,10 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -92,11 +93,15 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_one.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -99,8 +100,9 @@ func resourceServiceEndpointCheckMarxOneServiceRead(d *schema.ResourceData, m in
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointCheckMarxOneService(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -85,16 +84,12 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointCheckMarxSAST(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -84,7 +84,10 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -91,8 +92,9 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointCheckMarxSAST(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sast.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -84,11 +85,15 @@ func resourceServiceEndpointCheckMarxSASTRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -97,16 +96,12 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointCheckMarxSCA(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -96,11 +97,15 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -96,7 +96,10 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_checkmarx_sca.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -103,8 +104,9 @@ func resourceServiceEndpointCheckMarxSCARead(d *schema.ResourceData, m interface
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointCheckMarxSCA(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -87,7 +87,10 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -94,8 +95,9 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointDockerRegistry(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -88,16 +87,12 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointDockerRegistry(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dockerregistry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -87,11 +88,15 @@ func resourceServiceEndpointDockerRegistryRead(d *schema.ResourceData, m interfa
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dynamic_lifecycle_services.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dynamic_lifecycle_services.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"context"
+	"log"
 	"maps"
 	"time"
 
@@ -94,8 +95,9 @@ func resourceServiceEndpointDynamicsLifecycleServicesRead(ctx context.Context, d
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return diag.FromErr(err)
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointDynamicsLifecycleServices(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dynamic_lifecycle_services.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_dynamic_lifecycle_services.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"context"
-	"log"
 	"maps"
 	"time"
 
@@ -95,9 +94,8 @@ func resourceServiceEndpointDynamicsLifecycleServicesRead(ctx context.Context, d
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 	flattenServiceEndpointDynamicsLifecycleServices(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -87,8 +88,9 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 
 	flattenServiceEndpointExternalTFS(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -80,7 +80,10 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -80,11 +81,15 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -81,16 +80,12 @@ func resourceServiceEndpointExternalTFSRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 
 	flattenServiceEndpointExternalTFS(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_externaltfs_test.go
@@ -55,7 +55,8 @@ func TestServiceEndpointExternalTFS_ExpandFlatten_Roundtrip(t *testing.T) {
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,
-		&externalTfsTestServiceEndpoint)
+		&externalTfsTestServiceEndpoint,
+	)
 
 	serviceEndpointAfterRoundTrip, err := expandServiceEndpointExternalTFS(resourceData)
 
@@ -74,7 +75,8 @@ func TestServiceEndpointExternalTFS_Create_DoesNotSwallowError(t *testing.T) {
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,
-		&externalTfsTestServiceEndpoint)
+		&externalTfsTestServiceEndpoint,
+	)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
@@ -99,7 +101,8 @@ func TestServiceEndpointExternalTFS_Read_DoesNotSwallowError(t *testing.T) {
 	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointExternalTFS(
 		resourceData,
-		&externalTfsTestServiceEndpoint)
+		&externalTfsTestServiceEndpoint,
+	)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
@@ -127,7 +130,8 @@ func TestServiceEndpointExternalTFS_Delete_DoesNotSwallowError(t *testing.T) {
 	resourceData.Set("project_id", (*externalTfsTestServiceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id.String())
 	flattenServiceEndpointExternalTFS(
 		resourceData,
-		&externalTfsTestServiceEndpoint)
+		&externalTfsTestServiceEndpoint,
+	)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}
@@ -159,7 +163,8 @@ func TestServiceEndpointExternalTFS_Update_DoesNotSwallowError(t *testing.T) {
 	configureExternalTfsAuthPersonal(resourceData)
 	flattenServiceEndpointExternalTFS(
 		resourceData,
-		&externalTfsTestServiceEndpoint)
+		&externalTfsTestServiceEndpoint,
+	)
 
 	buildClient := azdosdkmocks.NewMockServiceendpointClient(ctrl)
 	clients := &client.AggregatedClient{ServiceEndpointClient: buildClient, Ctx: context.Background()}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -93,8 +94,9 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGcp(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -87,16 +86,12 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointGcp(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -86,11 +87,15 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gcp_terraform.go
@@ -86,7 +86,10 @@ func resourceServiceEndpointGcpTerraformRead(d *schema.ResourceData, m interface
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -83,8 +84,9 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGeneric(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -76,11 +77,15 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -76,7 +76,10 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -77,16 +76,12 @@ func resourceServiceEndpointGenericRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointGeneric(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -81,7 +81,10 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -88,8 +89,9 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGenericGit(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -82,16 +81,12 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointGenericGit(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -81,11 +82,15 @@ func resourceServiceEndpointGenericGitRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -456,6 +457,12 @@ func resourceServiceEndpointGenericV2Read(ctx context.Context, d *schema.Resourc
 
 	if serviceEndpoint == nil {
 		d.SetId("")
+		return nil
+	}
+
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint (ID: %s) returned partial data — likely insufficient permissions. Preserving existing state.",
+			d.Id())
 		return nil
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_generic_v2.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -460,10 +459,8 @@ func resourceServiceEndpointGenericV2Read(ctx context.Context, d *schema.Resourc
 		return nil
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint (ID: %s) returned partial data — likely insufficient permissions. Preserving existing state.",
-			d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if serviceEndpoint.Name != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -91,7 +91,10 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -98,8 +99,9 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGitHub(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -91,11 +92,15 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -92,16 +91,12 @@ func resourceServiceEndpointGitHubRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointGitHub(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -96,7 +96,10 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -103,8 +104,9 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGitHubEnterprise(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -97,16 +96,12 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointGitHubEnterprise(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_github_enterprise.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -96,11 +97,15 @@ func resourceServiceEndpointGitHubEnterpriseRead(d *schema.ResourceData, m inter
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gitlab.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gitlab.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"context"
+	"log"
 	"maps"
 	"time"
 
@@ -80,8 +81,9 @@ func resourceServiceEndpointGitLabRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return diag.FromErr(err)
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointGitLab(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gitlab.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_gitlab.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"context"
-	"log"
 	"maps"
 	"time"
 
@@ -81,9 +80,8 @@ func resourceServiceEndpointGitLabRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 	flattenServiceEndpointGitLab(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -74,11 +75,15 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -75,16 +74,12 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointIncomingWebhook(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -81,8 +82,9 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointIncomingWebhook(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_incomingwebhook.go
@@ -74,7 +74,10 @@ func resourceServiceEndpointIncomingWebhookRead(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -84,16 +83,12 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointJenkins(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -83,7 +83,10 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -83,11 +84,15 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jenkins.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -90,8 +91,9 @@ func resourceServiceEndpointJenkinsRead(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointJenkins(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -110,16 +109,12 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -109,7 +109,10 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -116,8 +117,9 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_artifactory_v2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -109,11 +110,15 @@ func resourceServiceEndpointJFrogArtifactoryV2Read(d *schema.ResourceData, m int
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -107,7 +107,10 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -107,11 +108,15 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -108,16 +107,12 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_distribution_v2.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -114,8 +115,9 @@ func resourceServiceEndpointJFrogDistributionV2Read(d *schema.ResourceData, m in
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -115,8 +116,9 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -109,16 +108,12 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -108,7 +108,10 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_platform_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -108,11 +109,15 @@ func resourceServiceEndpointJFrogPlatformV2Read(d *schema.ResourceData, m interf
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -108,11 +109,15 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -108,7 +108,10 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -115,8 +116,9 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_jfrog_xray_v2.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -109,16 +108,12 @@ func resourceServiceEndpointJFrogXRayV2Read(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointArtifactoryV2(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"gopkg.in/yaml.v3"
@@ -197,11 +198,15 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
 
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -197,7 +197,10 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
 
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"strings"
@@ -198,16 +197,12 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
 
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 
 	doBaseFlattening(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -197,7 +197,6 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			d.SetId("")

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_kubernetes.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"strings"
@@ -204,8 +205,9 @@ func resourceServiceEndpointKubernetesRead(d *schema.ResourceData, m interface{}
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 
 	doBaseFlattening(d, serviceEndpoint)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -116,11 +117,15 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -123,8 +124,9 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointMaven(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -117,16 +116,12 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointMaven(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_maven.go
@@ -116,7 +116,10 @@ func resourceServiceEndpointMavenRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -80,8 +81,9 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointNexus(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -74,16 +73,12 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointNexus(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -73,7 +73,10 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nexus.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
@@ -73,11 +74,15 @@ func resourceServiceEndpointNexusRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -70,11 +71,15 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -71,16 +70,12 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointNpm(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -70,7 +70,10 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_npm.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -77,8 +78,9 @@ func resourceServiceEndpointNpmRead(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointNpm(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -93,7 +93,10 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -94,16 +93,12 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointNuGet(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -100,8 +101,9 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointNuGet(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_nuget.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -93,11 +94,15 @@ func resourceServiceEndpointNuGetRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -74,16 +73,12 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointOctopusDeploy(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -80,8 +81,9 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointOctopusDeploy(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -73,7 +73,10 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_octopus_deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -73,11 +74,15 @@ func resourceServiceEndpointOctopusDeployRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"context"
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"strings"
@@ -132,16 +131,15 @@ func resourceServiceEndpointOpenshiftRead(ctx context.Context, d *schema.Resourc
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		return nil
-	}
-	if err != nil {
-		return diag.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 	if err := flattenServiceEndpointOpenshift(d, serviceEndpoint); err != nil {
 		return diag.Errorf(" Flattening service endpoint configuration: %+v", err)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"context"
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"strings"
@@ -138,8 +139,9 @@ func resourceServiceEndpointOpenshiftRead(ctx context.Context, d *schema.Resourc
 		return diag.Errorf(" looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return diag.Errorf(" Checking service connection permissions: %v", err)
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	if err := flattenServiceEndpointOpenshift(d, serviceEndpoint); err != nil {
 		return diag.Errorf(" Flattening service endpoint configuration: %+v", err)

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -131,14 +132,15 @@ func resourceServiceEndpointOpenshiftRead(ctx context.Context, d *schema.Resourc
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		return nil
+		return diag.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return diag.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_openshift.go
@@ -131,7 +131,10 @@ func resourceServiceEndpointOpenshiftRead(ctx context.Context, d *schema.Resourc
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -80,11 +81,15 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -87,8 +88,9 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointRunPipeline(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -81,16 +80,12 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointRunPipeline(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_runpipeline.go
@@ -80,7 +80,10 @@ func resourceServiceEndpointRunPipelineRead(d *schema.ResourceData, m interface{
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -182,11 +183,15 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -182,7 +182,10 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -183,16 +182,12 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointServiceFabric(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_servicefabric.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -189,8 +190,9 @@ func resourceServiceEndpointServiceFabricRead(d *schema.ResourceData, m interfac
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointServiceFabric(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -73,8 +74,9 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointSnyk(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -66,11 +67,15 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -67,16 +66,12 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointSnyk(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_snyk.go
@@ -66,7 +66,10 @@ func resourceServiceEndpointSnykRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -63,16 +62,12 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointSonarCloud(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -62,7 +62,10 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -69,8 +70,9 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointSonarCloud(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarcloud.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -62,11 +63,15 @@ func resourceServiceEndpointSonarCloudRead(d *schema.ResourceData, m interface{}
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -70,11 +71,15 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if serviceEndpoint.Id == nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -70,7 +70,10 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -71,11 +70,8 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
 	if serviceEndpoint.Id == nil {
@@ -83,9 +79,8 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 		return nil
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	flattenServiceEndpointSonarQube(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_sonarqube.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"time"
 
@@ -82,8 +83,9 @@ func resourceServiceEndpointSonarQubeRead(d *schema.ResourceData, m interface{})
 		return nil
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointSonarQube(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
@@ -88,11 +89,15 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
-		if deleted {
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
+			return nil
 		}
-		return err
+		return fmt.Errorf("looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
+	}
+	if serviceEndpoint == nil || serviceEndpoint.Id == nil {
+		return fmt.Errorf("unexpected nil service endpoint, ID: (%v), project ID: (%v)", getArgs.EndpointId, getArgs.Project)
 	}
 
 	if err = checkServiceConnection(serviceEndpoint); err != nil {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -2,6 +2,7 @@ package serviceendpoint
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -95,8 +96,9 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return err
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	return flattenServiceEndpointSSH(d, serviceEndpoint)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -88,7 +88,10 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+	if deleted, err := isServiceEndpointDeleted(err, serviceEndpoint, getArgs); deleted || err != nil {
+		if deleted {
+			d.SetId("")
+		}
 		return err
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_ssh.go
@@ -2,7 +2,6 @@ package serviceendpoint
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"strconv"
 	"time"
@@ -89,16 +88,12 @@ func resourceServiceEndpointSSHRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	serviceEndpoint, err := clients.ServiceEndpointClient.GetServiceEndpointDetails(clients.Ctx, *getArgs)
-	if isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("looking up service endpoint given ID (%s) and project ID (%s): %v", getArgs.EndpointId, *getArgs.Project, err)
+	if deleted, err := isServiceEndpointDeleted(d, err, serviceEndpoint, getArgs); deleted || err != nil {
+		return err
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return err
 	}
 	return flattenServiceEndpointSSH(d, serviceEndpoint)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_visualstudiomarketplace.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_visualstudiomarketplace.go
@@ -3,7 +3,6 @@ package serviceendpoint
 import (
 	"context"
 	"errors"
-	"log"
 	"maps"
 	"strings"
 	"time"
@@ -113,9 +112,8 @@ func resourceServiceEndpointMarketplaceRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
-		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
-		return nil
+	if err = checkServiceConnection(serviceEndpoint); err != nil {
+		return diag.FromErr(err)
 	}
 	flattenServiceEndpointMarketplace(d, serviceEndpoint)
 	return nil

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_visualstudiomarketplace.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_visualstudiomarketplace.go
@@ -3,6 +3,7 @@ package serviceendpoint
 import (
 	"context"
 	"errors"
+	"log"
 	"maps"
 	"strings"
 	"time"
@@ -112,8 +113,9 @@ func resourceServiceEndpointMarketplaceRead(ctx context.Context, d *schema.Resou
 		return diag.Errorf(" looking up service endpoint given ID (%v) and project ID (%v): %v", getArgs.EndpointId, getArgs.Project, err)
 	}
 
-	if err = checkServiceConnection(serviceEndpoint); err != nil {
-		return diag.FromErr(err)
+	if isServiceEndpointPartiallyReturned(serviceEndpoint) {
+		log.Printf("[WARN] Service endpoint %s returned partial data, likely due to insufficient permissions. Preserving existing state.", d.Id())
+		return nil
 	}
 	flattenServiceEndpointMarketplace(d, serviceEndpoint)
 	return nil


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
This fix aims to fix all the `azuredevops_servicepoint` resources, where a user with reader permissions will encounter drift when running `terraform plan`. The current implementation exits early due to a missing authorization field when a user only has reader permissions, which causes the drift. 


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result

1 test failed, but I don't believe it's related to this change.

<pre>
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_Create_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_Create_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_azureStack
=== PAUSE TestAccServiceEndpointAzureRm_azureStack
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_Create_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_azureStack
=== CONT  TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== NAME  TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
    resource_serviceendpoint_azurerm_test.go:229: Step 1/2 error: Check failed: Check 9/10 error: azuredevops_serviceendpoint_azurerm.serviceendpointrm: Attribute 'workload_identity_federation_issuer' didn't match "^https://vstoken.dev.azure.com/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$", got "https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2.0"
--- FAIL: TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate (54.31s)
--- PASS: TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate (54.81s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate (55.62s)
--- PASS: TestAccServiceEndpointAzureRm_azureStack (64.84s)
--- PASS: TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate (65.14s)
--- PASS: TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate (65.66s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate (66.02s)
--- PASS: TestAccServiceEndpointAzureRm_Create_WithValidate (104.00s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate (115.09s)
FAIL
FAIL    github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        115.103s
FAIL
</pre>

## Related Issue(s)

Fix #1445
