### PR TITLE
`azuredevops_build_definition` : Trim `refs/heads/` prefix for `branch_name`

### DIFF
--- a/azuredevops/internal/service/build/resource_build_definition.go
+++ b/azuredevops/internal/service/build/resource_build_definition.go
@@ -181,6 +181,9 @@ func ResourceBuildDefinition() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "master",
+							StateFunc: func(v interface{}) string {
+								return strings.TrimPrefix(v.(string), "refs/heads/")
+							},
 						},
 						"service_connection_id": {
 							Type:     schema.TypeString,
@@ -883,7 +886,7 @@ func flattenRepository(buildDefinition *build.BuildDefinition) (interface{}, err
 		"yml_path":              yamlFilePath,
 		"repo_id":               *buildDefinition.Repository.Id,
 		"repo_type":             *buildDefinition.Repository.Type,
-		"branch_name":           *buildDefinition.Repository.DefaultBranch,
+		"branch_name":           strings.TrimPrefix(*buildDefinition.Repository.DefaultBranch, "refs/heads/"),
 		"github_enterprise_url": githubEnterpriseUrl,
 		"url":                   *buildDefinition.Repository.Url,
 	}}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

When using the `azuredevops_build_definition` resource, it is possible to pass in the `branch_name` without a leading `refs/heads/` prefix. In this scenario, after `terraform apply`, the `branch_name` will be stored without a `refs/heads/` prefix. However, when performing this action from the user interface, the `branch_name` will have the `refs/heads/` prefix added in, which causes inconsistencies in this value between the API and state file.

To fix this, the read function will have the prefix trimmed before it is saved to `branch_name`. In the scenario where the user supplies a value to `branch_name` in the config file, it is trimmed as well via a `StateFunc` (e.g. `branch_name=azuredevops_git_repository.test.default_branch`, which resolves to `refs/heads/master`, which is then trimmed to `master`).


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccBuildDefinition_DataSource
=== PAUSE TestAccBuildDefinition_DataSource
=== RUN   TestAccBuildDefinition_with_path_DataSource
=== PAUSE TestAccBuildDefinition_with_path_DataSource
=== RUN   TestAccBuildDefinition_basic
=== PAUSE TestAccBuildDefinition_basic
=== RUN   TestAccBuildDefinition_pathUpdate
=== PAUSE TestAccBuildDefinition_pathUpdate
=== RUN   TestAccBuildDefinition_withVariables
=== PAUSE TestAccBuildDefinition_withVariables
=== RUN   TestAccBuildDefinition_schedules
=== PAUSE TestAccBuildDefinition_schedules
=== RUN   TestAccBuildDefinition_buildCompletionTrigger
=== PAUSE TestAccBuildDefinition_buildCompletionTrigger
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== RUN   TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== PAUSE TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== CONT  TestAccBuildDefinition_DataSource
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic
=== CONT  TestAccBuildDefinition_withVariables
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update
=== CONT  TestAccBuildDefinition_schedules
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_update
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_complete
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_basic
=== CONT  TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent
--- PASS: TestAccBuildDefinition_DataSource (30.80s)
=== CONT  TestAccBuildDefinition_basic
--- PASS: TestAccBuildDefinition_schedules (47.66s)
=== CONT  TestAccBuildDefinition_pathUpdate
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_multiConfiguration (48.77s)
=== CONT  TestAccBuildDefinition_with_path_DataSource
--- PASS: TestAccBuildDefinition_basic (26.02s)
=== CONT  TestAccBuildDefinition_buildCompletionTrigger
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_basic (57.20s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_update (64.59s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_complete (66.61s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_complete (67.32s)
--- PASS: TestAccBuildDefinition_with_path_DataSource (23.27s)
--- PASS: TestAccBuildDefinition_withVariables (73.00s)
--- PASS: TestAccBuildDefinition_pathUpdate (27.66s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_multiConfiguration (76.75s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_basic (79.39s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentlessJob_update (80.53s)
--- PASS: TestAccBuildDefinition_buildCompletionTrigger (25.92s)
--- PASS: TestAccBuildDefinition_otherGitRepositoryAgentJob_multiAgent (86.86s)
PASS
</pre>

## Related Issue(s)

Fix #1478 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
