### PR TITLE
`azuredevops_serviceendpoint_bitbucket` - Support email+api token authentication

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
@@ -59,6 +59,34 @@ func TestAccServiceEndpointBitBucket_complete(t *testing.T) {
 	})
 }
 
+func TestAccServiceEndpointBitBucket_token(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+	description := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_serviceendpoint_bitbucket"
+	tfSvcEpNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointBitBucketResourceToken(projectName, serviceEndpointName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "email"),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "api_token"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "email", "email@example.com"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
+				),
+			},
+		},
+	})
+}
+
 func TestAccServiceEndpointBitBucket_update(t *testing.T) {
 	projectName := testutils.GenerateResourceName()
 	serviceEndpointNameFirst := testutils.GenerateResourceName()
@@ -156,6 +184,20 @@ resource "azuredevops_serviceendpoint_bitbucket" "test" {
   description           = "%s"
   username              = "username"
   password              = "password"
+}`, serviceEndpointName, description)
+
+	projectResource := testutils.HclProjectResource(projectName)
+	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
+}
+
+func hclSvcEndpointBitBucketResourceToken(projectName string, serviceEndpointName string, description string) string {
+	serviceEndpointResource := fmt.Sprintf(`
+resource "azuredevops_serviceendpoint_bitbucket" "test" {
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "%s"
+  description           = "%s"
+  email                 = "email@example.com"
+  api_token             = "api_token"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)

--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_bitbucket_test.go
@@ -24,6 +24,8 @@ func TestAccServiceEndpointBitBucket_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "email", "email@example.com"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "api_token", "api_token"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
 				),
 			},
@@ -48,37 +50,8 @@ func TestAccServiceEndpointBitBucket_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "username"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "password"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "username", "username"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
-				),
-			},
-		},
-	})
-}
-
-func TestAccServiceEndpointBitBucket_token(t *testing.T) {
-	projectName := testutils.GenerateResourceName()
-	serviceEndpointName := testutils.GenerateResourceName()
-	description := testutils.GenerateResourceName()
-
-	resourceType := "azuredevops_serviceendpoint_bitbucket"
-	tfSvcEpNode := resourceType + ".test"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.GetProviders(),
-		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: hclSvcEndpointBitBucketResourceToken(projectName, serviceEndpointName, description),
-				Check: resource.ComposeTestCheckFunc(
-					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "email"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "api_token"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "email", "email@example.com"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "api_token", "api_token"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
 				),
@@ -104,7 +77,8 @@ func TestAccServiceEndpointBitBucket_update(t *testing.T) {
 			{
 				Config: hclSvcEndpointBitBucketResourceBasic(projectName, serviceEndpointNameFirst),
 				Check: resource.ComposeTestCheckFunc(
-					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst), resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameFirst),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameFirst),
 				),
 			},
@@ -113,9 +87,8 @@ func TestAccServiceEndpointBitBucket_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointNameSecond),
 					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "password"),
-					resource.TestCheckResourceAttrSet(tfSvcEpNode, "username"),
-					resource.TestCheckResourceAttr(tfSvcEpNode, "username", "username"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "email", "email@example.com"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "api_token", "api_token"),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointNameSecond),
 					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
 				),
@@ -149,13 +122,40 @@ func TestAccServiceEndpointBitBucket_RequiresImportErrorStep(t *testing.T) {
 	})
 }
 
