### PR TITLE
New resource : `azuredevops_area`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_area_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_test.go
@@ -1,0 +1,158 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+func TestAccArea_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	areaName := "TestArea"
+	tfNode := "azuredevops_area.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaBasic(projectName, areaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "name", areaName),
+					resource.TestCheckResourceAttr(tfNode, "path", "/"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAreaImportStateIdFunc(tfNode),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccArea_child(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	parentAreaName := "ParentArea"
+	childAreaName := "ChildArea"
+	tfNodeParent := "azuredevops_area.parent"
+	tfNodeChild := "azuredevops_area.child"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaChild(projectName, parentAreaName, childAreaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNodeParent, "id"),
+					resource.TestCheckResourceAttr(tfNodeParent, "name", parentAreaName),
+					resource.TestCheckResourceAttr(tfNodeParent, "path", "/"),
+					resource.TestCheckResourceAttrSet(tfNodeChild, "id"),
+					resource.TestCheckResourceAttr(tfNodeChild, "name", childAreaName),
+					resource.TestCheckResourceAttr(tfNodeChild, "path", "/"+parentAreaName),
+				),
+			},
+			{
+				ResourceName:      tfNodeParent,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAreaImportStateIdFunc(tfNodeParent),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      tfNodeChild,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAreaImportStateIdFunc(tfNodeChild),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccArea_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	areaName := "OriginalArea"
+	updatedAreaName := "UpdatedArea"
+	tfNode := "azuredevops_area.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaBasic(projectName, areaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "name", areaName),
+				),
+			},
+			{
+				Config: hclAreaBasic(projectName, updatedAreaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "name", updatedAreaName),
+				),
+			},
+		},
+	})
+}
+
+func hclAreaBasic(projectName, areaName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_area" "test" {
+  project_id = azuredevops_project.project.id
+  name       = "%s"
+  path       = "/"
+}
+`, testutils.HclProjectResource(projectName), areaName)
+}
+
+func hclAreaChild(projectName, parentAreaName, childAreaName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_area" "parent" {
+  project_id = azuredevops_project.project.id
+  name       = "%s"
+  path       = "/"
+}
+
+resource "azuredevops_area" "child" {
+  project_id = azuredevops_project.project.id
+  name       = "%s"
+  path       = "/${azuredevops_area.parent.name}"
+
+  depends_on = [azuredevops_area.parent]
+}
+`, testutils.HclProjectResource(projectName), parentAreaName, childAreaName)
+}
+
+func testAccAreaImportStateIdFunc(resourceName string) func(s *terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		projectID := rs.Primary.Attributes["project_id"]
+		name := rs.Primary.Attributes["name"]
+		path := rs.Primary.Attributes["path"]
+
+		var importID string
+		if path == "/" || path == "" {
+			importID = fmt.Sprintf("%s/%s", projectID, name)
+		} else {
+			importID = fmt.Sprintf("%s%s/%s", projectID, path, name)
+		}
+		return importID, nil
+	}
+}

--- a/azuredevops/internal/acceptancetests/resource_area_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_test.go
@@ -24,7 +24,6 @@ func TestAccArea_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
 					resource.TestCheckResourceAttr(tfNode, "name", areaName),
-					resource.TestCheckResourceAttrSet(tfNode, "area_id"),
 				),
 			},
 			{
@@ -54,10 +53,9 @@ func TestAccArea_child(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNodeParent, "id"),
 					resource.TestCheckResourceAttr(tfNodeParent, "name", parentAreaName),
-					resource.TestCheckResourceAttrSet(tfNodeParent, "area_id"),
 					resource.TestCheckResourceAttrSet(tfNodeChild, "id"),
 					resource.TestCheckResourceAttr(tfNodeChild, "name", childAreaName),
-					resource.TestCheckResourceAttrPair(tfNodeChild, "parent_area_id", tfNodeParent, "area_id"),
+					resource.TestCheckResourceAttrPair(tfNodeChild, "parent_id", tfNodeParent, "id"),
 				),
 			},
 			{
@@ -126,9 +124,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id     = azuredevops_project.project.id
-  name           = "%s"
-  parent_area_id = azuredevops_area.parent.area_id
+  project_id = azuredevops_project.project.id
+  name       = "%s"
+  parent_id  = azuredevops_area.parent.id
 }
 `, testutils.HclProjectResource(projectName), parentAreaName, childAreaName)
 }
@@ -140,7 +138,7 @@ func testAccAreaImportStateIdFunc(resourceName string) func(s *terraform.State) 
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 		projectID := rs.Primary.Attributes["project_id"]
-		nodeID := rs.Primary.Attributes["area_id"]
+		nodeID := rs.Primary.Attributes["id"]
 
 		return fmt.Sprintf("%s/%s", projectID, nodeID), nil
 	}

--- a/azuredevops/internal/acceptancetests/resource_area_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_test.go
@@ -24,7 +24,7 @@ func TestAccArea_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
 					resource.TestCheckResourceAttr(tfNode, "name", areaName),
-					resource.TestCheckResourceAttr(tfNode, "path", "/"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_id"),
 				),
 			},
 			{
@@ -54,10 +54,10 @@ func TestAccArea_child(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNodeParent, "id"),
 					resource.TestCheckResourceAttr(tfNodeParent, "name", parentAreaName),
-					resource.TestCheckResourceAttr(tfNodeParent, "path", "/"),
+					resource.TestCheckResourceAttrSet(tfNodeParent, "area_id"),
 					resource.TestCheckResourceAttrSet(tfNodeChild, "id"),
 					resource.TestCheckResourceAttr(tfNodeChild, "name", childAreaName),
-					resource.TestCheckResourceAttr(tfNodeChild, "path", "/"+parentAreaName),
+					resource.TestCheckResourceAttrPair(tfNodeChild, "parent_area_id", tfNodeParent, "area_id"),
 				),
 			},
 			{
@@ -112,7 +112,6 @@ func hclAreaBasic(projectName, areaName string) string {
 resource "azuredevops_area" "test" {
   project_id = azuredevops_project.project.id
   name       = "%s"
-  path       = "/"
 }
 `, testutils.HclProjectResource(projectName), areaName)
 }
