### PR TITLE
Add custom states to work item type

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -94,6 +94,96 @@ func TestAccWorkitemtrackingprocessWorkItemType_CreateAndUpdate(t *testing.T) {
 	})
 }
 
+func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
+	workItemTypeName := testutils.GenerateWorkItemTypeName()
+	processName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_workitemtrackingprocess_workitemtype.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProcessDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: workItemTypeWithStates(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "state.#", "2"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getWorkItemTypeStateIdFunc(tfNode),
+			},
+			{
+				Config: workItemTypeWithStatesUpdated(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getWorkItemTypeStateIdFunc(tfNode),
+			},
+		},
+	})
+}
+
+func workItemTypeWithStates(name, processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name       = "%s"
+  process_id = azuredevops_workitemtrackingprocess_process.test.id
+
+  state {
+    name           = "Active 2"
+    color          = "#ff9d00"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "Closed 2"
+    color          = "#339933"
+    state_category = "Completed"
+  }
+}
+`, process(processName), name)
+}
+
+func workItemTypeWithStatesUpdated(name, processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name       = "%s"
+  process_id = azuredevops_workitemtrackingprocess_process.test.id
+
+  state {
+    name           = "New"
+    color          = "#3544ca"
+    state_category = "Proposed"
+  }
+
+  state {
+    name           = "Active 2"
+    color          = "#020100"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "Closed 3"
+    color          = "#339933"
+    state_category = "Completed"
+  }
+}
+`, process(processName), name)
+}
+
 func basicWorkItemType(name string, processName string) string {
 	process := process(processName)
 	return fmt.Sprintf(`

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -287,7 +287,7 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
     color          = "#3544ca"
     state_category = "Proposed"
   }
-  
+
   state {
     name           = "New Active"
     color          = "#ff9d01"
@@ -322,7 +322,7 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
     color          = "#3544ca"
     state_category = "Proposed"
   }
-  
+
   state {
     name           = "Active Order"
     color          = "#020100"

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -165,6 +165,43 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 	})
 }
 
+func TestAccWorkitemtrackingprocessWorkItemType_Inherited(t *testing.T) {
+	processName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_workitemtrackingprocess_workitemtype.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProcessDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: inheritedWorkItemType(processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "reference_name"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getWorkItemTypeStateIdFunc(tfNode),
+			},
+		},
+	})
+}
+
+func inheritedWorkItemType(processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name                            = "Bug"
+  process_id                      = azuredevops_workitemtrackingprocess_process.test.id
+  parent_work_item_reference_name = "Microsoft.VSTS.WorkItemTypes.Bug"
+}
+`, process(processName))
+}
+
 func TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited(t *testing.T) {
 	workItemTypeName := testutils.GenerateWorkItemTypeName()
 	processName := testutils.GenerateResourceName()

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -107,7 +107,7 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 			{
 				Config: workItemTypeWithStates(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
+					resource.TestCheckResourceAttr(tfNode, "state.#", "2"),
 				),
 			},
 			{
@@ -118,6 +118,18 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 			},
 			{
 				Config: workItemTypeWithStatesUpdated(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "state.#", "4"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getWorkItemTypeStateIdFunc(tfNode),
+			},
+			{
+				Config: workItemTypeWithStatesChangingOrder(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "state.#", "4"),
 				),
@@ -192,19 +204,13 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
   process_id = azuredevops_workitemtrackingprocess_process.test.id
 
   state {
-    name           = "Active 2"
-    color          = "#ff9d00"
-    state_category = "InProgress"
-  }
-
-  state {
-    name           = "Active 3"
+    name           = "New Active"
     color          = "#ff9d01"
     state_category = "InProgress"
   }
 
   state {
-    name           = "Closed 2"
+    name           = "New Closed"
     color          = "#339933"
     state_category = "Completed"
   }
@@ -224,28 +230,59 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
     name           = "New"
     color          = "#3544ca"
     state_category = "Proposed"
-	order          = 1
+  }
+  
+  state {
+    name           = "New Active"
+    color          = "#ff9d01"
+    state_category = "InProgress"
   }
 
   state {
-    name           = "Active 3"
+    name           = "Active Order"
     color          = "#020100"
     state_category = "InProgress"
-	order          = 2
   }
 
   state {
-    name           = "Active 2"
-    color          = "#020100"
-    state_category = "InProgress"
-	order          = 3
-  }
-
-  state {
-    name           = "Closed 3"
+    name           = "New Closed"
     color          = "#339933"
     state_category = "Completed"
-	order          = 4
+  }
+}
+`, process(processName), name)
+}
+
+func workItemTypeWithStatesChangingOrder(name, processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name       = "%s"
+  process_id = azuredevops_workitemtrackingprocess_process.test.id
+
+  state {
+    name           = "New"
+    color          = "#3544ca"
+    state_category = "Proposed"
+  }
+  
+  state {
+    name           = "Active Order"
+    color          = "#020100"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "New Active"
+    color          = "#ff9d01"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "New Closed"
+    color          = "#339933"
+    state_category = "Completed"
   }
 }
 `, process(processName), name)

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -132,6 +132,57 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 	})
 }
 
