### PR TITLE
`azuredevops_service_principal` Data Source - Add search by `origin_id` support

### DIFF
--- a/azuredevops/internal/acceptancetests/data_service_principal_test.go
+++ b/azuredevops/internal/acceptancetests/data_service_principal_test.go
@@ -35,10 +35,43 @@ func TestAccServicePrincipalDataSource_Read_HappyPath(t *testing.T) {
 	})
 }
 
+func TestAccServicePrincipalDataSource_Read_ByOriginId(t *testing.T) {
+	if os.Getenv("AZDO_TEST_AAD_SERVICE_PRINCIPAL_OBJECT_ID") == "" {
+		t.Skip("Skip test due to `AZDO_TEST_AAD_SERVICE_PRINCIPAL_OBJECT_ID` not set")
+	}
+	servicePrincipalObjectId := os.Getenv("AZDO_TEST_AAD_SERVICE_PRINCIPAL_OBJECT_ID")
+
+	tfBuildDefNode := "data.azuredevops_service_principal.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclServicePrincipalDataByOriginId(servicePrincipalObjectId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "display_name"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "id"),
+					resource.TestCheckResourceAttrSet(tfBuildDefNode, "origin"),
+					resource.TestCheckResourceAttr(tfBuildDefNode, "origin_id", servicePrincipalObjectId),
+				),
+			},
+		},
+	})
+}
+
 func hclServicePrincipalDataBasic(servicePrincipalObjectId string) string {
 	return fmt.Sprintf(`
 %s
 data "azuredevops_service_principal" "test" {
   display_name = azuredevops_service_principal_entitlement.test.display_name
 }`, testutils.HclServicePrincipleEntitlementResource(servicePrincipalObjectId))
+}
+
+func hclServicePrincipalDataByOriginId(servicePrincipalObjectId string) string {
+	return fmt.Sprintf(`
+%s
+data "azuredevops_service_principal" "test" {
+  origin_id  = "%s"
+  depends_on = [azuredevops_service_principal_entitlement.test]
+}`, testutils.HclServicePrincipleEntitlementResource(servicePrincipalObjectId), servicePrincipalObjectId)
 }

--- a/azuredevops/internal/service/graph/data_service_principal.go
+++ b/azuredevops/internal/service/graph/data_service_principal.go
@@ -29,13 +29,13 @@ func DataServicePrincipal() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validation.StringIsNotWhiteSpace,
-				AtLeastOneOf:     []string{"display_name", "origin_id"},
+				ExactlyOneOf:     []string{"display_name", "origin_id"},
 			},
 			"origin_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"display_name", "origin_id"},
