### PR TITLE
`azuredevops_git_repository` - allow disabling on destroy

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_git_repository_test.go
+++ b/azuredevops/internal/acceptancetests/resource_git_repository_test.go
@@ -6,8 +6,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
@@ -113,6 +115,53 @@ func TestAccGitRepository_disabled(t *testing.T) {
 					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
 					resource.TestCheckResourceAttr(tfRepoNode, "disabled", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGitRepository_disableOnDestroy(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	gitRepoName := testutils.GenerateResourceName()
+	tfRepoNode := "azuredevops_git_repository.test"
+
+	var repoID, projectID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutils.PreCheck(t, nil) },
+		Providers: testutils.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: hclGitRepositoryDisableOnDestroy(projectName, gitRepoName),
+				Check: resource.ComposeTestCheckFunc(
+					checkGitRepoExists(gitRepoName),
+					resource.TestCheckResourceAttr(tfRepoNode, "disable_on_destroy", "true"),
+					func(s *terraform.State) error {
+						res, ok := s.RootModule().Resources[tfRepoNode]
+						if !ok {
+							return fmt.Errorf("Did not find a repo definition in the TF state")
+						}
+						repoID = res.Primary.ID
+						projectID = res.Primary.Attributes["project_id"]
+						return nil
+					},
+				),
+			},
+			{
+				Config: hclGitRepositoryDisableOnDestroyProjectOnly(projectName),
+				Check: func(s *terraform.State) error {
+					clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+					return retry.RetryContext(clients.Ctx, 1*time.Minute, func() *retry.RetryError {
+						repo, err := readGitRepo(clients, repoID, projectID)
+						if err != nil {
+							return retry.NonRetryableError(fmt.Errorf("repository with ID %s should still exist after destroy: %v", repoID, err))
+						}
+						if repo == nil || repo.IsDisabled == nil || !*repo.IsDisabled {
+							return retry.RetryableError(fmt.Errorf("repository with ID %s should be disabled after destroy", repoID))
+						}
+						return nil
+					})
+				},
 			},
 		},
 	})