@@ -124,15 +123,12 @@ func hclAreaChild(projectName, parentAreaName, childAreaName string) string {
 resource "azuredevops_area" "parent" {
   project_id = azuredevops_project.project.id
   name       = "%s"
-  path       = "/"
 }
 
 resource "azuredevops_area" "child" {
   project_id = azuredevops_project.project.id
   name       = "%s"
-  path       = "/${azuredevops_area.parent.name}"
-
-  depends_on = [azuredevops_area.parent]
+  parent_area_id  = azuredevops_area.parent.area_id
 }
 `, testutils.HclProjectResource(projectName), parentAreaName, childAreaName)
 }
@@ -144,15 +140,8 @@ func testAccAreaImportStateIdFunc(resourceName string) func(s *terraform.State) 
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 		projectID := rs.Primary.Attributes["project_id"]
-		name := rs.Primary.Attributes["name"]
-		path := rs.Primary.Attributes["path"]
+		nodeID := rs.Primary.Attributes["area_id"]
 
-		var importID string
-		if path == "/" || path == "" {
-			importID = fmt.Sprintf("%s/%s", projectID, name)
-		} else {
-			importID = fmt.Sprintf("%s%s/%s", projectID, path, name)
-		}
-		return importID, nil
+		return fmt.Sprintf("%s/%s", projectID, nodeID), nil
 	}
 }

--- a/azuredevops/internal/acceptancetests/resource_area_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_test.go
@@ -126,9 +126,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id = azuredevops_project.project.id
-  name       = "%s"
-  parent_area_id  = azuredevops_area.parent.area_id
+  project_id     = azuredevops_project.project.id
+  name           = "%s"
+  parent_area_id = azuredevops_area.parent.area_id
 }
 `, testutils.HclProjectResource(projectName), parentAreaName, childAreaName)
 }

--- a/azuredevops/internal/acceptancetests/resource_area_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_test.go
@@ -23,7 +23,7 @@ func TestAccArea_basic(t *testing.T) {
 				Config: hclAreaBasic(projectName, areaName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
-					resource.TestCheckResourceAttr(tfNode, "name", areaName),
+					resource.TestCheckResourceAttrSet(tfNode, "path"),
 				),
 			},
 			{
@@ -52,10 +52,10 @@ func TestAccArea_child(t *testing.T) {
 				Config: hclAreaChild(projectName, parentAreaName, childAreaName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNodeParent, "id"),
-					resource.TestCheckResourceAttr(tfNodeParent, "name", parentAreaName),
+					resource.TestCheckResourceAttrSet(tfNodeParent, "path"),
 					resource.TestCheckResourceAttrSet(tfNodeChild, "id"),
-					resource.TestCheckResourceAttr(tfNodeChild, "name", childAreaName),
-					resource.TestCheckResourceAttrPair(tfNodeChild, "parent_id", tfNodeParent, "id"),
+					resource.TestCheckResourceAttrSet(tfNodeChild, "path"),
+					resource.TestCheckResourceAttrPair(tfNodeChild, "parent_area_id", tfNodeParent, "id"),
 				),
 			},
 			{
@@ -89,6 +89,7 @@ func TestAccArea_update(t *testing.T) {
 				Config: hclAreaBasic(projectName, areaName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "path"),
 					resource.TestCheckResourceAttr(tfNode, "name", areaName),
 				),
 			},
@@ -96,6 +97,7 @@ func TestAccArea_update(t *testing.T) {
 				Config: hclAreaBasic(projectName, updatedAreaName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttrSet(tfNode, "path"),
 					resource.TestCheckResourceAttr(tfNode, "name", updatedAreaName),
 				),
 			},
