### PR TITLE
`azuredevops_securityrole_assignment` - Fix timeout issue when API returns count:0 and added import feature

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
+++ b/azuredevops/internal/acceptancetests/resource_securityrole_assignment_test.go
@@ -27,6 +27,30 @@ func TestAccSecurityRoleAssignmentResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccSecurityRoleAssignmentResource_import(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	groupName := testutils.GenerateResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSecurityRoleAssignmentBasic(projectName, groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("azuredevops_securityrole_assignment.test", "scope"),
+					resource.TestCheckResourceAttr("azuredevops_securityrole_assignment.test", "role_name", "Administrator"),
+				),
+			},
+			{
+				ResourceName:      "azuredevops_securityrole_assignment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSecurityRoleAssignmentResource_update(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	groupName := testutils.GenerateResourceName()

--- a/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
+++ b/azuredevops/internal/service/securityroles/resource_securityrole_assignment.go
@@ -1,6 +1,7 @@
 package securityroles
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/utils/sdk/securityroles"
 )
 
@@ -20,6 +22,9 @@ func ResourceSecurityRoleAssignment() *schema.Resource {
 		Read:   resourceSecurityRoleAssignmentRead,
 		Update: resourceSecurityRoleAssignmentCreateOrUpdate,
 		Delete: resourceSecurityRoleAssignmentDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: importSecurityRoleAssignment,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
@@ -42,6 +47,7 @@ func ResourceSecurityRoleAssignment() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.IsUUID,
 				Required:     true,
+				ForceNew:     true,
 			},
 			"role_name": {
 				Type:         schema.TypeString,
@@ -56,13 +62,13 @@ func resourceSecurityRoleAssignmentCreateOrUpdate(d *schema.ResourceData, m inte
 	clients := m.(*client.AggregatedClient)
 	scope := d.Get("scope").(string)
 	resourceId := d.Get("resource_id").(string)
+	roleName := d.Get("role_name").(string)
 
 	identityId, err := uuid.Parse(d.Get("identity_id").(string))
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing identity_id: %+v", err)
 	}
 
-	roleName := d.Get("role_name").(string)
 	err = clients.SecurityRolesClient.SetSecurityRoleAssignment(clients.Ctx, &securityroles.SetSecurityRoleAssignmentArgs{
 		Scope:      &scope,
 		ResourceId: &resourceId,
@@ -87,7 +93,7 @@ func resourceSecurityRoleAssignmentCreateOrUpdate(d *schema.ResourceData, m inte
 		return err
 	}
 
-	d.SetId("sra-" + uuid.New().String())
+	d.SetId(fmt.Sprintf("%s/%s/%s", scope, resourceId, identityId.String()))
 	return resourceSecurityRoleAssignmentRead(d, m)
 }
 
@@ -97,7 +103,7 @@ func resourceSecurityRoleAssignmentRead(d *schema.ResourceData, m interface{}) e
 	resourceId := d.Get("resource_id").(string)
 	identityId, err := uuid.Parse(d.Get("identity_id").(string))
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing identity_id: %+v", err)
 	}
 
 	assignment, err := clients.SecurityRolesClient.GetSecurityRoleAssignment(clients.Ctx, &securityroles.GetSecurityRoleAssignmentArgs{
@@ -110,7 +116,7 @@ func resourceSecurityRoleAssignmentRead(d *schema.ResourceData, m interface{}) e
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("reading group memberships during read: %+v", err)
+		return fmt.Errorf("reading security role assignment: %+v", err)
 	}
 
 	if assignment != nil && (assignment.Identity == nil && assignment.Role == nil) {
@@ -137,7 +143,7 @@ func resourceSecurityRoleAssignmentDelete(d *schema.ResourceData, m interface{})
 
 	identityId, err := uuid.Parse(d.Get("identity_id").(string))
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing identity_id: %+v", err)
 	}
 
 	err = clients.SecurityRolesClient.DeleteSecurityRoleAssignment(clients.Ctx, &securityroles.DeleteSecurityRoleAssignmentArgs{
@@ -181,4 +187,18 @@ func getSecurityRoleAssignment(clients client.AggregatedClient, scope, roleName,
 		}
 		return "", "succeed", nil
 	}
+}
+
+func importSecurityRoleAssignment(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts, err := tfhelper.ParseImportedNameParts(d.Id(), "scope/resource_id/identity_id", 3)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("scope", parts[0])
+	d.Set("resource_id", parts[1])
+	d.Set("identity_id", parts[2])
+	d.SetId(d.Id())
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/azuredevops/utils/sdk/securityroles/client.go
+++ b/azuredevops/utils/sdk/securityroles/client.go
@@ -12,6 +12,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -156,9 +158,21 @@ func (client *ClientImpl) SetSecurityRoleAssignment(ctx context.Context, args *S
 	}
 
 	locationId, _ := uuid.Parse("9461c234-c84c-4ed2-b918-2f0f92ad0a35")
-	_, err := client.Client.Send(ctx, http.MethodPut, locationId, "7.1-preview.1", routeValues, nil, bytes.NewReader(body), "application/json", "", nil)
+	resp, err := client.Client.Send(ctx, http.MethodPut, locationId, "7.1-preview.1", routeValues, nil, bytes.NewReader(body), "application/json", "", nil)
 	if err != nil {
 		return err
+	}
+
+	if resp != nil && resp.Body != nil {
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		if readErr == nil {
+			var result struct {
+				Count int `json:"count"`
+			}
+			if json.Unmarshal(bodyBytes, &result) == nil && result.Count == 0 {
+				return fmt.Errorf("the identity was not recognized by Azure DevOps. Ensure you are using the internal identity ID (storage key).")
+			}
+		}
 	}
 
 	return nil

--- a/website/docs/r/securityrole_assignment.html.markdown
+++ b/website/docs/r/securityrole_assignment.html.markdown
@@ -48,13 +48,15 @@ The following arguments are supported:
 
 * `resource_id` - (Required) The ID of the resource on which the role is to be assigned. Changing this forces a new resource to be created.
 
-* `identity_id` - (Required) The ID of the identity to authorize.
+* `identity_id` - (Required) The internal identity ID (storage key) of the identity to authorize.
 
 * `role_name` - (Required) Name of the role to assign.
 
 ## Attributes Reference
 
-No attributes are exported
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Security Role Assignment, in the format `scope/resource_id/identity_id`.
 
 ## Timeouts
 
@@ -64,6 +66,14 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 * `read` - (Defaults to 5 minute) Used when retrieving the Security Role Assignment.
 * `update` - (Defaults to 10 minutes) Used when updating the Security Role Assignment.
 * `delete` - (Defaults to 10 minutes) Used when deleting the Security Role Assignment.
+
+## Import
+
+Azure DevOps Security Role Assignments can be imported using the composite ID `scope/resource_id/identity_id`, e.g.
+
+```sh
+terraform import azuredevops_securityrole_assignment.example distributedtask.environmentreferencerole/projectId_environmentId/00000000-0000-0000-0000-000000000000
+```
 
 ## Relevant Links
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
Added import for `azuredevops_securityrole_assignment`

Currently, when `SetSecurityRoleAssignment` is called with an identity ID that the API doesn't recognize, the API returns HTTP 200 with {"count":0,"value":[]} instead of an error. Previously, this caused the provider to poll for 10 minutes before timing out with an unhelpful message. This fix will change it to return an error if `count:0`.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccSecurityRoleAssignmentResource_basic
=== PAUSE TestAccSecurityRoleAssignmentResource_basic
=== RUN   TestAccSecurityRoleAssignmentResource_import
=== PAUSE TestAccSecurityRoleAssignmentResource_import
=== RUN   TestAccSecurityRoleAssignmentResource_update
=== PAUSE TestAccSecurityRoleAssignmentResource_update
=== CONT  TestAccSecurityRoleAssignmentResource_basic
=== CONT  TestAccSecurityRoleAssignmentResource_update
=== CONT  TestAccSecurityRoleAssignmentResource_import
--- PASS: TestAccSecurityRoleAssignmentResource_basic (54.00s)
--- PASS: TestAccSecurityRoleAssignmentResource_import (54.05s)
--- PASS: TestAccSecurityRoleAssignmentResource_update (71.71s)
PASS
</pre>

## Related Issue(s)

Fix #1562 
