### PR TITLE
`azuredevops_group_membership` - Fix 60 minute loop when mode="overwrite"

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_group_membership_test.go
+++ b/azuredevops/internal/acceptancetests/resource_group_membership_test.go
@@ -34,6 +34,12 @@ func TestAccGroupMembership_overwrite(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "members.#", "0"),
 				),
 			},
+			{
+				Config: overwriteExistingMembers(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(tfNode, "members.#", "1"),
+				),
+			},
 		},
 	})
 }
@@ -75,6 +81,31 @@ resource "azuredevops_group" "member" {
 
 resource "azuredevops_group_membership" "test" {
   group   = azuredevops_group.test.id
+  mode    = "overwrite"
+  members = [azuredevops_group.member.id]
+}
+`, name)
+}
+
+func overwriteExistingMembers(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "acctest-%[1]s"
+}
+
+resource "azuredevops_group" "member" {
+  display_name = "acctest-member-%[1]s"
+  scope        = azuredevops_project.test.id
+}
+
+resource "azuredevops_group" "seeded" {
+  display_name = "acctest-seeded-%[1]s"
+  scope        = azuredevops_project.test.id
+  members      = [azuredevops_group.member.id]
+}
+
+resource "azuredevops_group_membership" "test" {
+  group   = azuredevops_group.seeded.id
   mode    = "overwrite"
   members = [azuredevops_group.member.id]
 }

--- a/azuredevops/internal/service/graph/resource_group_membership.go
+++ b/azuredevops/internal/service/graph/resource_group_membership.go
@@ -61,7 +61,7 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 	clients := m.(*client.AggregatedClient)
 	group := d.Get("group").(string)
 	mode := d.Get("mode").(string)
-	membersToAdd := d.Get("members").(*schema.Set)
+	membersToAdd := schema.NewSet(schema.HashString, d.Get("members").(*schema.Set).List())
 	var membersToRemove *schema.Set = nil
 
 	if strings.EqualFold("overwrite", mode) {
@@ -93,14 +93,14 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() <= 0) &&
-				(membersToRemove == nil || actualMembershipsSet.Intersection(membersToRemove).Len() <= 0) {
+			if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() == membersToAdd.Len()) &&
+				(membersToRemove == nil || actualMembershipsSet.Intersection(membersToRemove).Len() == 0) {
 				state = "Synched"
 			}
 
 			return state, state, nil
 		},
-		Timeout:                   60 * time.Minute,
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		MinTimeout:                5 * time.Second,
 		Delay:                     5 * time.Second,
 		ContinuousTargetOccurence: 2,
@@ -151,9 +151,9 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 	group := d.Get("group").(string)
 	oldData, newData := d.GetChange("members")
 	// members that need to be added will be missing from the old data, but present in the new data
-	membersToAdd := newData.(*schema.Set).Difference(oldData.(*schema.Set))
+	membersToAdd := schema.NewSet(schema.HashString, newData.(*schema.Set).Difference(oldData.(*schema.Set)).List())
 	// members that need to be removed will be missing from the new data, but present in the old data
-	membersToRemove := oldData.(*schema.Set).Difference(newData.(*schema.Set))
+	membersToRemove := schema.NewSet(schema.HashString, oldData.(*schema.Set).Difference(newData.(*schema.Set)).List())
 
 	err := applyMembershipUpdate(m.(*client.AggregatedClient),
 		expandGroupMembers(group, membersToAdd),
@@ -172,14 +172,14 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if actualMembershipsSet.Intersection(membersToAdd).Len() <= 0 &&
-				actualMembershipsSet.Intersection(membersToRemove).Len() <= 0 {
+			if actualMembershipsSet.Intersection(membersToAdd).Len() == membersToAdd.Len() &&
+				actualMembershipsSet.Intersection(membersToRemove).Len() == 0 {
 				state = "Synched"
 			}
 
 			return state, state, nil
 		},
-		Timeout:                   60 * time.Minute,
+		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		MinTimeout:                5 * time.Second,
 		Delay:                     5 * time.Second,
 		ContinuousTargetOccurence: 3,
@@ -215,7 +215,7 @@ func resourceGroupMembershipDelete(d *schema.ResourceData, m interface{}) error 
 
 			return state, state, nil
 		},
-		Timeout:                   60 * time.Minute,
+		Timeout:                   d.Timeout(schema.TimeoutDelete),
 		MinTimeout:                5 * time.Second,
 		Delay:                     5 * time.Second,
 		ContinuousTargetOccurence: 2,

--- a/azuredevops/internal/service/graph/resource_group_membership.go
+++ b/azuredevops/internal/service/graph/resource_group_membership.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -61,8 +62,8 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 	clients := m.(*client.AggregatedClient)
 	group := d.Get("group").(string)
 	mode := d.Get("mode").(string)
-	membersToAdd := schema.NewSet(schema.HashString, d.Get("members").(*schema.Set).List())
-	var membersToRemove *schema.Set = nil
+	membersToAdd := schemaSetToGoSet(d.Get("members").(*schema.Set))
+	var membersToRemove set.Collection[string] = nil
 
 	if strings.EqualFold("overwrite", mode) {
 		actualMemberships, err := getGroupMemberships(clients, group)
@@ -76,8 +77,8 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	err := applyMembershipUpdate(m.(*client.AggregatedClient),
-		expandGroupMembers(group, membersToAdd),
-		expandGroupMembers(group, membersToRemove))
+		expandGroupMembersSet(group, membersToAdd),
+		expandGroupMembersSet(group, membersToRemove))
 	if err != nil {
 		return fmt.Errorf("Adding group memberships during create: %+v", err)
 	}
@@ -93,8 +94,8 @@ func resourceGroupMembershipCreate(d *schema.ResourceData, m interface{}) error 
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() == membersToAdd.Len()) &&
-				(membersToRemove == nil || actualMembershipsSet.Intersection(membersToRemove).Len() == 0) {
+			if (membersToAdd == nil || actualMembershipsSet.Intersect(membersToAdd).Size() == membersToAdd.Size()) &&
+				(membersToRemove == nil || actualMembershipsSet.Intersect(membersToRemove).Size() == 0) {
 				state = "Synched"
 			}
 
@@ -151,13 +152,13 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 	group := d.Get("group").(string)
 	oldData, newData := d.GetChange("members")
 	// members that need to be added will be missing from the old data, but present in the new data
-	membersToAdd := schema.NewSet(schema.HashString, newData.(*schema.Set).Difference(oldData.(*schema.Set)).List())
+	membersToAdd := schemaSetToGoSet(newData.(*schema.Set).Difference(oldData.(*schema.Set)))
 	// members that need to be removed will be missing from the new data, but present in the old data
-	membersToRemove := schema.NewSet(schema.HashString, oldData.(*schema.Set).Difference(newData.(*schema.Set)).List())
+	membersToRemove := schemaSetToGoSet(oldData.(*schema.Set).Difference(newData.(*schema.Set)))
 
 	err := applyMembershipUpdate(m.(*client.AggregatedClient),
-		expandGroupMembers(group, membersToAdd),
-		expandGroupMembers(group, membersToRemove))
+		expandGroupMembersSet(group, membersToAdd),
+		expandGroupMembersSet(group, membersToRemove))
 	if err != nil {
 		return err
 	}
@@ -171,9 +172,9 @@ func resourceGroupMembershipUpdate(d *schema.ResourceData, m interface{}) error 
 			if err != nil {
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
-			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if actualMembershipsSet.Intersection(membersToAdd).Len() == membersToAdd.Len() &&
-				actualMembershipsSet.Intersection(membersToRemove).Len() == 0 {
+			actualSet := getGroupMembershipSet(actualMemberships)
+			if actualSet.Intersect(membersToAdd).Size() == membersToAdd.Size() &&
+				actualSet.Intersect(membersToRemove).Size() == 0 {
 				state = "Synched"
 			}
 
@@ -195,8 +196,8 @@ func resourceGroupMembershipDelete(d *schema.ResourceData, m interface{}) error 
 	clients := m.(*client.AggregatedClient)
 
 	group := d.Get("group").(string)
-	membersToRemove := d.Get("members").(*schema.Set)
-	memberships := expandGroupMembers(group, membersToRemove)
+	membersToRemove := schemaSetToGoSet(d.Get("members").(*schema.Set))
+	memberships := expandGroupMembersSet(group, membersToRemove)
 
 	err := removeMembers(clients, memberships)
 	stateConf := &retry.StateChangeConf{
@@ -209,7 +210,7 @@ func resourceGroupMembershipDelete(d *schema.ResourceData, m interface{}) error 
 				return nil, "", fmt.Errorf("Reading group memberships: %+v", err)
 			}
 			actualMembershipsSet := getGroupMembershipSet(actualMemberships)
-			if actualMembershipsSet.Intersection(membersToRemove).Len() <= 0 {
+			if actualMembershipsSet.Intersect(membersToRemove).Size() <= 0 {
 				state = "Synched"
 			}
 
@@ -299,6 +300,23 @@ func expandGroupMembers(group string, memberSet *schema.Set) *[]graph.GraphMembe
 	return &memberships
 }
 
+func expandGroupMembersSet(group string, memberSet set.Collection[string]) *[]graph.GraphMembership {
+	if memberSet == nil || memberSet.Empty() {
+		return &[]graph.GraphMembership{}
+	}
+	members := memberSet.Slice()
+	memberships := make([]graph.GraphMembership, len(members))
+
+	for i, member := range members {
+		memberships[i] = graph.GraphMembership{
+			ContainerDescriptor: &group,
+			MemberDescriptor:    converter.String(member),
+		}
+	}
+
+	return &memberships
+}
+
 func getGroupMemberships(clients *client.AggregatedClient, groupDescriptor string) (*[]graph.GraphMembership, error) {
 	return clients.GraphClient.ListMemberships(clients.Ctx, graph.ListMembershipsArgs{
 		SubjectDescriptor: &groupDescriptor,
@@ -307,12 +325,16 @@ func getGroupMemberships(clients *client.AggregatedClient, groupDescriptor strin
 	})
 }
 
-func getGroupMembershipSet(members *[]graph.GraphMembership) *schema.Set {
-	set := schema.NewSet(schema.HashString, nil)
-	if nil != members {
+func getGroupMembershipSet(members *[]graph.GraphMembership) *set.Set[string] {
+	s := set.New[string](0)
+	if members != nil {
 		for _, member := range *members {
-			set.Add(*member.MemberDescriptor)
+			s.Insert(*member.MemberDescriptor)
 		}
 	}
-	return set
+	return s
+}
+
+func schemaSetToGoSet(s *schema.Set) *set.Set[string] {
+	return set.FromFunc(s.List(), func(v interface{}) string { return v.(string) })
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
+	github.com/hashicorp/go-set/v3 v3.0.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshf
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-set/v3 v3.0.1 h1:ZwO15ZYmIrFYL9zSm2wBuwcRiHxVdp46m/XA/MUlM6I=
+github.com/hashicorp/go-set/v3 v3.0.1/go.mod h1:0oPQqhtitglZeT2ZiWnRIfUG6gJAHnn7LzrS7SbgNY4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -170,6 +172,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/shoenig/test v1.12.1 h1:mLHfnMv7gmhhP44WrvT+nKSxKkPDiNkIuHGdIGI9RLU=
+github.com/shoenig/test v1.12.1/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/vendor/github.com/hashicorp/go-set/v3/.copywrite.hcl
+++ b/vendor/github.com/hashicorp/go-set/v3/.copywrite.hcl
@@ -1,0 +1,12 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2022
+  header_ignore = [
+    ".golangci.yaml",
+    ".copywrite.hcl",
+    ".github/**",
+  ]
+}
+

--- a/vendor/github.com/hashicorp/go-set/v3/.gitignore
+++ b/vendor/github.com/hashicorp/go-set/v3/.gitignore
@@ -1,0 +1,23 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go work files
+go.work
+go.work.sum
+
+# IDE files
+.idea
+.fleet

--- a/vendor/github.com/hashicorp/go-set/v3/.golangci.yaml
+++ b/vendor/github.com/hashicorp/go-set/v3/.golangci.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+run:
+  timeout: 5m
+linters:
+  enable:
+   - gofmt
+   - errcheck
+   - errname
+   - errorlint
+   - bodyclose
+   - durationcheck
+   - exhaustive
+   - goconst
+   - whitespace
+

--- a/vendor/github.com/hashicorp/go-set/v3/CODEOWNERS
+++ b/vendor/github.com/hashicorp/go-set/v3/CODEOWNERS
@@ -1,0 +1,2 @@
+# codeowner default
+*                              @hashicorp/github-nomad-core @hashicorp/nomad-eng

--- a/vendor/github.com/hashicorp/go-set/v3/LICENSE
+++ b/vendor/github.com/hashicorp/go-set/v3/LICENSE
@@ -1,0 +1,375 @@
+Copyright (c) 2022 HashiCorp, Inc.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/go-set/v3/README.md
+++ b/vendor/github.com/hashicorp/go-set/v3/README.md
@@ -1,0 +1,223 @@
+# go-set
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/go-set.svg)](https://pkg.go.dev/github.com/hashicorp/go-set/v3)
+[![Run CI Tests](https://github.com/hashicorp/go-set/actions/workflows/ci.yaml/badge.svg)](https://github.com/hashicorp/go-set/actions/workflows/ci.yaml)
+[![GitHub](https://img.shields.io/github/license/hashicorp/go-set)](LICENSE)
+
+The `go-set` repository provides a `set` package containing a few
+generic [Set](https://en.wikipedia.org/wiki/Set) implementations for Go.
+
+---
+
+**PSA** August 2024 - The **v3** version of this package has been published,
+starting at tag version `v3.0.0`. A description of the changes including
+backwards incompatibilities can be found in https://github.com/hashicorp/go-set/issues/90
+
+_Requires `go1.23` or later._
+
+---
+
+**PSA** October 2023 - The **v2** version of this package has been published,
+starting at tag version `v2.1.0`. A description of the changes including
+backwards incompatibilities can be found in https://github.com/hashicorp/go-set/issues/73
+
+---
+
+Each implementation is optimal for a particular use case.
+
+**Set[T]** is ideal for `comparable` types.
+  - backed by `map` builtin
+  - commonly used with `string`, `int`, simple `struct` types, etc.
+
+**HashSet[T]** is useful for types that implement a `Hash()` function.
+  - backed by `map` builtin
+  - commonly used with complex structs
+  - also works with custom `HashFunc[T]` implementations
+
+**TreeSet[T]** is useful for comparable data (via `CompareFunc[T]`)
+  - backed by Red-Black Binary Search Tree
+  - commonly used with complex structs with extrinsic order
+  - efficient iteration in sort order
+  - additional methods `Min` / `Max` / `TopK` / `BottomK`
+
+This package is not thread-safe.
+
+---
+
+# Documentation
+
+The full `go-set` package reference is available on [pkg.go.dev](https://pkg.go.dev/github.com/hashicorp/go-set/v3).
+
+# Install
+
+```shell
+go get github.com/hashicorp/go-set/v3@latest
+```
+
+```shell
+import "github.com/hashicorp/go-set/v3"
+```
+
+# Motivation
+
+Package `set` helps reduce the boiler plate of using a `map[<type>]struct{}` as a set.
+
+Say we want to de-duplicate a slice of strings
+```go
+items := []string{"mitchell", "armon", "jack", "dave", "armon", "dave"}
+```
+
+A typical example of the classic way using `map` built-in:
+```go
+m := make(map[string]struct{})
+for _, item := range items {
+  m[item] = struct{}{}
+}
+list := make([]string, 0, len(items))
+for k := range m {
+  list = append(list, k)
+}
+```
+
+The same result, but in one line using package `go-set`.
+```go
+list := set.From[string](items).Slice()
+```
+
+# Set
+
+The `go-set` package includes `Set` for types that satisfy the `comparable` constraint.
+Uniqueness of a set elements is guaranteed via shallow comparison (result of == operator).
+
+Note: if pointers or structs with pointer fields are stored in the `Set`, they will
+be compared in the sense of pointer addresses, not in the sense of referenced values.
+Due to this fact the `Set` type is recommended to be used with builtin types like
+`string`, `int`, or simple struct types with no pointers. `Set` usage with pointers or 
+structs with pointer is also possible if shallow equality is acceptable.
+
+# HashSet
+
+The `go-set` package includes `HashSet` for types that implement a `Hash()` function.
+The custom type must satisfy `HashFunc[H Hash]` - essentially any `Hash()` function
+that returns a `string` or `integer`. This enables types to use string-y hash
+functions like `md5`, `sha1`, or even `GoString()`, but also enables types to
+implement an efficient hash function using a hash code based on prime multiples.
+
+# TreeSet
+
+The `go-set` package includes `TreeSet` for creating sorted sets. A `TreeSet` may
+be used with any type `T` as the comparison between elements is provided by implementing
+`CompareFunc[T]`. The standard library `cmp.Compare` function provides a convenient
+implementation of `CompareFunc` for `cmp.Ordered` types like `string` or `int`. A
+`TreeSet` is backed by an underlying balanced binary search tree, making operations
+like in-order traversal efficient, in addition to enabling functions like `Min()`,
+`Max()`, `TopK()`, and `BottomK()`.
+
+# Collection[T]
+
+The `Collection[T]` interface is implemented by each of `Set`, `HashSet`, and `TreeSet`.
+
+It serves as a useful abstraction over the common methods implemented by each set type.
+
+### Iteration
+
+Starting with `v3` each of `Set`, `HashSet`, and `TreeSet` implement an `Items`
+method. It can be used with the `range` keyword for iterating through each 
+element in the set.
+
+```go
+// e.g. print each element in the set
+for item := range s.Items() {
+  fmt.Println(item)
+}
+```
+
+# Set Examples
+
+Below are simple example usages of `Set`
+
+```go
+s := set.New[int](10)
+s.Insert(1)
+s.InsertSlice([]int{2, 3, 4})
+s.Size()
+```
+
+```go
+s := set.From[string]([]string{"one", "two", "three"})
+s.Contains("three")
+s.Remove("one")
+```
+
+
+```go
+a := set.From[int]([]int{2, 4, 6, 8})
+b := set.From[int]([]int{4, 5, 6})
+a.Intersect(b)
+```
+
+# HashSet Examples
+
+Below are simple example usages of `HashSet`
+
+(using a hash code)
+```go
+type inventory struct {
+    item   int
+    serial int
+}
+
+func (i *inventory) Hash() int {
+    code := 3 * item * 5 * serial
+    return code
+}
+
+i1 := &inventory{item: 42, serial: 101}
+
+s := set.NewHashSet[*inventory, int](10)
+s.Insert(i1)
+```
+
+(using a string hash)
+```go
+type employee struct {
+    name string
+    id   int
+}
+
+func (e *employee) Hash() string {
+    return fmt.Sprintf("%s:%d", e.name, e.id)
+}
+
+e1 := &employee{name: "armon", id: 2}
+
+s := set.NewHashSet[*employee, string](10)
+s.Insert(e1)
+```
+
+# TreeSet Examples
+
+Below are simple example usages of `TreeSet`
+
+```go
+ts := NewTreeSet[int](Compare[int])
+ts.Insert(5)
+```
+
+```go
+type waypoint struct {
+    distance int
+    name     string
+}
+
+// compare implements CompareFunc
+compare := func(w1, w2 *waypoint) int {
+    return w1.distance - w2.distance
+}
+
+ts := NewTreeSet[*waypoint](compare)
+ts.Insert(&waypoint{distance: 42, name: "tango"})
+ts.Insert(&waypoint{distance: 13, name: "alpha"})
+ts.Insert(&waypoint{distance: 71, name: "xray"})
+```
+

--- a/vendor/github.com/hashicorp/go-set/v3/collection.go
+++ b/vendor/github.com/hashicorp/go-set/v3/collection.go
@@ -1,0 +1,245 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import "iter"
+
+// Collection is a minimal common interface that all sets implement.
+
+// Fundamental set operations and familiar utility methods are part of this
+// interface. Each of Set, HashSet, and TreeSet may also provide implementation
+// specific methods not part of this interface.
+type Collection[T any] interface {
+
+	// Insert an element into the set.
+	//
+	// Returns true if the set is modified as a result.
+	Insert(T) bool
+
+	// InsertSlice will insert each element of a given slice into the set.
+	//
+	// Returns true if the set was modified as a result.
+	InsertSlice([]T) bool
+
+	// InsertSet will insert each element of a given Collection into the set.
+	//
+	// Returns true if the set was modified as a result.
+	InsertSet(Collection[T]) bool
+
+	// Remove will remove the given element from the set, if present.
+	//
+	// Returns true if the set was modified as a result of the operation.
+	Remove(T) bool
+
+	// RemoveSlice will remove each element of a slice from the set, if present.
+	//
+	// Returns true if the set was modified as a result of the operation.
+	RemoveSlice([]T) bool
+
+	// RemoveSet will remove each element of a Collection from the set.
+	//
+	// Returns true if the set was modified as a result of the operation.
+	RemoveSet(Collection[T]) bool
+
+	// RemoveFunc will remove each element from the set that satisfies the given predicate.
+	//
+	// Returns true if the set was modified as a result of the opearation.
+	RemoveFunc(func(T) bool) bool
+
+	// Contains returns whether an element is present in the set.
+	Contains(T) bool
+
+	// ContainsSlice returns whether the set contains the same set of elements as
+	// the given slice. The elements of the slice may contain duplicates.
+	ContainsSlice([]T) bool
+
+	// Subset returns whether the given Collection is a subset of the set.
+	Subset(Collection[T]) bool
+
+	// ProperSubset returns whether the given Collection is a proper subset of the set.
+	ProperSubset(Collection[T]) bool
+
+	// Size returns the number of elements in the set.
+	Size() int
+
+	// Empty returns whether the set contains no elements.
+	Empty() bool
+
+	// Union returns a new set containing the unique elements of both this set
+	// and a given Collection.
+	//
+	// https://en.wikipedia.org/wiki/Union_(set_theory)
+	Union(Collection[T]) Collection[T]
+
+	// Difference returns a new set that contains elements this set that are not
+	// in a given Collection.
+	//
+	// https://en.wikipedia.org/wiki/Complement_(set_theory)
+	Difference(Collection[T]) Collection[T]
+
+	// Intersect returns a new set that contains only the elements present in
+	// both this and a given Collection.
+	//
+	// https://en.wikipedia.org/wiki/Intersection_(set_theory)
+	Intersect(Collection[T]) Collection[T]
+
+	// Slice returns a slice of all elements in the set.
+	//
+	// For iterating elements, consider using Items() instead.
+	//
+	// Note: order of elements depends on the underlying implementation.
+	Slice() []T
+
+	// String creates a string representation of this set.
+	//
+	// Note: string representation depends on underlying implementation.
+	String() string
+
+	// StringFunc creates a string representation of this set, using the given
+	// function to transform each element into a string.
+	//
+	// Note: string representation depends on underlying implementation.
+	StringFunc(func(T) string) string
+
+	// EqualSet returns whether this set and a given Collection contain the same
+	// elements.
+	EqualSet(Collection[T]) bool
+
+	// EqualSlice returns whether this set and a given slice contain the same
+	// elements, where the slice may contain duplicates.
+	EqualSlice([]T) bool
+
+	// EqualSliceSet returns whether this set and a given slice contain exactly
+	// the same elements, where the slice must not contain duplicates.
+	EqualSliceSet([]T) bool
+
+	// Items returns a generator function for use with the range keyword
+	// enabling iteration of each element in the set.
+	//
+	// Note: iteration order depends on the underlying implementation.
+	//
+	//	for element := range s.Items() { ... }
+	Items() iter.Seq[T]
+}
+
+// InsertSliceFunc inserts all elements from items into col, applying the transform
+// function to each element before insertion.
+//
+// Returns true if col was modified as a result of the operation.
+func InsertSliceFunc[T, E any](col Collection[T], items []E, transform func(element E) T) bool {
+	modified := false
+	for _, item := range items {
+		if col.Insert(transform(item)) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// InsertSetFunc inserts the elements of a into b, applying the transform function
+// to each element before insertion.
+//
+// Returns true if b was modified as a result.
+func InsertSetFunc[T, E any](a Collection[T], b Collection[E], transform func(T) E) bool {
+	modified := false
+	for item := range a.Items() {
+		if b.Insert(transform(item)) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// SliceFunc produces a slice of the elements in s, applying the transform
+// function to each element first.
+func SliceFunc[T, E any](s Collection[T], transform func(T) E) []E {
+	slice := make([]E, 0, s.Size())
+	for item := range s.Items() {
+		slice = append(slice, transform(item))
+	}
+	return slice
+}
+
+func insert[T any](destination, col Collection[T]) {
+	for item := range col.Items() {
+		destination.Insert(item)
+	}
+}
+
+func intersect[T any](destination, a, b Collection[T]) {
+	var (
+		big   Collection[T] = a
+		small Collection[T] = b
+	)
+	if a.Size() < b.Size() {
+		big, small = b, a
+	}
+	for item := range small.Items() {
+		if big.Contains(item) {
+			destination.Insert(item)
+		}
+	}
+}
+
+func containsSlice[T any](col Collection[T], items []T) bool {
+	for _, item := range items {
+		if !col.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalSet[T any](a, b Collection[T]) bool {
+	// fast paths: sets are empty or different sizes
+	sizeA, sizeB := a.Size(), b.Size()
+	if sizeA == 0 && sizeB == 0 {
+		return true
+	}
+	if sizeA != sizeB {
+		return false
+	}
+
+	// look for any missing element
+	for item := range a.Items() {
+		if !b.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func removeSet[T any](s, col Collection[T]) bool {
+	modified := false
+	for item := range col.Items() {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+func removeFunc[T any](col Collection[T], predicate func(T) bool) bool {
+	remove := make([]T, 0)
+	for item := range col.Items() {
+		if predicate(item) {
+			remove = append(remove, item)
+		}
+	}
+	return col.RemoveSlice(remove)
+}
+
+func subset[T any](a, b Collection[T]) bool {
+	if b.Size() > a.Size() {
+		return false
+	}
+
+	for item := range b.Items() {
+		if !a.Contains(item) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-set/v3/hashset.go
+++ b/vendor/github.com/hashicorp/go-set/v3/hashset.go
@@ -1,0 +1,341 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import (
+	"fmt"
+	"iter"
+	"sort"
+)
+
+// Hash represents the output type of a Hash() function defined on a type.
+//
+// A Hash could be string-like or int-like. A string hash could be something like
+// and md5, sha1, or GoString() representation of a type. An int hash could be
+// something like the prime multiple hash code of a type.
+type Hash interface {
+	~string | ~int | ~uint | ~int64 | ~uint64 | ~int32 | ~uint32 | ~int16 | ~uint16 | ~int8 | ~uint8
+}
+
+// Hasher represents a type that implements a Hash() method. Types that wish to
+// cache a hash value with an internal field should implement Hash accordingly.
+type Hasher[H Hash] interface {
+	Hash() H
+}
+
+// HasherFunc creates a closure around the T.Hash function so that the type can
+// be used as the HashFunc for a HashSet.
+func HasherFunc[T Hasher[H], H Hash]() HashFunc[T, H] {
+	return func(t T) H {
+		return t.Hash()
+	}
+}
+
+// HashFunc represents a function that that produces a hash value when applied
+// to a given T. Typically this will be implemented as T.Hash but by separating
+// HashFunc a HashSet can be made to make use of any hash implementation.
+type HashFunc[T any, H Hash] func(T) H
+
+// HashSet is a generic implementation of the mathematical data structure, oriented
+// around the use of a HashFunc to make hash values from other types.
+type HashSet[T any, H Hash] struct {
+	fn    HashFunc[T, H]
+	items map[H]T
+}
+
+// NewHashSet creates a HashSet with underlying capacity of size and will compute
+// hash values from the T.Hash method.
+func NewHashSet[T Hasher[H], H Hash](size int) *HashSet[T, H] {
+	return NewHashSetFunc[T, H](size, HasherFunc[T, H]())
+}
+
+// NewHashSetFunc creates a HashSet with underlying capacity of size and uses
+// the given hashing function to compute hashes on elements.
+//
+// A HashSet will automatically grow or shrink its capacity as items are added
+// or removed.
+func NewHashSetFunc[T any, H Hash](size int, fn HashFunc[T, H]) *HashSet[T, H] {
+	return &HashSet[T, H]{
+		fn:    fn,
+		items: make(map[H]T, max(0, size)),
+	}
+}
+
+// HashSetFrom creates a new HashSet containing each element in items.
+//
+// T must implement HashFunc[H], where H is of type Hash. This allows custom types
+// that include non-comparable fields to provide their own hash algorithm.
+func HashSetFrom[T Hasher[H], H Hash](items []T) *HashSet[T, H] {
+	s := NewHashSet[T, H](len(items))
+	s.InsertSlice(items)
+	return s
+}
+
+// NewHashSetFromFunc creates a new HashSet containing each element in items.
+func HashSetFromFunc[T any, H Hash](items []T, hash HashFunc[T, H]) *HashSet[T, H] {
+	s := NewHashSetFunc[T, H](len(items), hash)
+	s.InsertSlice(items)
+	return s
+}
+
+// Insert item into s.
+//
+// Return true if s was modified (item was not already in s), false otherwise.
+func (s *HashSet[T, H]) Insert(item T) bool {
+	key := s.fn(item)
+	if _, exists := s.items[key]; exists {
+		return false
+	}
+	s.items[key] = item
+	return true
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *HashSet[T, H]) InsertSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// InsertSet will insert each element of col into s.
+//
+// Return true if s was modified (at least one item of col was not already in s), false otherwise.
+func (s *HashSet[T, H]) InsertSet(col Collection[T]) bool {
+	modified := false
+	for item := range col.Items() {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// Remove will remove item from s.
+//
+// Return true if s was modified (item was present), false otherwise.
+func (s *HashSet[T, H]) Remove(item T) bool {
+	key := s.fn(item)
+	if _, exists := s.items[key]; !exists {
+		return false
+	}
+	delete(s.items, key)
+	return true
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was present), false otherwise.
+func (s *HashSet[T, H]) RemoveSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// RemoveSet will remove each element of col from s.
+//
+// Return true if s was modified (any item of col was present in s), false otherwise.
+func (s *HashSet[T, H]) RemoveSet(col Collection[T]) bool {
+	return removeSet(s, col)
+}
+
+// RemoveFunc will remove each element from s that satisfies condition f.
+//
+// Return true if s was modified, false otherwise.
+func (s *HashSet[T, H]) RemoveFunc(f func(item T) bool) bool {
+	return removeFunc(s, f)
+}
+
+// Contains returns whether item is present in s.
+func (s *HashSet[T, H]) Contains(item T) bool {
+	hash := s.fn(item)
+	_, exists := s.items[hash]
+	return exists
+}
+
+// ContainsSlice returns true if all elements of items are in s, otherwise
+// false.
+func (s *HashSet[T, H]) ContainsSlice(items []T) bool {
+	for _, item := range items {
+		hash := s.fn(item)
+		if _, exists := s.items[hash]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+// Subset returns whether col is a subset of s.
+func (s *HashSet[T, H]) Subset(col Collection[T]) bool {
+	return subset(s, col)
+}
+
+// ProperSubset returns whether col is a proper subset of s.
+func (s *HashSet[T, H]) ProperSubset(col Collection[T]) bool {
+	if len(s.items) <= col.Size() {
+		return false
+	}
+	return s.Subset(col)
+}
+
+// Size returns the cardinality of s.
+func (s *HashSet[T, H]) Size() int {
+	return len(s.items)
+}
+
+// Empty returns true if s contains no elements, false otherwise.
+func (s *HashSet[T, H]) Empty() bool {
+	return s.Size() == 0
+}
+
+// Union returns a set that contains all elements of s and col combined.
+//
+// Elements in s take priority in the event of colliding hash values.
+func (s *HashSet[T, H]) Union(col Collection[T]) Collection[T] {
+	result := NewHashSetFunc[T, H](s.Size(), s.fn)
+	insert(result, s)
+	insert(result, col)
+	return result
+}
+
+// Difference returns a set that contains elements of s that are not in col.
+func (s *HashSet[T, H]) Difference(col Collection[T]) Collection[T] {
+	result := NewHashSetFunc[T, H](max(0, s.Size()-col.Size()), s.fn)
+	for item := range s.Items() {
+		if !col.Contains(item) {
+			result.Insert(item)
+		}
+	}
+	return result
+}
+
+// Intersect returns a set that contains elements that are present in both s and col.
+func (s *HashSet[T, H]) Intersect(col Collection[T]) Collection[T] {
+	result := NewHashSetFunc[T, H](0, s.fn)
+	intersect(result, s, col)
+	return result
+}
+
+// Copy creates a shallow copy of s.
+func (s *HashSet[T, H]) Copy() *HashSet[T, H] {
+	result := NewHashSetFunc[T, H](s.Size(), s.fn)
+	for key, item := range s.items {
+		result.items[key] = item
+	}
+	return result
+}
+
+// Slice creates a copy of s as a slice.
+//
+// The result is not ordered.
+func (s *HashSet[T, H]) Slice() []T {
+	result := make([]T, 0, s.Size())
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result
+}
+
+// String creates a string representation of s, using "%v" printf formatting to transform
+// each element into a string. The result contains elements sorted by their lexical
+// string order.
+func (s *HashSet[T, H]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each element
+// into a string. The result contains elements sorted by their string order.
+func (s *HashSet[T, H]) StringFunc(f func(element T) string) string {
+	l := make([]string, 0, s.Size())
+	for _, item := range s.items {
+		l = append(l, f(item))
+	}
+	sort.Strings(l)
+	return fmt.Sprintf("%s", l)
+}
+
+// Equal returns whether s and o contain the same elements.
+func (s *HashSet[T, H]) Equal(o *HashSet[T, H]) bool {
+	if len(s.items) != len(o.items) {
+		return false
+	}
+	for _, item := range s.items {
+		if !o.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualSet returns whether s and col contain the same elements.
+func (s *HashSet[T, H]) EqualSet(col Collection[T]) bool {
+	return equalSet(s, col)
+}
+
+// EqualSlice returns whether s and items contain the same elements.
+//
+// The items slice may contain duplicates.
+//
+// If the items slice is known to contain no duplicates, EqualSliceSet can be
+// used instead as a faster implementation.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *HashSet[T, H]) EqualSlice(items []T) bool {
+	other := HashSetFromFunc[T, H](items, s.fn)
+	return s.Equal(other)
+}
+
+// EqualSliceSet returns whether s and items contain exactly the same elements.
+//
+// If items contains duplicates EqualSliceSet will return false. The elements of
+// items are assumed to be set-like. For comparing s to a slice that may contain
+// duplicate elements, use EqualSlice instead.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *HashSet[T, H]) EqualSliceSet(items []T) bool {
+	if len(items) != s.Size() {
+		return false
+	}
+	for _, item := range items {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *HashSet[T, H]) MarshalJSON() ([]byte, error) {
+	return marshalJSON[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *HashSet[T, H]) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON[T](s, data)
+}
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for element := range s.Items() { ... }
+func (s *HashSet[T, H]) Items() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, item := range s.items {
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-set/v3/serialization.go
+++ b/vendor/github.com/hashicorp/go-set/v3/serialization.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import "encoding/json"
+
+// marshalJSON will serialize a Serializable[T] into a json byte array
+func marshalJSON[T any](s Collection[T]) ([]byte, error) {
+	return json.Marshal(s.Slice())
+}
+
+// unmarshalJSON will deserialize a json byte array into a Serializable[T]
+func unmarshalJSON[T any](s Collection[T], data []byte) error {
+	slice := make([]T, 0)
+	err := json.Unmarshal(data, &slice)
+	if err != nil {
+		return err
+	}
+	s.InsertSlice(slice)
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-set/v3/set.go
+++ b/vendor/github.com/hashicorp/go-set/v3/set.go
@@ -1,0 +1,313 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package set provides a basic generic set implementation.
+//
+// https://en.wikipedia.org/wiki/Set_(mathematics)
+package set
+
+import (
+	"fmt"
+	"iter"
+	"sort"
+)
+
+type nothing struct{}
+
+var sentinel = nothing{}
+
+// New creates a new Set with initial underlying capacity of size.
+//
+// A Set will automatically grow or shrink its capacity as items are added or
+// removed.
+//
+// T may be any comparable type. Keep in mind that pointer types or structs
+// containing pointer fields will be compared using shallow equality. For deep
+// equality use HashSet instead.
+func New[T comparable](size int) *Set[T] {
+	return &Set[T]{
+		items: make(map[T]nothing, max(0, size)),
+	}
+}
+
+// From creates a new Set containing each item in items.
+//
+// T may be any comparable type. Keep in mind that pointer types or structs
+// containing pointer fields will be compared using shallow equality. For deep
+// equality use HashSet instead.
+func From[T comparable](items []T) *Set[T] {
+	s := New[T](len(items))
+	s.InsertSlice(items)
+	return s
+}
+
+// FromFunc creates a new Set containing a conversion of each item in items.
+//
+// T may be any comparable type. Keep in mind that pointer types or structs
+// containing pointer fields will be compared using shallow equality. For deep
+// equality use HashSet instead.
+func FromFunc[A any, T comparable](items []A, conversion func(A) T) *Set[T] {
+	s := New[T](len(items))
+	for _, item := range items {
+		s.Insert(conversion(item))
+	}
+	return s
+}
+
+// Set is a simple, generic implementation of the set mathematical data structure.
+// It is optimized for correctness and convenience, as a replacement for the use
+// of map[interface{}]struct{}.
+type Set[T comparable] struct {
+	items map[T]nothing
+}
+
+// Insert item into s.
+//
+// Return true if s was modified (item was not already in s), false otherwise.
+func (s *Set[T]) Insert(item T) bool {
+	if _, exists := s.items[item]; exists {
+		return false
+	}
+	if s.items == nil {
+		s.items = make(map[T]nothing)
+	}
+	s.items[item] = sentinel
+	return true
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *Set[T]) InsertSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// InsertSet will insert each element of col into s.
+//
+// Return true if s was modified (at least one item of col was not already in s), false otherwise.
+func (s *Set[T]) InsertSet(col Collection[T]) bool {
+	modified := false
+	for item := range col.Items() {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// Remove will remove item from s.
+//
+// Return true if s was modified (item was present), false otherwise.
+func (s *Set[T]) Remove(item T) bool {
+	if _, exists := s.items[item]; !exists {
+		return false
+	}
+	delete(s.items, item)
+	return true
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was present), false otherwise.
+func (s *Set[T]) RemoveSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// RemoveSet will remove each element of col from s.
+//
+// Return true if s was modified (any item of o was present in s), false otherwise.
+func (s *Set[T]) RemoveSet(col Collection[T]) bool {
+	return removeSet(s, col)
+}
+
+// RemoveFunc will remove each element from s that satisfies condition f.
+//
+// Return true if s was modified, false otherwise.
+func (s *Set[T]) RemoveFunc(f func(T) bool) bool {
+	return removeFunc(s, f)
+}
+
+// Contains returns whether item is present in s.
+func (s *Set[T]) Contains(item T) bool {
+	_, exists := s.items[item]
+	return exists
+}
+
+// ContainsSlice returns whether all elements in items are present in s.
+func (s *Set[T]) ContainsSlice(items []T) bool {
+	return containsSlice(s, items)
+}
+
+// Subset returns whether col is a subset of s.
+func (s *Set[T]) Subset(col Collection[T]) bool {
+	return subset(s, col)
+}
+
+// Subset returns whether col is a proper subset of s.
+func (s *Set[T]) ProperSubset(col Collection[T]) bool {
+	if len(s.items) <= col.Size() {
+		return false
+	}
+	return s.Subset(col)
+}
+
+// Size returns the cardinality of s.
+func (s *Set[T]) Size() int {
+	return len(s.items)
+}
+
+// Empty returns true if s contains no elements, false otherwise.
+func (s *Set[T]) Empty() bool {
+	return s.Size() == 0
+}
+
+// Union returns a set that contains all elements of s and col combined.
+func (s *Set[T]) Union(col Collection[T]) Collection[T] {
+	size := max(s.Size(), col.Size())
+	result := New[T](size)
+	insert(result, s)
+	insert(result, col)
+	return result
+}
+
+// Difference returns a set that contains elements of s that are not in col.
+func (s *Set[T]) Difference(col Collection[T]) Collection[T] {
+	result := New[T](max(0, s.Size()-col.Size()))
+	for item := range s.items {
+		if !col.Contains(item) {
+			result.items[item] = sentinel
+		}
+	}
+	return result
+}
+
+// Intersect returns a set that contains elements that are present in both s and col.
+func (s *Set[T]) Intersect(col Collection[T]) Collection[T] {
+	result := New[T](0)
+	intersect(result, s, col)
+	return result
+}
+
+// Copy creates a copy of s.
+func (s *Set[T]) Copy() *Set[T] {
+	result := New[T](s.Size())
+	for item := range s.items {
+		result.items[item] = sentinel
+	}
+	return result
+}
+
+// Slice creates a copy of s as a slice. Elements are in no particular order.
+func (s *Set[T]) Slice() []T {
+	result := make([]T, 0, s.Size())
+	for item := range s.items {
+		result = append(result, item)
+	}
+	return result
+}
+
+// String creates a string representation of s, using "%v" printf formating to transform
+// each element into a string. The result contains elements sorted by their lexical
+// string order.
+func (s *Set[T]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each element
+// into a string. The result contains elements sorted by their lexical string order.
+func (s *Set[T]) StringFunc(f func(element T) string) string {
+	l := make([]string, 0, s.Size())
+	for item := range s.items {
+		l = append(l, f(item))
+	}
+	sort.Strings(l)
+	return fmt.Sprintf("%s", l)
+}
+
+// Equal returns whether s and o contain the same elements.
+func (s *Set[T]) Equal(o *Set[T]) bool {
+	if len(s.items) != len(o.items) {
+		return false
+	}
+	for item := range s.items {
+		if !o.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualSet returns whether s and col contain the same elements.
+func (s *Set[T]) EqualSet(col Collection[T]) bool {
+	return equalSet(s, col)
+}
+
+// EqualSlice returns whether s and items contain the same elements.
+//
+// The items slice may contain duplicates.
+//
+// If the items slice is known to contain no duplicates, EqualSliceSet may be
+// used instead as a faster implementation.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *Set[T]) EqualSlice(items []T) bool {
+	other := From[T](items)
+	return s.Equal(other)
+}
+
+// EqualSliceSet returns whether s and items contain exactly the same elements.
+//
+// If items contains duplicates EqualSliceSet will return false. The elements of
+// items are assumed to be set-like. For comparing s to a slice that may contain
+// duplicate elements, use EqualSlice instead.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *Set[T]) EqualSliceSet(items []T) bool {
+	if len(items) != s.Size() {
+		return false
+	}
+	for _, item := range items {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *Set[T]) MarshalJSON() ([]byte, error) {
+	return marshalJSON[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *Set[T]) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON[T](s, data)
+}
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for element := range s.Items() { ... }
+func (s *Set[T]) Items() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for item := range s.items {
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-set/v3/stack.go
+++ b/vendor/github.com/hashicorp/go-set/v3/stack.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+type stack[T any] struct {
+	top *object[T]
+}
+
+type object[T any] struct {
+	item T
+	next *object[T]
+}
+
+func makeStack[T any]() *stack[T] {
+	return new(stack[T])
+}
+
+func (s *stack[T]) push(item T) {
+	obj := &object[T]{
+		item: item,
+		next: s.top,
+	}
+	s.top = obj
+}
+
+func (s *stack[T]) pop() T {
+	obj := s.top
+	s.top = obj.next
+	obj.next = nil
+	return obj.item
+}
+
+func (s *stack[T]) empty() bool {
+	return s.top == nil
+}

--- a/vendor/github.com/hashicorp/go-set/v3/treeset.go
+++ b/vendor/github.com/hashicorp/go-set/v3/treeset.go
@@ -1,0 +1,1022 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import (
+	"fmt"
+	"iter"
+)
+
+// CompareFunc represents a function that compares two elements.
+//
+// Must return
+// < 0 if the first parameter is less than the second parameter
+// 0 if the two parameters are equal
+// > 0 if the first parameters is greater than the second parameter
+//
+// Often T will be a type that satisfies cmp.Ordered, and CompareFunc can
+// be implemented by using cmp.Compare.
+type CompareFunc[T any] func(T, T) int
+
+// TreeSet provides a generic sortable set implementation for Go.
+// Enables fast storage and retrieval of ordered information. Most effective
+// in cases where data is regularly being added and/or removed and fast
+// lookup properties must be maintained.
+//
+// The underlying data structure is a Red-Black Binary Search Tree.
+// https://en.wikipedia.org/wiki/Red–black_tree
+//
+// Not thread safe, and not safe for concurrent modification.
+type TreeSet[T any] struct {
+	comparison CompareFunc[T]
+	root       *node[T]
+	marker     *node[T]
+	size       int
+}
+
+// NewTreeSet creates a TreeSet of type T, comparing elements via a given
+// CompareFunc[T].
+//
+// T may be any type.
+//
+// For builtin types, CompareBuiltin provides a convenient CompareFunc implementation.
+func NewTreeSet[T any](compare CompareFunc[T]) *TreeSet[T] {
+	return &TreeSet[T]{
+		comparison: compare,
+		root:       nil,
+		marker:     &node[T]{color: black},
+		size:       0,
+	}
+}
+
+// TreeSetFrom creates a new TreeSet containing each item in items.
+//
+// T may be any type.
+//
+// C is an implementation of CompareFunc[T]. For builtin types, Cmp provides a
+// convenient Compare implementation.
+func TreeSetFrom[T any](items []T, compare CompareFunc[T]) *TreeSet[T] {
+	s := NewTreeSet[T](compare)
+	s.InsertSlice(items)
+	return s
+}
+
+// Insert item into s.
+//
+// Returns true if s was modified (item was not already in s), false otherwise.
+func (s *TreeSet[T]) Insert(item T) bool {
+	return s.insert(&node[T]{
+		element: item,
+		color:   red,
+	})
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *TreeSet[T]) InsertSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// InsertSet will insert each element of col into s.
+//
+// Return true if s was modified (at least one item of o was not already in s), false otherwise.
+func (s *TreeSet[T]) InsertSet(col Collection[T]) bool {
+	modified := false
+	for item := range col.Items() {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// Remove item from s.
+//
+// Returns true if s was modified (item was in s), false otherwise.
+func (s *TreeSet[T]) Remove(item T) bool {
+	return s.delete(item)
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was in s), false otherwise.
+func (s *TreeSet[T]) RemoveSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// RemoveSet will remove each element in col from s.
+//
+// Returns true if s was modified (at least one item in o was in s), false otherwise.
+func (s *TreeSet[T]) RemoveSet(col Collection[T]) bool {
+	return removeSet(s, col)
+}
+
+// RemoveFunc will remove each element from s that satisifies condition f.
+//
+// Return true if s was modified, false otherwise.
+func (s *TreeSet[T]) RemoveFunc(f func(T) bool) bool {
+	return removeFunc(s, f)
+}
+
+// Min returns the smallest item in the set.
+//
+// Must not be called on an empty set.
+func (s *TreeSet[T]) Min() T {
+	if s.root == nil {
+		panic("min: tree is empty")
+	}
+	n := s.min(s.root)
+	return n.element
+}
+
+// Max returns the largest item in s.
+//
+// Must not be called on an empty set.
+func (s *TreeSet[T]) Max() T {
+	if s.root == nil {
+		panic("max: tree is empty")
+	}
+	n := s.max(s.root)
+	return n.element
+}
+
+// TopK returns the top n (smallest) elements in s, in ascending order.
+func (s *TreeSet[T]) TopK(n int) []T {
+	result := make([]T, 0, n)
+	s.fillLeft(s.root, &result)
+	return result
+}
+
+// BottomK returns the bottom n (largest) elements in s, in descending order.
+func (s *TreeSet[T]) BottomK(n int) []T {
+	result := make([]T, 0, n)
+	s.fillRight(s.root, &result)
+	return result
+}
+
+// FirstBelow returns the first element strictly below item.
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T]) FirstBelow(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c > 0:
+			candidate = n
+			n = n.right
+		case c <= 0:
+			n = n.left
+		}
+	}
+	return candidate.get()
+}
+
+// FirstBelowEqual returns the first element below item (or item itself if present).
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T]) FirstBelowEqual(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c == 0:
+			return n.get()
+		case c > 0:
+			candidate = n
+			n = n.right
+		case c < 0:
+			n = n.left
+		}
+	}
+	return candidate.get()
+}
+
+// Below returns a TreeSet containing the elements of s that are < item.
+func (s *TreeSet[T]) Below(item T) *TreeSet[T] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterLeft(s.root, func(element T) bool {
+		return s.comparison(element, item) < 0
+	}, result)
+	return result
+}
+
+// BelowEqual returns a TreeSet containing the elements of s that are ≤ item.
+func (s *TreeSet[T]) BelowEqual(item T) *TreeSet[T] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterLeft(s.root, func(element T) bool {
+		return s.comparison(element, item) <= 0
+	}, result)
+	return result
+}
+
+// FirstAbove returns the first element strictly above item.
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T]) FirstAbove(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c < 0:
+			candidate = n
+			n = n.left
+		case c >= 0:
+			n = n.right
+		}
+	}
+	return candidate.get()
+}
+
+// FirstAboveEqual returns the first element above item (or item itself if present).
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T]) FirstAboveEqual(item T) (T, bool) {
+	var candidate *node[T]
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c == 0:
+			return n.get()
+		case c < 0:
+			candidate = n
+			n = n.left
+		case c > 0:
+			n = n.right
+		}
+	}
+	return candidate.get()
+}
+
+// After returns a TreeSet containing the elements of s that are > item.
+func (s *TreeSet[T]) Above(item T) *TreeSet[T] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterRight(s.root, func(element T) bool {
+		return s.comparison(element, item) > 0
+	}, result)
+	return result
+}
+
+// AfterEqual returns a TreeSet containing the elements of s that are ≥ item.
+func (s *TreeSet[T]) AboveEqual(item T) *TreeSet[T] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterRight(s.root, func(element T) bool {
+		return s.comparison(element, item) >= 0
+	}, result)
+	return result
+}
+
+// Contains returns whether item is present in s.
+func (s *TreeSet[T]) Contains(item T) bool {
+	return s.locate(s.root, item) != nil
+}
+
+// ContainsSlice returns whether all elements in items are present in s.
+func (s *TreeSet[T]) ContainsSlice(items []T) bool {
+	return containsSlice(s, items)
+}
+
+// Size returns the number of elements in s.
+func (s *TreeSet[T]) Size() int {
+	return s.size
+}
+
+// Empty returns true if there are no elements in s.
+func (s *TreeSet[T]) Empty() bool {
+	return s.Size() == 0
+}
+
+// Slice returns the elements of s as a slice, in order.
+func (s *TreeSet[T]) Slice() []T {
+	result := make([]T, 0, s.Size())
+	for item := range s.Items() {
+		result = append(result, item)
+	}
+	return result
+}
+
+// Subset returns whether col is a subset of s.
+func (s *TreeSet[T]) Subset(col Collection[T]) bool {
+	// try the fast paths
+	if col.Empty() {
+		return true
+	}
+	if s.Empty() {
+		return false
+	}
+	if s.Size() < col.Size() {
+		return false
+	}
+
+	// iterate o, and increment s finding each element
+	// i.e. merge algorithm but with channels
+	iterO := col.(*TreeSet[T]).iterate()
+	iterS := s.iterate()
+
+	idxO := 0
+	idxS := 0
+
+next:
+	for ; idxO < col.Size(); idxO++ {
+		nextO := iterO()
+		for idxS < s.Size() {
+			idxS++
+			nextS := iterS()
+			cmp := s.compare(nextS, nextO)
+			switch {
+			case cmp > 0:
+				return false
+			case cmp < 0:
+				continue
+			default:
+				continue next
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// ProperSubset returns whether col is a proper subset of s.
+func (s *TreeSet[T]) ProperSubset(col Collection[T]) bool {
+	if s.Size() <= col.Size() {
+		return false
+	}
+	return s.Subset(col)
+}
+
+// Union returns a set that contains all elements of s and col combined.
+func (s *TreeSet[T]) Union(col Collection[T]) Collection[T] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) { tree.Insert(n.element) }
+	s.prefix(f, s.root)
+	oSet := col.(*TreeSet[T])
+	oSet.prefix(f, oSet.root)
+	return tree
+}
+
+// Difference returns a set that contains elements of s that are not in col.
+func (s *TreeSet[T]) Difference(col Collection[T]) Collection[T] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		if !col.Contains(n.element) {
+			tree.Insert(n.element)
+		}
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Intersect returns a set that contains elements that are present in both s and col.
+func (s *TreeSet[T]) Intersect(col Collection[T]) Collection[T] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		if col.Contains(n.element) {
+			tree.Insert(n.element)
+		}
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Copy creates a copy of s.
+//
+// Individual elements are reference copies.
+func (s *TreeSet[T]) Copy() *TreeSet[T] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		tree.Insert(n.element)
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Equal return whether s and o contain the same elements.
+func (s *TreeSet[T]) Equal(o *TreeSet[T]) bool {
+	// try the fast fail paths
+	if s.Empty() || o.Empty() {
+		return s.Size() == o.Size()
+	}
+	switch {
+	case s.Size() != o.Size():
+		return false
+	case s.comparison(s.Min(), o.Min()) != 0:
+		return false
+	case s.comparison(s.Max(), o.Max()) != 0:
+		return false
+	}
+
+	iterS := s.iterate()
+	iterO := o.iterate()
+	for i := 0; i < s.Size(); i++ {
+		nextS := iterS()
+		nextO := iterO()
+		if s.compare(nextS, nextO) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// EqualSet returns s and col contain the same elements.
+func (s *TreeSet[T]) EqualSet(col Collection[T]) bool {
+	return equalSet(s, col)
+}
+
+// EqualSlice returns whether s and items contain the same elements.
+//
+// The items slice may contain duplicates.
+//
+// If the items slice is known to contain no duplicates, EqualSliceSet may be
+// used instead as a faster implementation.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *TreeSet[T]) EqualSlice(items []T) bool {
+	other := TreeSetFrom[T](items, s.comparison)
+	return s.Equal(other)
+}
+
+// EqualSliceSet returns whether s and items contain exactly the same elements.
+//
+// If items contains duplicates EqualSliceSet will return false. The elements of
+// items are assumed to be set-like. For comparing s to a slice that may contain
+// duplicate elements, use EqualSlice instead.
+//
+// To detect if a slice is a subset of s, use ContainsSlice.
+func (s *TreeSet[T]) EqualSliceSet(items []T) bool {
+	// TODO optimize
+	if s.Size() != len(items) {
+		return false
+	}
+	return s.EqualSlice(items)
+}
+
+// String creates a string representation of s, using "%v" printf formatting
+// each element into a string. The result contains elements in order.
+func (s *TreeSet[T]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each
+// element into a string. The result contains elements in order.
+func (s *TreeSet[T]) StringFunc(f func(T) string) string {
+	l := make([]string, 0, s.Size())
+	for item := range s.Items() {
+		l = append(l, f(item))
+	}
+	return fmt.Sprintf("%s", l)
+}
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for i, element := range s.Items() { ... }
+func (s *TreeSet[T]) Items() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		iter := s.iterate()
+		n := iter()
+		for i := 0; n != nil; i++ {
+			if !yield(n.element) {
+				return
+			}
+			n = iter()
+		}
+	}
+}
+
+// Red-Black Tree Invariants
+//
+// 1. each node is either red or black
+// 2. the root node is always black
+// 3. nil leaf nodes are always black
+// 4. a red node must not have red children
+// 5. all simple paths from a node to nil leaf contain the same number of
+// black nodes
+
+type color bool
+
+const (
+	red   color = false
+	black color = true
+)
+
+type node[T any] struct {
+	element T
+	color   color
+	parent  *node[T]
+	left    *node[T]
+	right   *node[T]
+}
+
+func (n *node[T]) black() bool {
+	return n == nil || n.color == black
+}
+
+func (n *node[T]) red() bool {
+	return n != nil && n.color == red
+}
+
+func (n *node[T]) get() (T, bool) {
+	if n == nil {
+		var zero T
+		return zero, false
+	}
+	return n.element, true
+}
+
+func (s *TreeSet[T]) locate(start *node[T], target T) *node[T] {
+	n := start
+	for {
+		if n == nil {
+			return nil
+		}
+		cmp := s.compare(n, &node[T]{element: target})
+		switch {
+		case cmp < 0:
+			n = n.right
+		case cmp > 0:
+			n = n.left
+		default:
+			return n
+		}
+	}
+}
+
+func (s *TreeSet[T]) rotateRight(n *node[T]) {
+	parent := n.parent
+	leftChild := n.left
+
+	n.left = leftChild.right
+	if leftChild.right != nil {
+		leftChild.right.parent = n
+	}
+
+	leftChild.right = n
+	n.parent = leftChild
+
+	s.replaceChild(parent, n, leftChild)
+}
+
+func (s *TreeSet[T]) rotateLeft(n *node[T]) {
+	parent := n.parent
+	rightChild := n.right
+
+	n.right = rightChild.left
+	if rightChild.left != nil {
+		rightChild.left.parent = n
+	}
+
+	rightChild.left = n
+	n.parent = rightChild
+
+	s.replaceChild(parent, n, rightChild)
+}
+
+func (s *TreeSet[T]) replaceChild(parent, previous, next *node[T]) {
+	switch {
+	case parent == nil:
+		s.root = next
+	case parent.left == previous:
+		parent.left = next
+	case parent.right == previous:
+		parent.right = next
+	default:
+		panic("node is not child of its parent")
+	}
+
+	if next != nil {
+		next.parent = parent
+	}
+}
+
+func (s *TreeSet[T]) insert(n *node[T]) bool {
+	var (
+		parent *node[T] = nil
+		tmp    *node[T] = s.root
+	)
+
+	for tmp != nil {
+		parent = tmp
+
+		cmp := s.compare(n, tmp)
+		switch {
+		case cmp < 0:
+			tmp = tmp.left
+		case cmp > 0:
+			tmp = tmp.right
+		default:
+			// already exists in tree
+			return false
+		}
+	}
+
+	n.color = red
+	switch {
+	case parent == nil:
+		s.root = n
+	case s.compare(n, parent) < 0:
+		parent.left = n
+	default:
+		parent.right = n
+	}
+	n.parent = parent
+
+	s.rebalanceInsertion(n)
+	s.size++
+	return true
+}
+
+func (s *TreeSet[T]) rebalanceInsertion(n *node[T]) {
+	parent := n.parent
+
+	// case 1: parent is nil
+	// - means we are the root
+	// - our color must be black
+	if parent == nil {
+		n.color = black
+		return
+	}
+
+	// if parent is black there is nothing to do
+	if parent.black() {
+		return
+	}
+
+	// case 2: no grandparent
+	// - implies the parent is root
+	// - we must now be black
+	grandparent := parent.parent
+	if grandparent == nil {
+		parent.color = black
+		return
+	}
+
+	uncle := s.uncleOf(parent)
+
+	switch {
+	// case 3: uncle is red
+	// - fix color of parent, grandparent, uncle
+	// - recurse upwards as necessary
+	case uncle != nil && uncle.red():
+		parent.color = black
+		grandparent.color = red
+		uncle.color = black
+		s.rebalanceInsertion(grandparent)
+
+	case parent == grandparent.left:
+		// case 4a: uncle is black
+		// + node is left->right child of its grandparent
+		if n == parent.right {
+			s.rotateLeft(parent)
+			parent = n // recolor in case 5a
+		}
+
+		// case 5a: uncle is black
+		// + node is left->left child of its grandparent
+		s.rotateRight(grandparent)
+
+		// fix color of original parent and grandparent
+		parent.color = black
+		grandparent.color = red
+
+		// parent is right child of grandparent
+	default:
+		// case 4b: uncle is black
+		// + node is right->left child of its grandparent
+		if n == parent.left {
+			s.rotateRight(parent)
+			// points to root of rotated sub tree
+			parent = n // recolor in case 5b
+		}
+
+		// case 5b: uncle is black
+		// + node is right->right child of its grandparent
+		s.rotateLeft(grandparent)
+
+		// fix color of original parent and grandparent
+		parent.color = black
+		grandparent.color = red
+	}
+}
+
+func (s *TreeSet[T]) delete(element T) bool {
+	n := s.locate(s.root, element)
+	if n == nil {
+		return false
+	}
+
+	var (
+		moved   *node[T]
+		deleted color
+	)
+
+	if n.left == nil || n.right == nil {
+		// case where deleted node had zero or one child
+		moved = s.delete01(n)
+		deleted = n.color
+	} else {
+		// case where node has two children
+
+		// find minimum of right subtree
+		successor := s.min(n.right)
+
+		// copy successor data into n
+		n.element = successor.element
+
+		// delete successor
+		moved = s.delete01(successor)
+		deleted = successor.color
+	}
+
+	// re-balance if the node was black
+	if deleted == black {
+		s.rebalanceDeletion(moved)
+
+		// remove marker
+		if moved == s.marker {
+			s.replaceChild(moved.parent, moved, nil)
+		}
+	}
+
+	// element was removed
+	s.size--
+	s.marker.color = black
+	s.marker.left = nil
+	s.marker.right = nil
+	s.marker.parent = nil
+	return true
+}
+
+func (s *TreeSet[T]) delete01(n *node[T]) *node[T] {
+	// node only has left child, replace by left child
+	if n.left != nil {
+		s.replaceChild(n.parent, n, n.left)
+		return n.left
+	}
+
+	// node only has right child, replace by right child
+	if n.right != nil {
+		s.replaceChild(n.parent, n, n.right)
+		return n.right
+	}
+
+	// node has both children
+	// if node is black replace with marker
+	// if node is red we just remove it
+	if n.black() {
+		s.replaceChild(n.parent, n, s.marker)
+		return s.marker
+	} else {
+		s.replaceChild(n.parent, n, nil)
+		return nil
+	}
+}
+
+func (s *TreeSet[T]) rebalanceDeletion(n *node[T]) {
+	// base case: node is root
+	if n == s.root {
+		n.color = black
+		return
+	}
+
+	sibling := s.siblingOf(n)
+
+	// case: sibling is red
+	if sibling.red() {
+		s.fixRedSibling(n, sibling)
+		sibling = s.siblingOf(n)
+	}
+
+	// case: black sibling with two black children
+	if sibling.left.black() && sibling.right.black() {
+		sibling.color = red
+
+		// case: black sibling with to black children and a red parent
+		if n.parent.red() {
+			n.parent.color = black
+		} else {
+			// case: black sibling with two black children and black parent
+			s.rebalanceDeletion(n.parent)
+		}
+	} else {
+		// case: black sibling with at least one red child
+		s.fixBlackSibling(n, sibling)
+	}
+}
+
+func (s *TreeSet[T]) fixRedSibling(n *node[T], sibling *node[T]) {
+	sibling.color = black
+	n.parent.color = red
+
+	switch {
+	case n == n.parent.left:
+		s.rotateLeft(n.parent)
+	default:
+		s.rotateRight(n.parent)
+	}
+}
+
+func (s *TreeSet[T]) fixBlackSibling(n, sibling *node[T]) {
+	isLeftChild := n == n.parent.left
+
+	if isLeftChild && sibling.right.black() {
+		sibling.left.color = black
+		sibling.color = red
+		s.rotateRight(sibling)
+		sibling = n.parent.right
+	} else if !isLeftChild && sibling.left.black() {
+		sibling.right.color = black
+		sibling.color = red
+		s.rotateLeft(sibling)
+		sibling = n.parent.left
+	}
+
+	sibling.color = n.parent.color
+	n.parent.color = black
+	if isLeftChild {
+		sibling.right.color = black
+		s.rotateLeft(n.parent)
+	} else {
+		sibling.left.color = black
+		s.rotateRight(n.parent)
+	}
+}
+
+func (s *TreeSet[T]) siblingOf(n *node[T]) *node[T] {
+	parent := n.parent
+	switch {
+	case n == parent.left:
+		return parent.right
+	case n == parent.right:
+		return parent.left
+	default:
+		panic("bug: parent is not a child of its grandparent")
+	}
+}
+
+func (*TreeSet[T]) uncleOf(n *node[T]) *node[T] {
+	grandparent := n.parent
+	switch {
+	case grandparent.left == n:
+		return grandparent.right
+	case grandparent.right == n:
+		return grandparent.left
+	default:
+		panic("bug: parent is not a child of our childs grandparent")
+	}
+}
+
+func (s *TreeSet[T]) min(n *node[T]) *node[T] {
+	for n.left != nil {
+		n = n.left
+	}
+	return n
+}
+
+func (s *TreeSet[T]) max(n *node[T]) *node[T] {
+	for n.right != nil {
+		n = n.right
+	}
+	return n
+}
+
+func (s *TreeSet[T]) compare(a, b *node[T]) int {
+	return s.comparison(a.element, b.element)
+}
+
+// TreeNodeVisit is a function that is called for each node in the tree.
+type TreeNodeVisit[T any] func(*node[T]) (next bool)
+
+func (s *TreeSet[T]) infix(visit TreeNodeVisit[T], n *node[T]) (next bool) {
+	if n == nil {
+		return true
+	}
+	if next = s.infix(visit, n.left); !next {
+		return
+	}
+	if next = visit(n); !next {
+		return
+	}
+	return s.infix(visit, n.right)
+}
+
+func (s *TreeSet[T]) fillLeft(n *node[T], k *[]T) {
+	if n == nil {
+		return
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillLeft(n.left, k)
+	}
+
+	if len(*k) < cap(*k) {
+		*k = append(*k, n.element)
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillLeft(n.right, k)
+	}
+}
+
+func (s *TreeSet[T]) fillRight(n *node[T], k *[]T) {
+	if n == nil {
+		return
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillRight(n.right, k)
+	}
+
+	if len(*k) < cap(*k) {
+		*k = append(*k, n.element)
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillRight(n.left, k)
+	}
+}
+
+func (s *TreeSet[T]) prefix(visit func(*node[T]), n *node[T]) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	s.prefix(visit, n.left)
+	s.prefix(visit, n.right)
+}
+
+func (s *TreeSet[T]) iterate() func() *node[T] {
+	stck := makeStack[*node[T]]()
+
+	for n := s.root; n != nil; n = n.left {
+		stck.push(n)
+	}
+
+	return func() *node[T] {
+		if stck.empty() {
+			return nil
+		}
+		n := stck.pop()
+		for r := n.right; r != nil; r = r.left {
+			stck.push(r)
+		}
+		return n
+	}
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *TreeSet[T]) MarshalJSON() ([]byte, error) {
+	return marshalJSON[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *TreeSet[T]) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON[T](s, data)
+}
+
+func (s *TreeSet[T]) filterLeft(n *node[T], accept func(element T) bool, result *TreeSet[T]) {
+	if n == nil {
+		return
+	}
+
+	s.filterLeft(n.left, accept, result)
+
+	if accept(n.element) {
+		result.Insert(n.element)
+		s.filterLeft(n.right, accept, result)
+	}
+}
+
+func (s *TreeSet[T]) filterRight(n *node[T], accept func(element T) bool, result *TreeSet[T]) {
+	if n == nil {
+		return
+	}
+
+	s.filterRight(n.right, accept, result)
+
+	if accept(n.element) {
+		result.Insert(n.element)
+		s.filterRight(n.left, accept, result)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,6 +164,9 @@ github.com/hashicorp/go-plugin/runner
 # github.com/hashicorp/go-retryablehttp v0.7.7
 ## explicit; go 1.19
 github.com/hashicorp/go-retryablehttp
+# github.com/hashicorp/go-set/v3 v3.0.1
+## explicit; go 1.23
+github.com/hashicorp/go-set/v3
 # github.com/hashicorp/go-uuid v1.0.3
 ## explicit
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

Fixes a bug in  azuredevops_group_membership  where, with mode = "overwrite" and a non-empty target group at create time, the members are added successfully but the post-create sync hangs for the full 60-minute timeout.

Also fixed timeout to honor the timeout block instead of the 60 minutes hardcode.

### Root Cause

`membersToAdd` was initially set to `d.Get("members").(*schema.Set)`, and while the values inside are correct, `actualMembershipsSet` is populated using `schema.NewSet(...)`. This means that using the `Difference` and `Intersection` functions between `membersToAdd` and `actualMembershipsSet` won't work as intended. In this case, using `actualMembershipsSet.Difference(membersToAdd)` will always return all the values inside `actualMembershipsSet`, which then lead to `membersToRemove` always containing the existing members inside the group. This also means `actualMembershipsSet.Intersection(membersToAdd)` will always be empty, hence the initial `if (membersToAdd == nil || actualMembershipsSet.Intersection(membersToAdd).Len() <= 0)` check.

This has been resolved by also populating `membersToAdd` using `schema.NewSet(...)` and fixing the logic inside the post create sync function.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result
<pre>
=== RUN   TestAccGroupMembership_overwrite
=== PAUSE TestAccGroupMembership_overwrite
=== CONT  TestAccGroupMembership_overwrite
--- PASS: TestAccGroupMembership_overwrite (142.15s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        142.159s
</pre>

## Related Issue(s)

Fix #1567