@@ -124,9 +126,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id = azuredevops_project.project.id
-  name       = "%s"
-  parent_id  = azuredevops_area.parent.id
+  project_id     = azuredevops_project.project.id
+  name           = "%s"
+  parent_area_id = azuredevops_area.parent.id
 }
 `, testutils.HclProjectResource(projectName), parentAreaName, childAreaName)
 }

--- a/azuredevops/internal/service/workitemtracking/resource_area.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area.go
@@ -111,11 +111,18 @@ func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diag.Errorf("reading area path %q: %+v", d.Get("name").(string), err)
 	}
 
-	if len(*nodes) > 0 {
-		d.SetId(strconv.Itoa(*(*nodes)[0].Id))
-		d.Set("name", (*nodes)[0].Name)
-		d.Set("path", convertAreaNodePath((*nodes)[0].Path))
+	if len(*nodes) != 1 {
+		return diag.Errorf("reading area path %q: unexpected number of nodes returned for area (id=%d)", d.Get("name").(string), id)
 	}
+
+	node := (*nodes)[0]
+	if node.Id == nil {
+		return diag.Errorf("reading area path %q: area node (id=%d) has nil ID", d.Get("name").(string), id)
+	}
+
+	d.SetId(strconv.Itoa(*node.Id))
+	d.Set("name", node.Name)
+	d.Set("path", convertAreaNodePath(node.Path))
 
 	return nil
 }

--- a/azuredevops/internal/service/workitemtracking/resource_area.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area.go
@@ -1,0 +1,223 @@
+package workitemtracking
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/workitemtracking"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+func ResourceArea() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAreaCreate,
+		ReadContext:   resourceAreaRead,
+		UpdateContext: resourceAreaUpdate,
+		DeleteContext: resourceAreaDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAreaImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+				ForceNew: true,
+			},
+			"full_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	name := d.Get("name").(string)
+	parentPath := d.Get("path").(string)
+
+	apiPath := trimLeadingSlash(parentPath)
+
+	node, err := clients.WorkItemTrackingClient.CreateOrUpdateClassificationNode(clients.Ctx, workitemtracking.CreateOrUpdateClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Path:           &apiPath,
+		PostedNode: &workitemtracking.WorkItemClassificationNode{
+			Name: &name,
+		},
+	})
+	if err != nil {
+		return diag.Errorf("creating area path %q under %q: %+v", name, parentPath, err)
+	}
+
+	if node.Identifier == nil {
+		return diag.Errorf("creating area path: identifier was nil")
+	}
+
+	d.SetId(node.Identifier.String())
+	return resourceAreaRead(ctx, d, m)
+}
+
+func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	name := d.Get("name").(string)
+	parentPath := d.Get("path").(string)
+
+	apiPath := buildApiPath(parentPath, name)
+
+	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Path:           &apiPath,
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("reading area path %q: %+v", apiPath, err)
+	}
+
+	d.SetId(node.Identifier.String())
+	d.Set("name", node.Name)
+	d.Set("full_path", convertAreaNodePath(node.Path))
+
+	return nil
+}
+
+func resourceAreaUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	oldName, newName := d.GetChange("name")
+	parentPath := d.Get("path").(string)
+
+	apiPath := buildApiPath(parentPath, oldName.(string))
+
+	_, err := clients.WorkItemTrackingClient.UpdateClassificationNode(clients.Ctx, workitemtracking.UpdateClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Path:           &apiPath,
+		PostedNode: &workitemtracking.WorkItemClassificationNode{
+			Name: converter.String(newName.(string)),
+		},
+	})
+	if err != nil {
+		return diag.Errorf("updating area path %q to %q: %+v", oldName, newName, err)
+	}
+
+	return resourceAreaRead(ctx, d, m)
+}
+
+func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	name := d.Get("name").(string)
+	parentPath := d.Get("path").(string)
+
+	apiPath := buildApiPath(parentPath, name)
+
+	err := clients.WorkItemTrackingClient.DeleteClassificationNode(clients.Ctx, workitemtracking.DeleteClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Path:           &apiPath,
+	})
+	if err != nil {
+		return diag.Errorf("deleting area path %q: %+v", apiPath, err)
+	}
+
+	return nil
+}
+
+func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid import format, expected: project_id/path (e.g., project-uuid/ParentArea/ChildArea)")
+	}
+
+	projectID := parts[0]
+	fullPath := "/" + parts[1]
+
+	pathParts := strings.Split(strings.TrimPrefix(fullPath, "/"), "/")
+	name := pathParts[len(pathParts)-1]
+	parentPath := "/"
+	if len(pathParts) > 1 {
+		parentPath = "/" + strings.Join(pathParts[:len(pathParts)-1], "/")
+	}
+
+	d.Set("project_id", projectID)
+	d.Set("name", name)
+	d.Set("path", parentPath)
+
+	clients := m.(*client.AggregatedClient)
+	apiPath := parts[1]
+
+	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Path:           &apiPath,
+		Depth:          converter.Int(0),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading area path for import %q: %+v", fullPath, err)
+	}
+
+	d.SetId(node.Identifier.String())
+	d.Set("full_path", convertAreaNodePath(node.Path))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func buildApiPath(parentPath, name string) string {
+	parent := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(parentPath), "/"), "/")
+	if parent == "" {
+		return name
+	}
+	return parent + "/" + name
+}
+
+func trimLeadingSlash(path string) string {
+	return strings.TrimPrefix(strings.TrimSpace(path), "/")
+}
+
+func convertAreaNodePath(path *string) string {
+	if path == nil {
+		return "/"
+	}
+	itemPath := strings.ReplaceAll(*path, "\\", "/")
+	parts := strings.Split(itemPath, "/")
+	if len(parts) > 3 {
+		return "/" + strings.Join(parts[3:], "/")
+	}
+	return "/"
+}

--- a/azuredevops/internal/service/workitemtracking/resource_area.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area.go
@@ -45,12 +45,12 @@ func ResourceArea() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateClassificationNodeName,
 			},
-			"parent_id": {
+			"parent_area_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
-			"full_path": {
+			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -63,7 +63,7 @@ func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
-	parentID := d.Get("parent_id").(int)
+	parentID := d.Get("parent_area_id").(int)
 
 	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
@@ -99,7 +99,7 @@ func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diag.Errorf("parsing resource ID: %+v", err)
 	}
 
-	node, err := clients.WorkItemTrackingClient.GetClassificationNodes(clients.Ctx, workitemtracking.GetClassificationNodesArgs{
+	nodes, err := clients.WorkItemTrackingClient.GetClassificationNodes(clients.Ctx, workitemtracking.GetClassificationNodesArgs{
 		Project: &projectID,
 		Ids:     &[]int{id},
 	})
@@ -110,13 +110,12 @@ func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		}
 		return diag.Errorf("reading area path %q: %+v", d.Get("name").(string), err)
 	}
-	if (*node)[0].Id == nil {
-		return diag.Errorf("reading area path %q: API did not return node ID", d.Get("name").(string))
-	}
 
-	d.SetId(strconv.Itoa(*(*node)[0].Id))
-	d.Set("name", (*node)[0].Name)
-	d.Set("full_path", convertAreaNodePath((*node)[0].Path))
+	if len(*nodes) > 0 {
+		d.SetId(strconv.Itoa(*(*nodes)[0].Id))
+		d.Set("name", (*nodes)[0].Name)
+		d.Set("path", convertAreaNodePath((*nodes)[0].Path))
+	}
 
 	return nil
 }
@@ -126,7 +125,7 @@ func resourceAreaUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	oldName, newName := d.GetChange("name")
-	parentID := d.Get("parent_id").(int)
+	parentID := d.Get("parent_area_id").(int)
 
 	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
@@ -154,7 +153,7 @@ func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
-	parentID := d.Get("parent_id").(int)
+	parentID := d.Get("parent_area_id").(int)
 
 	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
@@ -202,7 +201,7 @@ func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface
 	d.SetId(strconv.Itoa(*node.Id))
 	d.Set("project_id", projectID)
 	d.Set("name", node.Name)
-	d.Set("full_path", convertAreaNodePath(node.Path))
+	d.Set("path", convertAreaNodePath(node.Path))
 
 	if node.Path != nil {
 		parts := strings.Split(*node.Path, "\\")
@@ -217,7 +216,7 @@ func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface
 				return nil, fmt.Errorf("reading parent area for import: %+v", err)
 			}
 			if parentNode.Id != nil {
-				d.Set("parent_id", *parentNode.Id)
+				d.Set("parent_area_id", *parentNode.Id)
 			}
 		}
 	}
@@ -242,6 +241,9 @@ func resolveParentPath(clients *client.AggregatedClient, projectID string, paren
 	}
 
 	parentNode := (*nodes)[0]
+	if parentNode.Path == nil {
+		return "", fmt.Errorf("parent area node (id=%d) has no path", parentID)
+	}
 	parts := strings.Split(*parentNode.Path, "\\")
 	if len(parts) > 3 {
 		return strings.Join(parts[3:], "/"), nil

--- a/azuredevops/internal/service/workitemtracking/resource_area.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area.go
@@ -3,8 +3,11 @@ package workitemtracking
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,13 +43,16 @@ func ResourceArea() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotWhiteSpace,
+				ValidateFunc: validateClassificationNodeName,
 			},
-			"path": {
-				Type:     schema.TypeString,
+			"parent_area_id": {
+				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  "/",
 				ForceNew: true,
+			},
+			"area_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"full_path": {
 				Type:     schema.TypeString,
@@ -61,9 +67,11 @@ func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
-	parentPath := d.Get("path").(string)
 
-	apiPath := trimLeadingSlash(parentPath)
+	apiPath, err := resolveParentPath(clients, projectID, d)
+	if err != nil {
+		return diag.Errorf("resolving parent path: %+v", err)
+	}
 
 	node, err := clients.WorkItemTrackingClient.CreateOrUpdateClassificationNode(clients.Ctx, workitemtracking.CreateOrUpdateClassificationNodeArgs{
 		Project:        &projectID,
@@ -74,7 +82,7 @@ func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface
 		},
 	})
 	if err != nil {
-		return diag.Errorf("creating area path %q under %q: %+v", name, parentPath, err)
+		return diag.Errorf("creating area path %q: %+v", name, err)
 	}
 
 	if node.Identifier == nil {
@@ -90,26 +98,32 @@ func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
-	parentPath := d.Get("path").(string)
 
-	apiPath := buildApiPath(parentPath, name)
+	apiPath, err := resolveParentPath(clients, projectID, d)
+	if err != nil {
+		return diag.Errorf("resolving parent path: %+v", err)
+	}
+	fullApiPath := buildApiPath(apiPath, name)
 
 	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
 		Project:        &projectID,
 		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
-		Path:           &apiPath,
+		Path:           &fullApiPath,
 	})
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("reading area path %q: %+v", apiPath, err)
+		return diag.Errorf("reading area path %q: %+v", fullApiPath, err)
 	}
 
 	d.SetId(node.Identifier.String())
 	d.Set("name", node.Name)
 	d.Set("full_path", convertAreaNodePath(node.Path))
+	if node.Id != nil {
+		d.Set("area_id", *node.Id)
+	}
 
 	return nil
 }
@@ -119,14 +133,17 @@ func resourceAreaUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	oldName, newName := d.GetChange("name")
-	parentPath := d.Get("path").(string)
 
-	apiPath := buildApiPath(parentPath, oldName.(string))
+	apiPath, err := resolveParentPath(clients, projectID, d)
+	if err != nil {
+		return diag.Errorf("resolving parent path: %+v", err)
+	}
+	fullApiPath := buildApiPath(apiPath, oldName.(string))
 
-	_, err := clients.WorkItemTrackingClient.UpdateClassificationNode(clients.Ctx, workitemtracking.UpdateClassificationNodeArgs{
+	_, err = clients.WorkItemTrackingClient.UpdateClassificationNode(clients.Ctx, workitemtracking.UpdateClassificationNodeArgs{
 		Project:        &projectID,
 		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
-		Path:           &apiPath,
+		Path:           &fullApiPath,
 		PostedNode: &workitemtracking.WorkItemClassificationNode{
 			Name: converter.String(newName.(string)),
 		},
@@ -143,17 +160,20 @@ func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
-	parentPath := d.Get("path").(string)
 
-	apiPath := buildApiPath(parentPath, name)
+	apiPath, err := resolveParentPath(clients, projectID, d)
+	if err != nil {
+		return diag.Errorf("resolving parent path: %+v", err)
+	}
+	fullApiPath := buildApiPath(apiPath, name)
 
-	err := clients.WorkItemTrackingClient.DeleteClassificationNode(clients.Ctx, workitemtracking.DeleteClassificationNodeArgs{
+	err = clients.WorkItemTrackingClient.DeleteClassificationNode(clients.Ctx, workitemtracking.DeleteClassificationNodeArgs{
 		Project:        &projectID,
 		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
-		Path:           &apiPath,
+		Path:           &fullApiPath,
 	})
 	if err != nil {
-		return diag.Errorf("deleting area path %q: %+v", apiPath, err)
+		return diag.Errorf("deleting area path %q: %+v", fullApiPath, err)
 	}
 
 	return nil
@@ -162,40 +182,80 @@ func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return nil, fmt.Errorf("invalid import format, expected: project_id/path (e.g., project-uuid/ParentArea/ChildArea)")
+		return nil, fmt.Errorf("invalid import format, expected: project_id/area_id, got: %q", d.Id())
 	}
 
 	projectID := parts[0]
-	fullPath := "/" + parts[1]
-
-	pathParts := strings.Split(strings.TrimPrefix(fullPath, "/"), "/")
-	name := pathParts[len(pathParts)-1]
-	parentPath := "/"
-	if len(pathParts) > 1 {
-		parentPath = "/" + strings.Join(pathParts[:len(pathParts)-1], "/")
+	nodeID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid area_id %q, must be an integer: %+v", parts[1], err)
 	}
-
-	d.Set("project_id", projectID)
-	d.Set("name", name)
-	d.Set("path", parentPath)
 
 	clients := m.(*client.AggregatedClient)
-	apiPath := parts[1]
 
-	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
-		Project:        &projectID,
-		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
-		Path:           &apiPath,
-		Depth:          converter.Int(0),
+	nodes, err := clients.WorkItemTrackingClient.GetClassificationNodes(clients.Ctx, workitemtracking.GetClassificationNodesArgs{
+		Project: &projectID,
+		Ids:     &[]int{nodeID},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("reading area path for import %q: %+v", fullPath, err)
+		return nil, fmt.Errorf("reading area node (id=%d) for import: %+v", nodeID, err)
+	}
+	if nodes == nil || len(*nodes) == 0 {
+		return nil, fmt.Errorf("area node (id=%d) not found", nodeID)
+	}
+	node := (*nodes)[0]
+	d.SetId(node.Identifier.String())
+	d.Set("project_id", projectID)
+	d.Set("name", node.Name)
+	d.Set("full_path", convertAreaNodePath(node.Path))
+	if node.Id != nil {
+		d.Set("area_id", *node.Id)
 	}
 
-	d.SetId(node.Identifier.String())
-	d.Set("full_path", convertAreaNodePath(node.Path))
+	if node.Path != nil {
+		parts := strings.Split(*node.Path, "\\")
+		if len(parts) > 4 {
+			parentApiPath := strings.Join(parts[3:len(parts)-1], "/")
+			parentNode, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
+				Project:        &projectID,
+				StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+				Path:           &parentApiPath,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("reading parent area for import: %+v", err)
+			}
+			if parentNode.Id != nil {
+				d.Set("parent_area_id", *parentNode.Id)
+			}
+		}
+	}
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func resolveParentPath(clients *client.AggregatedClient, projectID string, d *schema.ResourceData) (string, error) {
+	parentID := d.Get("parent_area_id").(int)
+	if parentID == 0 {
+		return "", nil
+	}
+
+	nodes, err := clients.WorkItemTrackingClient.GetClassificationNodes(clients.Ctx, workitemtracking.GetClassificationNodesArgs{
+		Project: &projectID,
+		Ids:     &[]int{parentID},
+	})
+	if err != nil {
+		return "", fmt.Errorf("looking up parent area node (id=%d): %+v", parentID, err)
+	}
+	if nodes == nil || len(*nodes) == 0 {
+		return "", fmt.Errorf("parent area node (id=%d) not found", parentID)
+	}
+
+	parentNode := (*nodes)[0]
+	parts := strings.Split(*parentNode.Path, "\\")
+	if len(parts) > 3 {
+		return strings.Join(parts[3:], "/"), nil
+	}
+	return "", nil
 }
 
 func buildApiPath(parentPath, name string) string {
@@ -206,18 +266,53 @@ func buildApiPath(parentPath, name string) string {
 	return parent + "/" + name
 }
 
-func trimLeadingSlash(path string) string {
-	return strings.TrimPrefix(strings.TrimSpace(path), "/")
-}
-
 func convertAreaNodePath(path *string) string {
 	if path == nil {
 		return "/"
 	}
-	itemPath := strings.ReplaceAll(*path, "\\", "/")
-	parts := strings.Split(itemPath, "/")
+	parts := strings.Split(*path, "\\")
 	if len(parts) > 3 {
 		return "/" + strings.Join(parts[3:], "/")
 	}
 	return "/"
+}
+
+var classificationNodeReservedNames = []string{
+	"PRN", "CON", "NUL", "AUX", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM10", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+}
+
+func validateClassificationNodeName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if len(strings.TrimSpace(value)) == 0 {
+		errors = append(errors, fmt.Errorf("%q must not be empty or whitespace", k))
+		return warnings, errors
+	}
+
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf("%q must not exceed 255 characters, got %d", k, len(value)))
+	}
+
+	if value == "." || value == ".." {
+		errors = append(errors, fmt.Errorf("%q must not be a reserved name (%q)", k, value))
+	}
+
+	upper := strings.ToUpper(value)
+	if slices.Contains(classificationNodeReservedNames, upper) {
+		errors = append(errors, fmt.Errorf("%q must not be a system-reserved name (%s)", k, value))
+	}
+
+	const invalidChars = `\/:"*?<>|#$&+`
+	for _, ch := range value {
+		if strings.ContainsRune(invalidChars, ch) {
+			errors = append(errors, fmt.Errorf("%q must not contain the character %q", k, string(ch)))
+			break
+		}
+		if unicode.IsControl(ch) {
+			errors = append(errors, fmt.Errorf("%q must not contain Unicode control characters", k))
+			break
+		}
+	}
+
+	return warnings, errors
 }