+// Azure DevOps rejects any Update against a Completed state (VS403093) even
+// when the payload is identical, so the sync must skip those calls.
+func TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges(t *testing.T) {
+	workItemTypeName := testutils.GenerateWorkItemTypeName()
+	processName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_workitemtrackingprocess_workitemtype.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProcessDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: workItemTypeStatesWithNoChanges(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func workItemTypeStatesWithNoChanges(name, processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name       = "%s"
+  process_id = azuredevops_workitemtrackingprocess_process.test.id
+
+  state {
+    name           = "New"
+    color          = "#3544ca"
+    state_category = "Proposed"
+  }
+
+  state {
+    name           = "Active"
+    color          = "#ff9d00"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "Closed"
+    color          = "#339933"
+    state_category = "Completed"
+  }
+}
+`, process(processName), name)
+}
+
 func workItemTypeWithStates(name, processName string) string {
 	return fmt.Sprintf(`
 %s

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -107,7 +107,7 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 			{
 				Config: workItemTypeWithStates(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(tfNode, "state.#", "2"),
+					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
 				),
 			},
 			{
@@ -119,7 +119,7 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 			{
 				Config: workItemTypeWithStatesUpdated(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
+					resource.TestCheckResourceAttr(tfNode, "state.#", "4"),
 				),
 			},
 			{
@@ -198,6 +198,12 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
   }
 
   state {
+    name           = "Active 3"
+    color          = "#ff9d01"
+    state_category = "InProgress"
+  }
+
+  state {
     name           = "Closed 2"
     color          = "#339933"
     state_category = "Completed"
@@ -218,18 +224,28 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
     name           = "New"
     color          = "#3544ca"
     state_category = "Proposed"
+	order          = 1
+  }
+
+  state {
+    name           = "Active 3"
+    color          = "#020100"
+    state_category = "InProgress"
+	order          = 2
   }
 
   state {
     name           = "Active 2"
     color          = "#020100"
     state_category = "InProgress"
+	order          = 3
   }
 
   state {
     name           = "Closed 3"
     color          = "#339933"
     state_category = "Completed"
+	order          = 4
   }
 }
 `, process(processName), name)

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -200,6 +200,32 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
 `, process(processName), name)
 }
 