+				ExactlyOneOf: []string{"display_name", "origin_id"},
 			},
 			"origin": {
 				Type:     schema.TypeString,

--- a/azuredevops/internal/service/graph/data_service_principal.go
+++ b/azuredevops/internal/service/graph/data_service_principal.go
@@ -24,14 +24,18 @@ func DataServicePrincipal() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
+				Computed:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validation.StringIsNotWhiteSpace,
+				AtLeastOneOf:     []string{"display_name", "origin_id"},
 			},
 			"origin_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"display_name", "origin_id"},
 			},
 			"origin": {
 				Type:     schema.TypeString,
@@ -53,32 +57,42 @@ func dataSourceServicePrincipalRead(d *schema.ResourceData, m interface{}) error
 	clients := m.(*client.AggregatedClient)
 	searchFilter := converter.String("General")
 	displayName := d.Get("display_name").(string)
+	origin_id := d.Get("origin_id").(string)
+	var servicePrincipal *graph.GraphServicePrincipal
+	var err error
 
-	// Query ADO for list of identity user with filter
-	filteredServicePrincipals, err := getIdentityServicePrincipalsWithFilterValue(clients, searchFilter, displayName)
-	if err != nil || filteredServicePrincipals == nil || len(*filteredServicePrincipals) == 0 {
-		return fmt.Errorf("Finding service principal with filter %s. Error: %v", *searchFilter, err)
-	}
-
-	flattenedServicePrincipals, err := flattenIdentityServicePrincipals(filteredServicePrincipals)
-	if err != nil {
-		return fmt.Errorf("Flatten service principals. Error: %v", err)
-	}
-
-	// Filter for the desired user in the FilterUsers results
-	targetServicePrincipal := validateIdentityServicePrincipal(flattenedServicePrincipals, displayName)
-	if targetServicePrincipal == nil {
-		return fmt.Errorf("Could not find service principal with name: %s", displayName)
-	}
-
-	servicePrincipalDescriptor := targetServicePrincipal.SubjectDescriptor
-
-	servicePrincipal, err := getServicePrincipal(clients, servicePrincipalDescriptor)
-	if err != nil {
-		if servicePrincipalDescriptor != nil {
-			return fmt.Errorf("Finding service principal with Descriptor %s", *servicePrincipalDescriptor)
+	if origin_id != "" {
+		servicePrincipal, err = getServicePrincipalByOriginId(clients, origin_id)
+		if err != nil {
+			return fmt.Errorf("Finding service principal with origin_id %s. Error: %v", origin_id, err)
 		}
-		return fmt.Errorf("Finding service principal. Error: %v", err)
+	} else {
+		// Query ADO for list of identity user with filter
+		filteredServicePrincipals, err := getIdentityServicePrincipalsWithFilterValue(clients, searchFilter, displayName)
+		if err != nil || filteredServicePrincipals == nil || len(*filteredServicePrincipals) == 0 {
+			return fmt.Errorf("Finding service principal with filter %s. Error: %v", *searchFilter, err)
+		}
+
+		flattenedServicePrincipals, err := flattenIdentityServicePrincipals(filteredServicePrincipals)
+		if err != nil {
+			return fmt.Errorf("Flatten service principals. Error: %v", err)
+		}
+
+		// Filter for the desired user in the FilterUsers results
+		targetServicePrincipal := validateIdentityServicePrincipal(flattenedServicePrincipals, displayName)
+		if targetServicePrincipal == nil {
+			return fmt.Errorf("Could not find service principal with name: %s", displayName)
+		}
+
+		servicePrincipalDescriptor := targetServicePrincipal.SubjectDescriptor
+
+		servicePrincipal, err = getServicePrincipal(clients, servicePrincipalDescriptor)
+		if err != nil {
+			if servicePrincipalDescriptor != nil {
+				return fmt.Errorf("Finding service principal with Descriptor %s", *servicePrincipalDescriptor)
+			}
+			return fmt.Errorf("Finding service principal. Error: %v", err)
+		}
 	}
 
 	d.SetId(*servicePrincipal.Descriptor)
@@ -136,4 +150,29 @@ func getServicePrincipal(clients *client.AggregatedClient, servicePrincipalDescr
 	return clients.GraphClient.GetServicePrincipal(clients.Ctx, graph.GetServicePrincipalArgs{
 		ServicePrincipalDescriptor: servicePrincipalDescriptor,
 	})
+}
+
+func getServicePrincipalByOriginId(clients *client.AggregatedClient, originId string) (*graph.GraphServicePrincipal, error) {
+	var continuationToken *string
+	for {
+		result, err := clients.GraphClient.ListServicePrincipals(clients.Ctx, graph.ListServicePrincipalsArgs{
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing service principals: %v", err)
+		}
+		if result.GraphServicePrincipals != nil {
+			for i, sp := range *result.GraphServicePrincipals {
+				if sp.OriginId != nil && *sp.OriginId == originId {
+					return &(*result.GraphServicePrincipals)[i], nil
+				}
+			}
+		}
+		if result.ContinuationToken == nil || len(*result.ContinuationToken) == 0 || (*result.ContinuationToken)[0] == "" {
+			break
+		}
+		token := (*result.ContinuationToken)[0]
+		continuationToken = &token
+	}
+	return nil, fmt.Errorf("could not find service principal with origin_id: %s", originId)
 }

--- a/website/docs/d/service_principal.html.markdown
+++ b/website/docs/d/service_principal.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `origin_id` - (Optional) The origin ID of the Service Principal.
 
-~> **NOTE:** One of `display_name` or `origin_id` must be specified.
+~> **NOTE:** Exactly one of `display_name` or `origin_id` must be specified.
 
 ## Attributes Reference
 

--- a/website/docs/d/service_principal.html.markdown
+++ b/website/docs/d/service_principal.html.markdown
@@ -11,9 +11,23 @@ Use this data source to access information about an existing Service Principal.
 
 ## Example Usage
 
+### By Display Name
+
 ```hcl
 data "azuredevops_service_principal" "example" {
   display_name = "existing"
+}
+
+output "id" {
+  value = data.azuredevops_service_principal.example.id
+}
+```
+
+### By Origin ID
+
+```hcl
+data "azuredevops_service_principal" "example" {
+  origin_id = "00000000-0000-0000-0000-000000000000"
 }
 
 output "id" {
@@ -25,7 +39,11 @@ output "id" {
 
 The following arguments are supported:
 
-* `display_name` - (Required) The Display Name of the Service Principal. Changing this forces a new Service Principal to be created.
+* `display_name` - (Optional) The Display Name of the Service Principal. Changing this forces a new Service Principal to be created.
+
+* `origin_id` - (Optional) The origin ID of the Service Principal.
+
+~> **NOTE:** One of `display_name` or `origin_id` must be specified.
 
 ## Attributes Reference
 
@@ -36,8 +54,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `descriptor` - The descriptor of the Service Principal.
 
 * `origin` - The origin of the Service Principal.
-
-* `origin_id` - The origin ID of the Service Principal..
 
 ## Timeouts
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

This PR aims to add support to use `origin_id` to search for the service principal. Previously, `origin_id` is only computed, and could only use `display_name` to search for the service principal. With this PR, it is possible to search by both `origin_id` and `display_name`.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccServicePrincipalDataSource_Read_HappyPath
=== PAUSE TestAccServicePrincipalDataSource_Read_HappyPath
=== RUN   TestAccServicePrincipalDataSource_Read_ByOriginId
=== PAUSE TestAccServicePrincipalDataSource_Read_ByOriginId
=== CONT  TestAccServicePrincipalDataSource_Read_HappyPath
=== CONT  TestAccServicePrincipalDataSource_Read_ByOriginId
--- PASS: TestAccServicePrincipalDataSource_Read_HappyPath (4.03s)
--- PASS: TestAccServicePrincipalDataSource_Read_ByOriginId (5.44s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        5.451s
</pre>

## Related Issue(s)

Fix #746