--- a/azuredevops/internal/service/workitemtracking/resource_area.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area.go
@@ -45,14 +45,10 @@ func ResourceArea() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateClassificationNodeName,
 			},
-			"parent_area_id": {
+			"parent_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
-			},
-			"area_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
 			},
 			"full_path": {
 				Type:     schema.TypeString,
@@ -67,8 +63,9 @@ func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
+	parentID := d.Get("parent_id").(int)
 
-	apiPath, err := resolveParentPath(clients, projectID, d)
+	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
 		return diag.Errorf("resolving parent path: %+v", err)
 	}
@@ -84,12 +81,12 @@ func resourceAreaCreate(ctx context.Context, d *schema.ResourceData, m interface
 	if err != nil {
 		return diag.Errorf("creating area path %q: %+v", name, err)
 	}
-
-	if node.Identifier == nil {
-		return diag.Errorf("creating area path: identifier was nil")
+	if node.Id == nil {
+		return diag.Errorf("creating area path %q: API did not return node ID", name)
 	}
 
-	d.SetId(node.Identifier.String())
+	d.SetId(strconv.Itoa(*node.Id))
+
 	return resourceAreaRead(ctx, d, m)
 }
 
@@ -97,33 +94,29 @@ func resourceAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	clients := m.(*client.AggregatedClient)
 
 	projectID := d.Get("project_id").(string)
-	name := d.Get("name").(string)
-
-	apiPath, err := resolveParentPath(clients, projectID, d)
+	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return diag.Errorf("resolving parent path: %+v", err)
+		return diag.Errorf("parsing resource ID: %+v", err)
 	}