+func TestAccWorkitemtrackingprocessWorkItemType_StatesRemovedFromConfig(t *testing.T) {
+	workItemTypeName := testutils.GenerateWorkItemTypeName()
+	processName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_workitemtrackingprocess_workitemtype.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProcessDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: workItemTypeStatesWithNoChanges(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "state.#", "3"),
+				),
+			},
+			{
+				Config: basicWorkItemType(workItemTypeName, processName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "reference_name"),
+				),
+			},
+		},
+	})
+}
+
 // Azure DevOps rejects any Update against a Completed state (VS403093) even
 // when the payload is identical, so the sync must skip those calls.
 func TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges(t *testing.T) {

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -108,6 +108,10 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 				Config: workItemTypeWithStates(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "state.#", "2"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.name", "New Active"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.order", "1"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.name", "New Closed"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.order", "2"),
 				),
 			},
 			{
@@ -120,6 +124,14 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 				Config: workItemTypeWithStatesUpdated(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "state.#", "4"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.name", "New"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.order", "1"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.name", "New Active"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.order", "2"),
+					resource.TestCheckResourceAttr(tfNode, "state.2.name", "Active Order"),
+					resource.TestCheckResourceAttr(tfNode, "state.2.order", "3"),
+					resource.TestCheckResourceAttr(tfNode, "state.3.name", "New Closed"),
+					resource.TestCheckResourceAttr(tfNode, "state.3.order", "4"),
 				),
 			},
 			{
@@ -132,6 +144,14 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 				Config: workItemTypeWithStatesChangingOrder(workItemTypeName, processName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tfNode, "state.#", "4"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.name", "New"),
+					resource.TestCheckResourceAttr(tfNode, "state.0.order", "1"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.name", "Active Order"),
+					resource.TestCheckResourceAttr(tfNode, "state.1.order", "2"),
+					resource.TestCheckResourceAttr(tfNode, "state.2.name", "New Active"),
+					resource.TestCheckResourceAttr(tfNode, "state.2.order", "3"),
+					resource.TestCheckResourceAttr(tfNode, "state.3.name", "New Closed"),
+					resource.TestCheckResourceAttr(tfNode, "state.3.order", "4"),
 				),
 			},
 			{

--- a/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
+++ b/azuredevops/internal/acceptancetests/resource_workitemtrackingprocess_workitemtype_test.go
@@ -2,6 +2,7 @@ package acceptancetests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -162,6 +163,41 @@ func TestAccWorkitemtrackingprocessWorkItemType_States(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited(t *testing.T) {
+	workItemTypeName := testutils.GenerateWorkItemTypeName()
+	processName := testutils.GenerateResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.GetProviderFactories(),
+		CheckDestroy:      testutils.CheckProcessDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config:      workItemTypeWithStatesAndParent(workItemTypeName, processName),
+				ExpectError: regexp.MustCompile(`state.*blocks are only valid on non-inherited work item types`),
+			},
+		},
+	})
+}
+
+func workItemTypeWithStatesAndParent(name, processName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_workitemtrackingprocess_workitemtype" "test" {
+  name                            = "%s"
+  process_id                      = azuredevops_workitemtrackingprocess_process.test.id
+  parent_work_item_reference_name = "Microsoft.VSTS.WorkItemTypes.Bug"
+
+  state {
+    name           = "Custom"
+    color          = "#3544ca"
+    state_category = "Proposed"
+  }
+}
+`, process(processName), name)
 }
 
 // Azure DevOps rejects any Update against a Completed state (VS403093) even

--- a/azuredevops/internal/service/workitemtrackingprocess/order.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/order.go
@@ -1,6 +1,7 @@
 package workitemtrackingprocess
 
 import (
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-cty/cty/gocty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -13,6 +14,31 @@ func getOrder(d *schema.ResourceData) (*int, error) {
 	}
 
 	order := rawPlan.GetAttr("order")
+	if !order.IsKnown() || order.IsNull() {
+		return nil, nil
+	}
+
+	var val int
+	if err := gocty.FromCtyValue(order, &val); err != nil {
+		return nil, err
+	}
+	return &val, nil
+}
+
+// getOrderFromAttribute returns order on the i-th block of a list-shaped
+// schema attribute if there is one defined, otherwise nil.
+func getOrderFromAttribute(d *schema.ResourceData, attrName string, i int) (*int, error) {
+	rawPlan := d.GetRawPlan()
+	if !rawPlan.IsKnown() || rawPlan.IsNull() {
+		return nil, nil
+	}
+
+	attr := rawPlan.GetAttr(attrName)
+	if !attr.IsKnown() || attr.IsNull() || i >= attr.LengthInt() {
+		return nil, nil
+	}
+
+	order := attr.Index(cty.NumberIntVal(int64(i))).GetAttr("order")
 	if !order.IsKnown() || order.IsNull() {
 		return nil, nil
 	}

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -99,6 +99,7 @@ func ResourceWorkItemType() *schema.Resource {
 			"state": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Description: "Custom states for the work item type. This is mutually exclusive with `azuredevops_workitemtrackingprocess_state`. Only valid for non-inherited work item types (i.e. `parent_work_item_reference_name` is not set).",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -346,10 +347,6 @@ func readResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any
 		return diags
 	}
 
-	// Only handle custom states if at least one state block has been declared
-	if !hasStateBlocks(d) {
-		return nil
-	}
 	return readWorkItemTypeStates(ctx, clients, d, processId, referenceName)
 }
 

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -366,6 +366,10 @@ func readResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any
 		return diags
 	}
 
+	// Inherited work item types inherit states, which this resource does not handle
+	if workItemType.Inherits != nil && *workItemType.Inherits != "" {
+		return nil
+	}
 	return readWorkItemTypeStates(ctx, clients, d, processId, referenceName)
 }
 

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -2,6 +2,7 @@ package workitemtrackingprocess
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
@@ -40,6 +41,15 @@ func ResourceWorkItemType() *schema.Resource {
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m any) error {
+			if len(d.Get("state").([]any)) == 0 {
+				return nil
+			}
+			if v, ok := d.GetOk("parent_work_item_reference_name"); ok && v.(string) != "" {
+				return fmt.Errorf("`state` blocks are only valid on non-inherited work item types; remove `parent_work_item_reference_name` or remove the `state` block(s)")
+			}
+			return nil
 		},
 		Schema: map[string]*schema.Schema{
 			"process_id": {

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -256,7 +257,74 @@ func readResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any
 		return diag.Errorf(" Getting work item type with reference name: %s for process with id %s. Error: %+v", referenceName, processId, err)
 	}
 
-	return flattenWorkItemType(d, workItemType)
+	if diags := flattenWorkItemType(d, workItemType); diags.HasError() {
+		return diags
+	}
+
+	// Only handle custom states if at least one state block has been declared
+	if !hasStateBlocks(d) {
+		return nil
+	}
+	return readWorkItemTypeStates(ctx, clients, d, processId, referenceName)
+}
+
+// hasStateBlocks reports whether at least one `state` block exists in either
+// the resource's config or its prior state.
+func hasStateBlocks(d *schema.ResourceData) bool {
+	return hasStateAttr(d.GetRawConfig()) || hasStateAttr(d.GetRawState())
+}
+
+func hasStateAttr(v cty.Value) bool {
+	if v.IsNull() || !v.IsKnown() || !v.Type().IsObjectType() || !v.Type().HasAttribute("state") {
+		return false
+	}
+	states := v.GetAttr("state")
+	if states.IsNull() || !states.IsKnown() {
+		return false
+	}
+	return states.LengthInt() > 0
+}
+
+func readWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClient, d *schema.ResourceData, processId, witRefName string) diag.Diagnostics {
+	args := workitemtrackingprocess.GetStateDefinitionsArgs{
+		ProcessId:  converter.UUID(processId),
+		WitRefName: &witRefName,
+	}
+	states, err := clients.WorkItemTrackingProcessClient.GetStateDefinitions(ctx, args)
+	if err != nil {
+		return diag.Errorf("getting states for work item type %s: %+v", witRefName, err)
+	}
+	if states == nil {
+		return nil
+	}
+
+	flat := make([]map[string]any, 0, len(*states))
+	for _, s := range *states {
+		entry := map[string]any{}
+		if s.Id != nil {
+			entry["id"] = s.Id.String()
+		}
+		if s.Name != nil {
+			entry["name"] = *s.Name
+		}
+		if s.Color != nil {
+			entry["color"] = convertColorToResource(*s.Color)
+		}
+		if s.StateCategory != nil {
+			entry["state_category"] = *s.StateCategory
+		}
+		if s.Order != nil {
+			entry["order"] = *s.Order
+		}
+		if s.Url != nil {
+			entry["url"] = *s.Url
+		}
+		flat = append(flat, entry)
+	}
+	if err := d.Set("state", flat); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 func updateResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -376,21 +375,8 @@ func stateChanged(current workitemtrackingprocess.WorkItemStateResultModel, desi
 	return false
 }
 
-// hasStateBlocks reports whether at least one `state` block exists in either
-// the resource's config or its prior state.
 func hasStateBlocks(d *schema.ResourceData) bool {
-	return hasStateAttr(d.GetRawConfig()) || hasStateAttr(d.GetRawState())
-}
-
-func hasStateAttr(v cty.Value) bool {
-	if v.IsNull() || !v.IsKnown() || !v.Type().IsObjectType() || !v.Type().HasAttribute("state") {
-		return false
-	}
-	states := v.GetAttr("state")
-	if states.IsNull() || !states.IsKnown() {
-		return false
-	}
-	return states.LengthInt() > 0
+	return len(d.Get("state").([]any)) > 0
 }
 
 func readWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClient, d *schema.ResourceData, processId, witRefName string) diag.Diagnostics {

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -3,6 +3,8 @@ package workitemtrackingprocess
 import (
 	"context"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -233,8 +235,91 @@ func createResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m a
 	}
 	d.SetId(*createdWorkItemType.ReferenceName)
 
+	processId := d.Get("process_id").(string)
+	referenceName := *createdWorkItemType.ReferenceName
+	if hasStateBlocks(d) {
+		if diags := syncWorkItemTypeStates(ctx, clients, d, processId, referenceName); diags.HasError() {
+			return diags
+		}
+	}
+
 	// The POST operation doesn't support layout expand, so we have to call read and risk eventual consistency problems
 	return readResourceWorkItemType(ctx, d, m)
+}
+
+// syncWorkItemTypeStates reconciles the work item type's states with the
+// `state` blocks declared in config. Deletes are performed last to avoid
+// at-least-one constraints
+func syncWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClient, d *schema.ResourceData, processId, witRefName string) diag.Diagnostics {
+	existing, err := clients.WorkItemTrackingProcessClient.GetStateDefinitions(ctx, workitemtrackingprocess.GetStateDefinitionsArgs{
+		ProcessId:  converter.UUID(processId),
+		WitRefName: &witRefName,
+	})
+	if err != nil {
+		return diag.Errorf("listing existing states for work item type %s: %+v", witRefName, err)
+	}
+	var remaining []workitemtrackingprocess.WorkItemStateResultModel
+	if existing != nil {
+		remaining = *existing
+	}
+
+	for _, raw := range d.Get("state").([]any) {
+		s := raw.(map[string]any)
+		name := s["name"].(string)
+		model := workitemtrackingprocess.WorkItemStateInputModel{
+			Name:          &name,
+			Color:         converter.String(strings.TrimPrefix(s["color"].(string), "#")),
+			StateCategory: converter.String(s["state_category"].(string)),
+		}
+
+		desiredOrder, hasOrder := 0, false
+		if v, ok := s["order"].(int); ok && v != 0 {
+			desiredOrder, hasOrder = v, true
+		}
+
+		if hasOrder {
+			model.Order = &desiredOrder
+		}
+
+		matchIdx := slices.IndexFunc(remaining, func(e workitemtrackingprocess.WorkItemStateResultModel) bool {
+			return e.Name != nil && *e.Name == name
+		})
+		if matchIdx < 0 {
+			if _, err := clients.WorkItemTrackingProcessClient.CreateStateDefinition(ctx, workitemtrackingprocess.CreateStateDefinitionArgs{
+				ProcessId:  converter.UUID(processId),
+				WitRefName: &witRefName,
+				StateModel: &model,
+			}); err != nil {
+				return diag.Errorf("creating state %s: %+v", name, err)
+			}
+			continue
+		}
+
+		current := remaining[matchIdx]
+		remaining = slices.Delete(remaining, matchIdx, matchIdx+1)
+		if _, err := clients.WorkItemTrackingProcessClient.UpdateStateDefinition(ctx, workitemtrackingprocess.UpdateStateDefinitionArgs{
+			ProcessId:  converter.UUID(processId),
+			WitRefName: &witRefName,
+			StateId:    current.Id,
+			StateModel: &model,
+		}); err != nil {
+			return diag.Errorf("updating state %s: %+v", name, err)
+		}
+	}
+
+	for _, s := range remaining {
+		if s.Id == nil {
+			continue
+		}
+		if err := clients.WorkItemTrackingProcessClient.DeleteStateDefinition(ctx, workitemtrackingprocess.DeleteStateDefinitionArgs{
+			ProcessId:  converter.UUID(processId),
+			WitRefName: &witRefName,
+			StateId:    s.Id,
+		}); err != nil {
+			return diag.Errorf("deleting state %s: %+v", *s.Name, err)
+		}
+	}
+	return nil
 }
 
 func readResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -351,6 +436,12 @@ func updateResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m a
 	_, err := clients.WorkItemTrackingProcessClient.UpdateProcessWorkItemType(ctx, args)
 	if err != nil {
 		return diag.Errorf(" Update work item type. Error %+v", err)
+	}
+
+	if hasStateBlocks(d) {
+		if diags := syncWorkItemTypeStates(ctx, clients, d, processId, referenceName); diags.HasError() {
+			return diags
+		}
 	}
 
 	// The PATCH operation doesn't support layout expand, so we have to call read and risk eventual consistency problems

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -298,6 +298,13 @@ func syncWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClien
 
 		current := remaining[matchIdx]
 		remaining = slices.Delete(remaining, matchIdx, matchIdx+1)
+
+		// States in Completed category cannot be changed, so we explicitly
+		// ignore calling update on any state that has no changes. If it has change,
+		// let the downstream API respond with any errors accordingly
+		if !stateChanged(current, model) {
+			continue
+		}
 		if _, err := clients.WorkItemTrackingProcessClient.UpdateStateDefinition(ctx, workitemtrackingprocess.UpdateStateDefinitionArgs{
 			ProcessId:  converter.UUID(processId),
 			WitRefName: &witRefName,
@@ -348,6 +355,19 @@ func readResourceWorkItemType(ctx context.Context, d *schema.ResourceData, m any
 	}
 
 	return readWorkItemTypeStates(ctx, clients, d, processId, referenceName)
+}
+
+func stateChanged(current workitemtrackingprocess.WorkItemStateResultModel, desired workitemtrackingprocess.WorkItemStateInputModel) bool {
+	if desired.Color != nil && (current.Color == nil || *current.Color != *desired.Color) {
+		return true
+	}
+	if desired.StateCategory != nil && (current.StateCategory == nil || *current.StateCategory != *desired.StateCategory) {
+		return true
+	}
+	if desired.Order != nil && (current.Order == nil || *current.Order != *desired.Order) {
+		return true
+	}
+	return false
 }
 
 // hasStateBlocks reports whether at least one `state` block exists in either

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -93,6 +93,49 @@ func ResourceWorkItemType() *schema.Resource {
 				Computed:    true,
 				Description: "Url of the work item type.",
 			},
+			"state": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Custom states for the work item type. This is mutually exclusive with `azuredevops_workitemtrackingprocess_state`. Only valid for non-inherited work item types (i.e. `parent_work_item_reference_name` is not set).",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID of the state.",
+						},
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+							Description:      "Name of the state.",
+						},
+						"color": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`^#[0-9a-fA-F]{6}$`), "Must be a hexadecimal color code, i.e. #b2b2b2")),
+							Description:      "Color hexadecimal code to represent the state.",
+						},
+						"state_category": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"Proposed", "InProgress", "Resolved", "Completed", "Removed"}, false)),
+							Description:      "Category of the state. Valid values: Proposed, InProgress, Resolved, Completed, Removed.",
+						},
+						"order": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "Order within the category where the state should appear.",
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "URL of the state.",
+						},
+					},
+				},
+			},
 			"pages": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -264,7 +264,7 @@ func syncWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClien
 		remaining = *existing
 	}
 
