### PR TITLE
fix: migrate data_users to ReadContext to enforce read timeout

### DIFF
--- a/azuredevops/internal/service/graph/data_users.go
+++ b/azuredevops/internal/service/graph/data_users.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ahmetb/go-linq"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/graph"
@@ -20,9 +22,9 @@ import (
 // DataUsers schema and implementation for users data source
 func DataUsers() *schema.Resource {
 	return &schema.Resource{
-		Read: dataUsersRead,
+		ReadContext: dataUsersReadContext,
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(30 * time.Minute),
+			Read: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"principal_name": {
@@ -106,7 +108,7 @@ func DataUsers() *schema.Resource {
 	}
 }
 
-func dataUsersRead(d *schema.ResourceData, m interface{}) error {
+func dataUsersReadContext(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	clients := m.(*client.AggregatedClient)
 	users := make([]interface{}, 0)
 	subjectTypes := []string{}
@@ -122,11 +124,11 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 
 	var currentToken string
 	for hasMore := true; hasMore; {
-		newUsers, latestToken, err := getUsersWithContinuationToken(clients, &subjectTypes, currentToken)
+		newUsers, latestToken, err := getUsersWithContinuationToken(ctx, clients, &subjectTypes, currentToken)
 		currentToken = latestToken
 		hasMore = currentToken != ""
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		linq.From(newUsers).
@@ -156,9 +158,9 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 			numWorkers = v.(int)
 		}
 	}
-	err := addStorageKeyAsId(clients, users, numWorkers)
+	err := addStorageKeyAsId(ctx, clients, users, numWorkers)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var descriptors []string
@@ -173,11 +175,11 @@ func dataUsersRead(d *schema.ResourceData, m interface{}) error {
 
 	h := sha1.New()
 	if _, err := h.Write([]byte(strings.Join(descriptors, "-"))); err != nil {
-		return fmt.Errorf("Unable to compute hash for user descriptors: %v", err)
+		return diag.FromErr(fmt.Errorf("Unable to compute hash for user descriptors: %v", err))
 	}
 	d.SetId("users#" + base64.URLEncoding.EncodeToString(h.Sum(nil)))
 	if err := d.Set("users", users); err != nil {
-		return fmt.Errorf("Error setting `users`: %+v", err)
+		return diag.FromErr(fmt.Errorf("Error setting `users`: %+v", err))
 	}
 
 	return nil
@@ -223,14 +225,14 @@ func flattenUser(user *graph.GraphUser) map[string]interface{} {
 	return s
 }
 
-func getUsersWithContinuationToken(clients *client.AggregatedClient, subjectTypes *[]string, continuationToken string) ([]graph.GraphUser, string, error) {
+func getUsersWithContinuationToken(ctx context.Context, clients *client.AggregatedClient, subjectTypes *[]string, continuationToken string) ([]graph.GraphUser, string, error) {
 	args := graph.ListUsersArgs{
 		SubjectTypes: subjectTypes,
 	}
 	if continuationToken != "" {
 		args.ContinuationToken = &continuationToken
 	}
-	response, err := clients.GraphClient.ListUsers(clients.Ctx, args)
+	response, err := clients.GraphClient.ListUsers(ctx, args)
 	if err != nil {
 		return nil, "", fmt.Errorf("Listing users: %q", err)
 	}
@@ -243,7 +245,7 @@ func getUsersWithContinuationToken(clients *client.AggregatedClient, subjectType
 	return *response.GraphUsers, continuationToken, nil
 }
 
-func addStorageKeyAsId(clients *client.AggregatedClient, users []interface{}, numWorkers int) error {
+func addStorageKeyAsId(ctx context.Context, clients *client.AggregatedClient, users []interface{}, numWorkers int) error {
 	userQueue := make(chan map[string]interface{}, len(users))
 	errChan := make(chan error)
 
@@ -254,7 +256,7 @@ func addStorageKeyAsId(clients *client.AggregatedClient, users []interface{}, nu
 		go func() {
 			defer wg.Done()
 			for user := range userQueue {
-				storageKey, err := clients.GraphClient.GetStorageKey(clients.Ctx, graph.GetStorageKeyArgs{
+				storageKey, err := clients.GraphClient.GetStorageKey(ctx, graph.GetStorageKeyArgs{
 					SubjectDescriptor: converter.String(user["descriptor"].(string)),
 				})
 				if err != nil {

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
   GitHubDirectory          = "ghb"  # GitHub
   ```
   </pre>
-  
+
 
 * `origin_id` - (Optional) The unique identifier from the system of origin.
 
@@ -141,4 +141,4 @@ A `users` block supports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 30 minute) Used when retrieving the Users.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Users.


### PR DESCRIPTION
## Description

The `data.azuredevops_users` data source was using the legacy `Read` callback instead of `ReadContext`. With the legacy callback, Terraform never cancels the context when the declared timeout fires — meaning the underlying HTTP call to the Azure DevOps Graph API can hang indefinitely, blocking the entire plan until the CI runner's hard wall-clock limit is reached.

This was observed in production: a `terraform plan` hung for over 1h20m on `data.azuredevops_users` lookups before being killed by the 1h30m TFC runner timeout. The same lookups completed in 7–8 seconds on a prior run, confirming the hang was due to the AzDO Graph API not responding rather than slow but progressing work.

**Root cause:** The Terraform Plugin SDK only wires timeout cancellation through `ReadContext` (and its siblings `CreateContext`, `UpdateContext`, `DeleteContext`). The legacy `Read` callback receives no `context.Context`, so the `Timeouts` block declared on the resource is effectively ignored. See:

- [Terraform Plugin SDK — Retries and Customizable Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts): *"If the practitioner or the provider's timeout is reached, the context passed to `ReadContext` will be cancelled, but there is no mechanism for the legacy `Read` function."*
- [SDK v2 Upgrade Guide — Context-aware functions](https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#context-aware-functions)
- [SDK source — `resource.go`](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go): `ReadContext` receives a `ctx` derived from `d.Timeout(schema.TimeoutRead)`; legacy `Read` does not.
- [HashiCorp blog — Calling APIs without context in Terraform providers is risky](https://www.hashicorp.com/blog/calling-apis-without-context-in-terraform-providers-is-risky)

**Changes:**
- Migrate `DataUsers()` from `Read` to `ReadContext`
- Thread `context.Context` through `getUsersWithContinuationToken` and `addStorageKeyAsId` so in-flight HTTP requests are cancelled when the timeout fires
- Reduce the default read timeout from 30 minutes to 5 minutes — typical response time is under 10 seconds; 5 minutes is a safe ceiling that prevents plans from silently blocking for extended periods
- Update docs to reflect the new 5-minute default

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Users who explicitly configure `timeouts { read = "..." }` in their HCL are unaffected. The reduced default only impacts users relying on the implicit 30-minute default, and only in the (previously unbounded) hang scenario this fixes.

## Test Result

Existing unit and acceptance tests pass unchanged. The failure mode (AzDO Graph API returning no response) cannot be reliably reproduced in a test environment.