-	fullApiPath := buildApiPath(apiPath, name)
 
-	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
-		Project:        &projectID,
-		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
-		Path:           &fullApiPath,
+	node, err := clients.WorkItemTrackingClient.GetClassificationNodes(clients.Ctx, workitemtracking.GetClassificationNodesArgs{
+		Project: &projectID,
+		Ids:     &[]int{id},
 	})
 	if err != nil {
 		if utils.ResponseWasNotFound(err) {
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("reading area path %q: %+v", fullApiPath, err)
+		return diag.Errorf("reading area path %q: %+v", d.Get("name").(string), err)
+	}
+	if (*node)[0].Id == nil {
+		return diag.Errorf("reading area path %q: API did not return node ID", d.Get("name").(string))
 	}
 
-	d.SetId(node.Identifier.String())
-	d.Set("name", node.Name)
-	d.Set("full_path", convertAreaNodePath(node.Path))
-	if node.Id != nil {
-		d.Set("area_id", *node.Id)
-	}
+	d.SetId(strconv.Itoa(*(*node)[0].Id))
+	d.Set("name", (*node)[0].Name)
+	d.Set("full_path", convertAreaNodePath((*node)[0].Path))
 
 	return nil
 }
@@ -133,8 +126,9 @@ func resourceAreaUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	oldName, newName := d.GetChange("name")
+	parentID := d.Get("parent_id").(int)
 