+func TestAccServiceEndpointBitBucket_usernamePassword(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+	description := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_serviceendpoint_bitbucket"
+	tfSvcEpNode := resourceType + ".test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclSvcEndpointBitBucketResourceUsernamePassword(projectName, serviceEndpointName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfSvcEpNode, serviceEndpointName),
+					resource.TestCheckResourceAttrSet(tfSvcEpNode, "project_id"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "username", "username"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "password", "password"),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "service_endpoint_name", serviceEndpointName),
+					resource.TestCheckResourceAttr(tfSvcEpNode, "description", description),
+				),
+			},
+		},
+	})
+}
+
 func hclSvcEndpointBitBucketResourceBasic(projectName string, serviceEndpointName string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_bitbucket" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%s"
-  username              = "username"
-  password              = "password"
+  email                 = "email@example.com"
+  api_token             = "api_token"
 }`, serviceEndpointName)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -168,8 +168,8 @@ resource "azuredevops_serviceendpoint_bitbucket" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%s"
   description           = "%s"
-  username              = "username"
-  password              = "password"
+  email                 = "email@example.com"
+  api_token             = "api_token"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -182,22 +182,22 @@ resource "azuredevops_serviceendpoint_bitbucket" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%s"
   description           = "%s"
-  username              = "username"
-  password              = "password"
+  email                 = "email@example.com"
+  api_token             = "api_token"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
 	return fmt.Sprintf("%s\n%s", projectResource, serviceEndpointResource)
 }
 
-func hclSvcEndpointBitBucketResourceToken(projectName string, serviceEndpointName string, description string) string {
+func hclSvcEndpointBitBucketResourceUsernamePassword(projectName string, serviceEndpointName string, description string) string {
 	serviceEndpointResource := fmt.Sprintf(`
 resource "azuredevops_serviceendpoint_bitbucket" "test" {
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "%s"
   description           = "%s"
-  email                 = "email@example.com"
-  api_token             = "api_token"
+  username              = "username"
+  password              = "password"
 }`, serviceEndpointName, description)
 
 	projectResource := testutils.HclProjectResource(projectName)
@@ -212,8 +212,8 @@ resource "azuredevops_serviceendpoint_bitbucket" "import" {
   project_id            = azuredevops_serviceendpoint_bitbucket.test.project_id
   service_endpoint_name = azuredevops_serviceendpoint_bitbucket.test.service_endpoint_name
   description           = azuredevops_serviceendpoint_bitbucket.test.description
-  username              = azuredevops_serviceendpoint_bitbucket.test.username
-  password              = "password"
+  email                 = azuredevops_serviceendpoint_bitbucket.test.email
+  api_token             = "api_token"
 }
 `, template)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -32,18 +32,40 @@ func ResourceServiceEndpointBitBucket() *schema.Resource {
 
 	maps.Copy(r.Schema, map[string]*schema.Schema{
 		"username": {
-			Type:        schema.TypeString,
-			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", nil),
-			Description: "The bitbucket username which should be used.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", nil),
+			Description:  "The bitbucket username which should be used.",
+			RequiredWith: []string{"password"},
+			Deprecated:   "Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.",
 		},
 
 		"password": {
-			Type:        schema.TypeString,
-			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_PASSWORD", nil),
-			Description: "The bitbucket password which should be used.",
-			Sensitive:   true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_PASSWORD", nil),
+			Description:  "The bitbucket password which should be used.",
+			Sensitive:    true,
+			RequiredWith: []string{"username"},
+			Deprecated:   "Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.",
+		},
+
+		"email": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_EMAIL", nil),
+			Description:  "The bitbucket account email which should be used.",
+			RequiredWith: []string{"api_token"},
+			ExactlyOneOf: []string{"username", "email"},
+		},
+
+		"api_token": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			DefaultFunc:  schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_API_TOKEN", nil),
+			Description:  "The bitbucket API token which should be used.",
+			Sensitive:    true,
+			RequiredWith: []string{"email"},
 		},
 	})
 