@@ -224,7 +273,7 @@ func TestAccGitRepository_import_by_name(t *testing.T) {
 				ResourceName:            tfRepoNode,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initialization"},
+				ImportStateVerifyIgnore: []string{"initialization", "disable_on_destroy"},
 				ImportStateId:           fmt.Sprintf("%s/%s", projectName, gitRepoName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tfRepoNode, "name", gitRepoName),
@@ -524,6 +573,31 @@ resource "azuredevops_git_repository" "test" {
   }
 }
 `, projectName, repoName, disabled)
+}
+
+func hclGitRepositoryDisableOnDestroy(projectName, repoName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_git_repository" "test" {
+  project_id         = azuredevops_project.test.id
+  name               = "%s"
+  disable_on_destroy = true
+  initialization {
+    init_type = "Clean"
+  }
+}
+`, projectName, repoName)
+}
+
+func hclGitRepositoryDisableOnDestroyProjectOnly(projectName string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+`, projectName)
 }
 
 func hclGitRepositoryIncorrectInitialization(projectName, repoName string) string {

--- a/azuredevops/internal/service/git/resource_git_repository.go
+++ b/azuredevops/internal/service/git/resource_git_repository.go
@@ -169,6 +169,11 @@ func ResourceGitRepository() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"disable_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"is_fork": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -426,7 +431,17 @@ func resourceGitRepositoryDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *repoActual.IsDisabled {
+		if d.Get("disable_on_destroy").(bool) {
+			return nil
+		}
 		return fmt.Errorf("A disabled repository cannot be deleted, please enable the repository before attempting to delete : %s", repoID)
+	}
+
+	if d.Get("disable_on_destroy").(bool) {
+		if _, err = updateIsDisabledGitRepository(clients, repoID, projectID, true); err != nil {
+			return fmt.Errorf("disabling repository on destroy with ID %s. Error: %+v", repoID, err)
+		}
+		return nil
 	}
 
 	repoUUId, err := uuid.Parse(repoID)

--- a/website/docs/r/git_repository.html.markdown
+++ b/website/docs/r/git_repository.html.markdown
@@ -241,6 +241,8 @@ The following arguments are supported:
 
 * `disabled` - (Optional) The ability to disable or enable the repository. Defaults to `false`.
 
+* `disable_on_destroy` - (Optional) If `true`, the repository will be disabled instead of deleted when the resource is destroyed. Defaults to `false`.
+
 ---
 
 A `initialization` - block supports the following:


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
This PR adds a new property `disable_on_destroy`, which allows the user to disable the repository instead of destroying it if it's removed from the terraform configuration. The current `disable` flag will only work if the config still includes the repository resource, and the resource is destroyed when it is removed from the config. `disable_on_destroy` would help with allowing the user to remove the resource in the configuration without destroying the repository.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

The tests seems to have racing conditions for the read and write, which means that it is inconsistent whenever it is run and will have different errors.

<pre>

=== RUN   TestAccGitRepository_DataSource
=== PAUSE TestAccGitRepository_DataSource
=== RUN   TestAccGitRepository_DataSource_notExist
=== PAUSE TestAccGitRepository_DataSource_notExist
=== RUN   TestAccGitRepository_withDefaultBranch
=== PAUSE TestAccGitRepository_withDefaultBranch
=== RUN   TestAccGitRepository_update
=== PAUSE TestAccGitRepository_update
=== RUN   TestAccGitRepository_disabled
=== PAUSE TestAccGitRepository_disabled
=== RUN   TestAccGitRepository_disableOnDestroy
--- PASS: TestAccGitRepository_disableOnDestroy (25.07s)
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== RUN   TestAccGitRepository_incorrectInitialization
=== PAUSE TestAccGitRepository_incorrectInitialization
=== RUN   TestAccGitRepository_importGitRepository
=== PAUSE TestAccGitRepository_importGitRepository
=== RUN   TestAccGitRepository_import_by_name
=== PAUSE TestAccGitRepository_import_by_name
=== RUN   TestAccGitRepository_initializationClean
=== PAUSE TestAccGitRepository_initializationClean
=== RUN   TestAccGitRepository_uninitialized
=== PAUSE TestAccGitRepository_uninitialized
=== RUN   TestAccGitRepository_forkBranchNotEmpty
=== PAUSE TestAccGitRepository_forkBranchNotEmpty
=== CONT  TestAccGitRepository_DataSource
--- PASS: TestAccGitRepository_DataSource (22.20s)
=== CONT  TestAccGitRepository_incorrectInitialization
--- PASS: TestAccGitRepository_incorrectInitialization (0.15s)
=== CONT  TestAccGitRepository_forkBranchNotEmpty
--- PASS: TestAccGitRepository_forkBranchNotEmpty (25.56s)
=== CONT  TestAccGitRepository_uninitialized
--- PASS: TestAccGitRepository_uninitialized (23.10s)
=== CONT  TestAccGitRepository_initializationClean
--- PASS: TestAccGitRepository_initializationClean (24.11s)
=== CONT  TestAccGitRepository_import_by_name
--- PASS: TestAccGitRepository_import_by_name (24.55s)
=== CONT  TestAccGitRepository_importGitRepository
--- PASS: TestAccGitRepository_importGitRepository (48.36s)
=== CONT  TestAccGitRepository_update
--- PASS: TestAccGitRepository_update (23.19s)
=== CONT  TestAccGitRepository_disabledCannotUpdate
    resource_git_repository_test.go:176: Step 3/3 error: Error running apply: exit status 1
        
        Error: Updating repository in Azure DevOps: TF401019: The Git repository with name or identifier b9a7f5fd-680b-4a5a-ba28-afbfd126cd7c does not exist or you do not have permissions for the operation you are attempting.
        
          with azuredevops_git_repository.test,
          on terraform_plugin_test.tf line 16, in resource "azuredevops_git_repository" "test":
          16: resource "azuredevops_git_repository" "test" {
        
--- FAIL: TestAccGitRepository_disabledCannotUpdate (25.56s)
=== CONT  TestAccGitRepository_disabled
--- PASS: TestAccGitRepository_disabled (25.34s)
=== CONT  TestAccGitRepository_withDefaultBranch
--- PASS: TestAccGitRepository_withDefaultBranch (34.09s)
=== CONT  TestAccGitRepository_DataSource_notExist
--- PASS: TestAccGitRepository_DataSource_notExist (21.67s)
FAIL
</pre>

`TestAccGitRepository_disabledCannotUpdate` will suceed or fail depending on the race condition. The test is able to succeed after running it a couple more times.

<pre>
=== RUN   TestAccGitRepository_disabledCannotUpdate
=== PAUSE TestAccGitRepository_disabledCannotUpdate
=== CONT  TestAccGitRepository_disabledCannotUpdate
--- PASS: TestAccGitRepository_disabledCannotUpdate (25.95s)
PASS
</pre>

## Related Issue(s)

Fix #1540