-	apiPath, err := resolveParentPath(clients, projectID, d)
+	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
 		return diag.Errorf("resolving parent path: %+v", err)
 	}
@@ -160,8 +154,9 @@ func resourceAreaDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
+	parentID := d.Get("parent_id").(int)
 
-	apiPath, err := resolveParentPath(clients, projectID, d)
+	apiPath, err := resolveParentPath(clients, projectID, parentID)
 	if err != nil {
 		return diag.Errorf("resolving parent path: %+v", err)
 	}
@@ -204,13 +199,10 @@ func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface
 		return nil, fmt.Errorf("area node (id=%d) not found", nodeID)
 	}
 	node := (*nodes)[0]
-	d.SetId(node.Identifier.String())
+	d.SetId(strconv.Itoa(*node.Id))
 	d.Set("project_id", projectID)
 	d.Set("name", node.Name)
 	d.Set("full_path", convertAreaNodePath(node.Path))
-	if node.Id != nil {
-		d.Set("area_id", *node.Id)
-	}
 
 	if node.Path != nil {
 		parts := strings.Split(*node.Path, "\\")
@@ -225,7 +217,7 @@ func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface
 				return nil, fmt.Errorf("reading parent area for import: %+v", err)
 			}
 			if parentNode.Id != nil {
-				d.Set("parent_area_id", *parentNode.Id)
+				d.Set("parent_id", *parentNode.Id)
 			}
 		}
 	}