@@ -106,12 +128,22 @@ func resourceServiceEndpointBitbucketDelete(d *schema.ResourceData, m interface{
 
 func expandServiceEndpointBitBucket(d *schema.ResourceData) *serviceendpoint.ServiceEndpoint {
 	serviceEndpoint := doBaseExpansion(d)
-	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
-		Parameters: &map[string]string{
-			"username": d.Get("username").(string),
-			"password": d.Get("password").(string),
-		},
-		Scheme: converter.String("UsernamePassword"),
+	if apiToken, ok := d.GetOk("api_token"); ok {
+		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+			Parameters: &map[string]string{
+				"email":    d.Get("email").(string),
+				"apitoken": apiToken.(string),
+			},
+			Scheme: converter.String("Token"),
+		}
+	} else {
+		serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+			Parameters: &map[string]string{
+				"username": d.Get("username").(string),
+				"password": d.Get("password").(string),
+			},
+			Scheme: converter.String("UsernamePassword"),
+		}
 	}
 	serviceEndpoint.Type = converter.String(string(model.RepoTypeValues.Bitbucket))
 	serviceEndpoint.Url = converter.String("https://api.bitbucket.org/")
@@ -120,5 +152,14 @@ func expandServiceEndpointBitBucket(d *schema.ResourceData) *serviceendpoint.Ser
 
 func flattenServiceEndpointBitBucket(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint) {
 	doBaseFlattening(d, serviceEndpoint)
-	d.Set("username", (*serviceEndpoint.Authorization.Parameters)["username"])
+	if serviceEndpoint.Authorization == nil || serviceEndpoint.Authorization.Scheme == nil || serviceEndpoint.Authorization.Parameters == nil {
+		return
+	}
+	params := *serviceEndpoint.Authorization.Parameters
+	switch *serviceEndpoint.Authorization.Scheme {
+	case "Token":
+		d.Set("email", params["email"])
+	case "UsernamePassword":
+		d.Set("username", params["username"])
+	}
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_bitbucket.go
@@ -37,6 +37,7 @@ func ResourceServiceEndpointBitBucket() *schema.Resource {
 			DefaultFunc:  schema.EnvDefaultFunc("AZDO_BITBUCKET_SERVICE_CONNECTION_USERNAME", nil),
 			Description:  "The bitbucket username which should be used.",
 			RequiredWith: []string{"password"},
+			ExactlyOneOf: []string{"username", "email"},
 			Deprecated:   "Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.",
 		},
 

--- a/website/docs/r/serviceendpoint_bitbucket.html.markdown
+++ b/website/docs/r/serviceendpoint_bitbucket.html.markdown
@@ -22,8 +22,8 @@ resource "azuredevops_project" "example" {
 
 resource "azuredevops_serviceendpoint_bitbucket" "example" {
   project_id            = azuredevops_project.example.id
-  username              = "username"
-  password              = "password"
+  email                 = "email@example.com"
+  api_token             = "api_token"
   service_endpoint_name = "Example Bitbucket"
   description           = "Managed by Terraform"
 }
@@ -37,13 +37,19 @@ The following arguments are supported:
 
 * `service_endpoint_name` - (Required) The Service Endpoint name.
 
-* `username` - (Required) Bitbucket account username.
-
-* `password` - (Required) Bitbucket account password.
-
 ---
 
+* `email` - (Optional) Bitbucket account email. Used together with `api_token` to authenticate using an Atlassian API token.
+
+* `api_token` - (Optional) Bitbucket account API token. Used together with `email` to authenticate using an Atlassian API token.
+
+* `username` - (Optional) Bitbucket account username. Used together with `password` to authenticate using an app password. **Deprecated**: Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.
+
+* `password` - (Optional) Bitbucket account password. Used together with `username` to authenticate using an app password. **Deprecated**: Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.
+
 * `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
+
+~> **NOTE:** Exactly one authentication method must be configured. Provide either `email` + `api_token` (recommended) or `username` + `password` (deprecated).
 
 ## Attributes Reference
 

--- a/website/docs/r/serviceendpoint_bitbucket.html.markdown
+++ b/website/docs/r/serviceendpoint_bitbucket.html.markdown
@@ -47,9 +47,9 @@ The following arguments are supported:
 
 * `password` - (Optional) Bitbucket account password. Used together with `username` to authenticate using an app password. **Deprecated**: Bitbucket Cloud has deprecated app password (username and password) authentication. Use `email` and `api_token` instead.
 
-* `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
-
 ~> **NOTE:** Exactly one authentication method must be configured. Provide either `email` + `api_token` (recommended) or `username` + `password` (deprecated).
+
+* `description` - (Optional) The Service Endpoint description. Defaults to `Managed by Terraform`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
Adds email + api key authentication to the `azuredevops_serviceendpoint_bitbucket` resource, since it currently only supports username + password. 


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>

=== RUN   TestAccServiceEndpointBitBucket_basic
=== PAUSE TestAccServiceEndpointBitBucket_basic
=== RUN   TestAccServiceEndpointBitBucket_complete
=== PAUSE TestAccServiceEndpointBitBucket_complete
=== RUN   TestAccServiceEndpointBitBucket_token
=== PAUSE TestAccServiceEndpointBitBucket_token
=== RUN   TestAccServiceEndpointBitBucket_update
=== PAUSE TestAccServiceEndpointBitBucket_update
=== RUN   TestAccServiceEndpointBitBucket_RequiresImportErrorStep
=== PAUSE TestAccServiceEndpointBitBucket_RequiresImportErrorStep
=== CONT  TestAccServiceEndpointBitBucket_basic
=== CONT  TestAccServiceEndpointBitBucket_update
=== CONT  TestAccServiceEndpointBitBucket_token
=== CONT  TestAccServiceEndpointBitBucket_complete
=== CONT  TestAccServiceEndpointBitBucket_RequiresImportErrorStep
--- PASS: TestAccServiceEndpointBitBucket_token (54.76s)
--- PASS: TestAccServiceEndpointBitBucket_complete (54.77s)
</pre>

<!-- A screenshot or text pasted here to show the acctest result. -->

## Related Issue(s)

Fix #1575