-	for _, raw := range d.Get("state").([]any) {
+	for i, raw := range d.Get("state").([]any) {
 		s := raw.(map[string]any)
 		name := s["name"].(string)
 		model := workitemtrackingprocess.WorkItemStateInputModel{
@@ -273,14 +273,11 @@ func syncWorkItemTypeStates(ctx context.Context, clients *client.AggregatedClien
 			StateCategory: converter.String(s["state_category"].(string)),
 		}
 
-		desiredOrder, hasOrder := 0, false
-		if v, ok := s["order"].(int); ok && v != 0 {
-			desiredOrder, hasOrder = v, true
+		orderPtr, err := getOrderFromAttribute(d, "state", i)
+		if err != nil {
+			return diag.FromErr(err)
 		}
-
-		if hasOrder {
-			model.Order = &desiredOrder
-		}
+		model.Order = orderPtr
 
 		matchIdx := slices.IndexFunc(remaining, func(e workitemtrackingprocess.WorkItemStateResultModel) bool {
 			return e.Name != nil && *e.Name == name

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -128,9 +128,8 @@ func ResourceWorkItemType() *schema.Resource {
 						},
 						"order": {
 							Type:        schema.TypeInt,
-							Optional:    true,
 							Computed:    true,
-							Description: "Order within the category where the state should appear.",
+							Description: "Order within the category where the state should appear. Specified by the order the state blocks are defined in.",
 						},
 						"url": {
 							Type:        schema.TypeString,

--- a/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
+++ b/azuredevops/internal/service/workitemtrackingprocess/resource_work_item_type.go
@@ -42,10 +42,17 @@ func ResourceWorkItemType() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m any) error {
-			if len(d.Get("state").([]any)) == 0 {
+			// Custom states and inherited work item type are mutually exclusive
+			raw := d.GetRawConfig()
+			if !raw.IsKnown() || raw.IsNull() {
 				return nil
 			}
-			if v, ok := d.GetOk("parent_work_item_reference_name"); ok && v.(string) != "" {
+			states := raw.GetAttr("state")
+			if states.IsNull() || !states.IsKnown() || states.LengthInt() == 0 {
+				return nil
+			}
+			parent := raw.GetAttr("parent_work_item_reference_name")
+			if !parent.IsNull() && parent.IsKnown() && parent.AsString() != "" {
 				return fmt.Errorf("`state` blocks are only valid on non-inherited work item types; remove `parent_work_item_reference_name` or remove the `state` block(s)")
 			}
 			return nil

--- a/website/docs/r/workitemtrackingprocess_workitemtype.html.markdown
+++ b/website/docs/r/workitemtrackingprocess_workitemtype.html.markdown
@@ -106,7 +106,7 @@ Each `state` block additionally exports:
 
 * `id` - ID of the state.
 
-* `order` - Order assigned. Read-only — defiend by the order of the `state` blocks.
+* `order` - Order assigned. Read-only — defined by the order of the `state` blocks.
 
 * `url` - URL of the state.
 

--- a/website/docs/r/workitemtrackingprocess_workitemtype.html.markdown
+++ b/website/docs/r/workitemtrackingprocess_workitemtype.html.markdown
@@ -26,6 +26,36 @@ resource "azuredevops_workitemtrackingprocess_workitemtype" "example" {
 }
 ```
 
+### With custom states
+
+Declaring one or more `state` blocks opts into full state management for the
+work item type: states not listed here will be deleted. Mutually exclusive with `azuredevops_workitemtrackingprocess_state`. Only valid for work item types with no parent, i.e. `parent_work_item_reference_name` is not set. Use `azuredevops_workitemtrackingprocess_inherited_state` for work item types with a parent.
+
+```hcl
+resource "azuredevops_workitemtrackingprocess_workitemtype" "example" {
+  process_id = azuredevops_workitemtrackingprocess_process.example.id
+  name       = "example"
+
+  state {
+    name           = "New"
+    color          = "#3544ca"
+    state_category = "Proposed"
+  }
+
+  state {
+    name           = "Active"
+    color          = "#ff9d00"
+    state_category = "InProgress"
+  }
+
+  state {
+    name           = "Closed"
+    color          = "#339933"
+    state_category = "Completed"
+  }
+}
+```
+
 ## Arguments Reference
 
 The following arguments are supported:
@@ -46,6 +76,18 @@ The following arguments are supported:
 
 * `is_enabled` - (Optional) True if the work item type is enabled. Default: true
 
+* `state` - (Optional) One or more `state` blocks as defined below. See the [example](#with-custom-states) for caveats. Leaves custom states as-is if not defined.
+
+---
+
+A `state` block supports the following:
+
+* `name` - (Required) Name of the state.
+
+* `color` - (Required) Color hexadecimal code to represent the state, e.g. `#b2b2b2`.
+
+* `state_category` - (Required) Category of the state. Valid values: `Proposed`, `InProgress`, `Resolved`, `Completed`, `Removed`.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
@@ -57,6 +99,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `reference_name` -  Reference name of the work item type.
 
 * `url` -  Url of the work item type.
+
+---
+
+Each `state` block additionally exports:
+
+* `id` - ID of the state.
+
+* `order` - Order assigned. Read-only — defiend by the order of the `state` blocks.
+
+* `url` - URL of the state.
 
 ---
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
Add custom state management for work item types with no inheritance. Work item types that has no parent are created with custom states implicitly. In order to manage these states `state` blocks are introduced.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result
```
TF_ACC=1 go test -v -run 'TestAccWorkitemtrackingprocessWorkItemType_' ./azuredevops/internal/acceptancetests/... -timeout 120m
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_DataSource_Get
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_DataSource_Get
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_Basic
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_Basic
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_CreateAndUpdate
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_CreateAndUpdate
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_States
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_States
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_Inherited
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_Inherited
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_StatesRemovedFromConfig
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_StatesRemovedFromConfig
=== RUN   TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges
=== PAUSE TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_DataSource_Get
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_Inherited
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_CreateAndUpdate
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_States
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_Basic
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_StatesRemovedFromConfig
=== CONT  TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_StatesForbiddenOnInherited (0.99s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_StatesWithNoChanges (3.17s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_DataSource_Get (3.30s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_Basic (3.86s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_Inherited (4.40s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_StatesRemovedFromConfig (4.54s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_CreateAndUpdate (6.18s)
--- PASS: TestAccWorkitemtrackingprocessWorkItemType_States (11.05s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        11.064s
?       github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils      [no test files]
```

## Related Issue(s)

Fix #1547 

## Other information
N/A