@@ -233,8 +225,7 @@ func resourceAreaImport(ctx context.Context, d *schema.ResourceData, m interface
 	return []*schema.ResourceData{d}, nil
 }
 
-func resolveParentPath(clients *client.AggregatedClient, projectID string, d *schema.ResourceData) (string, error) {
-	parentID := d.Get("parent_area_id").(int)
+func resolveParentPath(clients *client.AggregatedClient, projectID string, parentID int) (string, error) {
 	if parentID == 0 {
 		return "", nil
 	}
@@ -259,7 +250,7 @@ func resolveParentPath(clients *client.AggregatedClient, projectID string, d *sc
 }
 
 func buildApiPath(parentPath, name string) string {
-	parent := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(parentPath), "/"), "/")
+	parent := strings.Trim(parentPath, "/")
 	if parent == "" {
 		return name
 	}
@@ -277,11 +268,11 @@ func convertAreaNodePath(path *string) string {
 	return "/"
 }
 
-var classificationNodeReservedNames = []string{
-	"PRN", "CON", "NUL", "AUX", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM10", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
-}
-
 func validateClassificationNodeName(v interface{}, k string) (warnings []string, errors []error) {
+	classificationNodeReservedNames := []string{
+		"PRN", "CON", "NUL", "AUX", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM10", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+	}
+
 	value := v.(string)
 
 	if len(strings.TrimSpace(value)) == 0 {

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -44,6 +44,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"azuredevops_agent_pool":                                  taskagent.ResourceAgentPool(),
 			"azuredevops_agent_queue":                                 taskagent.ResourceAgentQueue(),
+			"azuredevops_area":                                        workitemtracking.ResourceArea(),
 			"azuredevops_area_permissions":                            permissions.ResourceAreaPermissions(),
 			"azuredevops_branch_policy_auto_reviewers":                branch.ResourceBranchPolicyAutoReviewers(),
 			"azuredevops_branch_policy_build_validation":              branch.ResourceBranchPolicyBuildValidation(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -12,6 +12,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"azuredevops_agent_pool",
 		"azuredevops_agent_queue",
+		"azuredevops_area",
 		"azuredevops_area_permissions",
 		"azuredevops_branch_policy_auto_reviewers",
 		"azuredevops_branch_policy_build_validation",

--- a/website/docs/r/area.html.markdown
+++ b/website/docs/r/area.html.markdown
@@ -27,7 +27,6 @@ resource "azuredevops_project" "example" {
 resource "azuredevops_area" "example" {
   project_id = azuredevops_project.example.id
   name       = "Frontend"
-  path       = "/"
 }
 ```
 
@@ -37,13 +36,12 @@ resource "azuredevops_area" "example" {
 resource "azuredevops_area" "parent" {
   project_id = azuredevops_project.example.id
   name       = "Engineering"
-  path       = "/"
 }
 
 resource "azuredevops_area" "child" {
   project_id = azuredevops_project.example.id
   name       = "Frontend"
-  path       = azuredevops_area.parent.full_path
+  parent_area_id  = azuredevops_area.parent.area_id
 }
 ```
 
@@ -52,20 +50,21 @@ resource "azuredevops_area" "child" {
 The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project. Changing this forces a new resource to be created.
-* `name` - (Required) The name of the area path node.
-* `path` - (Optional) The parent path where this area will be created. Defaults to `"/"` (root). Changing this forces a new resource to be created.
+* `name` - (Required) The name of the area path node. Must conform to [naming restrictions](https://learn.microsoft.com/en-us/azure/devops/organizations/settings/about-areas-iterations?view=azure-devops#naming-restrictions).
+* `parent_area_id` - (Optional) The integer ID of the parent area node. If not specified, the area is created at the root level. Changing this forces a new resource to be created. Use the `area_id` attribute of another `azuredevops_area` resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The UUID identifier of the area path node.
+* `area_id` - The integer ID of this area node. Use this to reference as `parent_area_id` in child areas.
 * `full_path` - The full path of the area, relative to the project (e.g., `/Engineering/Frontend`).
 
 ## Import
 
-Area paths can be imported using the project ID and full path, e.g.:
+Area paths can be imported using the project ID and the area's integer node ID, e.g.:
 
 ```shell
-terraform import azuredevops_area.example 00000000-0000-0000-0000-000000000000/Engineering/Frontend
+terraform import azuredevops_area.example 00000000-0000-0000-0000-000000000000/42
 ```

--- a/website/docs/r/area.html.markdown
+++ b/website/docs/r/area.html.markdown
@@ -39,9 +39,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id = azuredevops_project.example.id
-  name       = "Frontend"
-  parent_id  = azuredevops_area.parent.id
+  project_id     = azuredevops_project.example.id
+  name           = "Frontend"
+  parent_area_id = azuredevops_area.parent.id
 }
 ```
 
@@ -51,14 +51,14 @@ The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project. Changing this forces a new resource to be created.
 * `name` - (Required) The name of the area path node. Must conform to [naming restrictions](https://learn.microsoft.com/en-us/azure/devops/organizations/settings/about-areas-iterations?view=azure-devops#naming-restrictions).
-* `parent_id` - (Optional) The integer ID of the parent area node. If not specified, the area is created at the root level. Changing this forces a new resource to be created. Use the `id` attribute of another `azuredevops_area` resource.
+* `parent_id` - (Optional) The integer ID of the parent area node. If not specified, the area is created at the root level. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The integer ID of the area path node.
-* `full_path` - The full path of the area, relative to the project (e.g., `/Engineering/Frontend`).
+* `path` - The path of the area, relative to the project root (e.g., `/Engineering/Frontend`).
 
 ## Import
 

--- a/website/docs/r/area.html.markdown
+++ b/website/docs/r/area.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_area"
+description: |-
+  Manages an Area Path in Azure DevOps.
+---
+
+# azuredevops_area
+
+Manages an Area Path (classification node) in Azure DevOps.
+
+Area paths allow you to group work items by team or product area. They form a hierarchy under the project's root area node.
+
+## Example Usage
+
+### Basic area at root level
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_area" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Frontend"
+  path       = "/"
+}
+```
+
+### Nested area paths
+
+```hcl
+resource "azuredevops_area" "parent" {
+  project_id = azuredevops_project.example.id
+  name       = "Engineering"
+  path       = "/"
+}
+
+resource "azuredevops_area" "child" {
+  project_id = azuredevops_project.example.id
+  name       = "Frontend"
+  path       = azuredevops_area.parent.full_path
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the area path node.
+* `path` - (Optional) The parent path where this area will be created. Defaults to `"/"` (root). Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The UUID identifier of the area path node.
+* `full_path` - The full path of the area, relative to the project (e.g., `/Engineering/Frontend`).
+
+## Import
+
+Area paths can be imported using the project ID and full path, e.g.:
+
+```shell
+terraform import azuredevops_area.example 00000000-0000-0000-0000-000000000000/Engineering/Frontend
+```

--- a/website/docs/r/area.html.markdown
+++ b/website/docs/r/area.html.markdown
@@ -39,9 +39,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id = azuredevops_project.example.id
-  name       = "Frontend"
-  parent_area_id  = azuredevops_area.parent.area_id
+  project_id     = azuredevops_project.example.id
+  name           = "Frontend"
+  parent_area_id = azuredevops_area.parent.area_id
 }
 ```
 

--- a/website/docs/r/area.html.markdown
+++ b/website/docs/r/area.html.markdown
@@ -39,9 +39,9 @@ resource "azuredevops_area" "parent" {
 }
 
 resource "azuredevops_area" "child" {
-  project_id     = azuredevops_project.example.id
-  name           = "Frontend"
-  parent_area_id = azuredevops_area.parent.area_id
+  project_id = azuredevops_project.example.id
+  name       = "Frontend"
+  parent_id  = azuredevops_area.parent.id
 }
 ```
 
@@ -51,14 +51,13 @@ The following arguments are supported:
 
 * `project_id` - (Required) The ID of the project. Changing this forces a new resource to be created.
 * `name` - (Required) The name of the area path node. Must conform to [naming restrictions](https://learn.microsoft.com/en-us/azure/devops/organizations/settings/about-areas-iterations?view=azure-devops#naming-restrictions).
-* `parent_area_id` - (Optional) The integer ID of the parent area node. If not specified, the area is created at the root level. Changing this forces a new resource to be created. Use the `area_id` attribute of another `azuredevops_area` resource.
+* `parent_id` - (Optional) The integer ID of the parent area node. If not specified, the area is created at the root level. Changing this forces a new resource to be created. Use the `id` attribute of another `azuredevops_area` resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The UUID identifier of the area path node.
-* `area_id` - The integer ID of this area node. Use this to reference as `parent_area_id` in child areas.
+* `id` - The integer ID of the area path node.
 * `full_path` - The full path of the area, relative to the project (e.g., `/Engineering/Frontend`).
 
 ## Import


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

Add a new resource `azuredevops_area` to manage area path classification nodes in Azure DevOps projects.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Test Result
<pre>
=== RUN   TestAccArea_basic
=== PAUSE TestAccArea_basic
=== RUN   TestAccArea_child
=== PAUSE TestAccArea_child
=== RUN   TestAccArea_update
=== PAUSE TestAccArea_update
=== CONT  TestAccArea_basic
=== CONT  TestAccArea_update
=== CONT  TestAccArea_child
--- PASS: TestAccArea_basic (22.98s)
--- PASS: TestAccArea_update (23.78s)
--- PASS: TestAccArea_child (23.83s)
PASS
</pre>

## Related Issue(s)

Fix #394 

## Other information

This has been addressed in PR #1452, but author doesn't seem to be responding. 