### PR TITLE
`azuredevops_check_approval` - Fix fail refresh when target `azuredevops_environment` is deleted outside of Terraform

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_check_approval_test.go
+++ b/azuredevops/internal/acceptancetests/resource_check_approval_test.go
@@ -3,10 +3,14 @@ package acceptancetests
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 )
 
 func TestAccCheckApproval_basic(t *testing.T) {
@@ -104,6 +108,65 @@ func TestAccCheckApproval_update(t *testing.T) {
 	})
 }
 
+func TestAccCheckApproval_targetResourceDeletedOutOfBand(t *testing.T) {
+	if os.Getenv("AZDO_TEST_AAD_USER_EMAIL") == "" {
+		t.Skip("Skip test due to `AZDO_TEST_AAD_USER_EMAIL` not set")
+	}
+
+	projectName := testutils.GenerateResourceName()
+
+	resourceType := "azuredevops_check_approval"
+	tfCheckNode := resourceType + ".test"
+	tfEnvNode := "azuredevops_environment.environment"
+	principalName := os.Getenv("AZDO_TEST_AAD_USER_EMAIL")
+
+	var projectID, environmentID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, &[]string{"AZDO_TEST_AAD_USER_EMAIL"}) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckPipelineCheckDestroyed(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: hclCheckApprovalResourceEnvironment(projectName, principalName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
+					resource.TestCheckResourceAttr(tfCheckNode, "target_resource_type", "environment"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[tfEnvNode]
+						if !ok {
+							return fmt.Errorf("environment %q not found in state", tfEnvNode)
+						}
+						environmentID = rs.Primary.ID
+						projectID = rs.Primary.Attributes["project_id"]
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+					envID, err := strconv.Atoi(environmentID)
+					if err != nil {
+						t.Fatalf("parsing environment ID %q: %v", environmentID, err)
+					}
+					if err := clients.TaskAgentClient.DeleteEnvironment(clients.Ctx, taskagent.DeleteEnvironmentArgs{
+						Project:       &projectID,
+						EnvironmentId: &envID,
+					}); err != nil {
+						t.Fatalf("deleting environment %d out of band: %v", envID, err)
+					}
+				},
+				Config: hclCheckApprovalResourceEnvironment(projectName, principalName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfCheckNode, "project_id"),
+					resource.TestCheckResourceAttr(tfCheckNode, "target_resource_type", "environment"),
+				),
+			},
+		},
+	})
+}
+
 func hclCheckApprovalResourceBasic(projectName string, principalName string) string {
 	checkResource := fmt.Sprintf(`
 data "azuredevops_users" "test" {
@@ -153,4 +216,26 @@ resource "azuredevops_check_approval" "test" {
 
 	genericcheckResource := testutils.HclServiceEndpointGenericResource(projectName, "serviceendpoint", "https://test/", "test", "test")
 	return fmt.Sprintf("%s\n%s", genericcheckResource, checkResource)
+}
+
+func hclCheckApprovalResourceEnvironment(projectName string, principalName string) string {
+	checkResource := fmt.Sprintf(`
+data "azuredevops_users" "test" {
+  principal_name = "%s"
+}
+
+resource "azuredevops_check_approval" "test" {
+  project_id           = azuredevops_project.project.id
+  target_resource_id   = azuredevops_environment.environment.id
+  target_resource_type = "environment"
+
+  requester_can_approve = false
+  approvers = [
+    one(data.azuredevops_users.test.users).id,
+  ]
+}
+`, principalName)
+
+	environmentResource := testutils.HclEnvironmentResource(projectName, "environment_test")
+	return fmt.Sprintf("%s\n%s", environmentResource, checkResource)
 }

--- a/azuredevops/internal/service/approvalsandchecks/common_check.go
+++ b/azuredevops/internal/service/approvalsandchecks/common_check.go
@@ -3,6 +3,7 @@ package approvalsandchecks
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -154,7 +155,9 @@ func genCheckReadFunc(flatFunc flatFunc) func(d *schema.ResourceData, m interfac
 			Expand:  converter.ToPtr(pipelineschecksextras.CheckConfigurationExpandParameterValues.Settings),
 		})
 		if err != nil {
-			if utils.ResponseWasNotFound(err) || strings.Contains(err.Error(), "does not exist.") {
+			if utils.ResponseWasNotFound(err) || strings.Contains(err.Error(), "does not exist.") ||
+				(utils.ResponseWasStatusCode(err, http.StatusForbidden) &&
+					utils.ResponseContainsStatusMessage(err, "does not have required permissions to view assignment on the resource")) {
 				d.SetId("")
 				return nil
 			}

--- a/azuredevops/internal/service/approvalsandchecks/common_check.go
+++ b/azuredevops/internal/service/approvalsandchecks/common_check.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
@@ -155,11 +156,20 @@ func genCheckReadFunc(flatFunc flatFunc) func(d *schema.ResourceData, m interfac
 			Expand:  converter.ToPtr(pipelineschecksextras.CheckConfigurationExpandParameterValues.Settings),
 		})
 		if err != nil {
-			if utils.ResponseWasNotFound(err) || strings.Contains(err.Error(), "does not exist.") ||
-				(utils.ResponseWasStatusCode(err, http.StatusForbidden) &&
-					utils.ResponseContainsStatusMessage(err, "does not have required permissions to view assignment on the resource")) {
+			if utils.ResponseWasNotFound(err) || strings.Contains(err.Error(), "does not exist.") {
 				d.SetId("")
 				return nil
+			}
+			if utils.ResponseWasStatusCode(err, http.StatusForbidden) &&
+				utils.ResponseContainsStatusMessage(err, "does not have required permissions to view assignment on the resource") {
+				deleted, verifyErr := checkTargetResourceDeleted(clients, projectID, d)
+				if verifyErr != nil {
+					return verifyErr
+				}
+				if deleted {
+					d.SetId("")
+					return nil
+				}
 			}
 			return err
 		}
@@ -256,4 +266,29 @@ func doBaseFlattening(d *schema.ResourceData, check *pipelineschecksextras.Check
 	d.Set("version", check.Version)
 
 	return nil
+}
+
+func checkTargetResourceDeleted(clients *client.AggregatedClient, projectID string, d *schema.ResourceData) (bool, error) {
+	switch d.Get("target_resource_type").(string) {
+	case "environment":
+		targetID := d.Get("target_resource_id").(string)
+		environmentID, err := strconv.Atoi(targetID)
+		if err != nil {
+			return false, fmt.Errorf("parsing environment target_resource_id %q: %+v", targetID, err)
+		}
+
+		_, err = clients.TaskAgentClient.GetEnvironmentById(clients.Ctx, taskagent.GetEnvironmentByIdArgs{
+			EnvironmentId: &environmentID,
+			Project:       &projectID,
+		})
+		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	default:
+		return false, nil
+	}
 }


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description
This PR aims to fix an issue with `azuredevops_check_approval`, where if the user deletes the target `azuredevops_environment` outside of terraform, running terraform plan/apply again would result in terraform reporting that the user does not have permission to access the environment, when the environment actually has been deleted.

In this scenario, the API returns an error 403, which is related to permission issues, even though the environment has already been deleted. This fix checks for the 403 error, and then performs a search for the environment to confirm if it exists or not, which then determines if `d.SetId("")` should be performed.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccCheckApproval_basic
=== PAUSE TestAccCheckApproval_basic
=== RUN   TestAccCheckApproval_complete
=== PAUSE TestAccCheckApproval_complete
=== RUN   TestAccCheckApproval_update
=== PAUSE TestAccCheckApproval_update
=== RUN   TestAccCheckApproval_targetResourceDeletedOutOfBand
--- PASS: TestAccCheckApproval_targetResourceDeletedOutOfBand (29.42s)
=== CONT  TestAccCheckApproval_basic
=== CONT  TestAccCheckApproval_update
=== CONT  TestAccCheckApproval_complete
--- PASS: TestAccCheckApproval_basic (47.60s)
--- PASS: TestAccCheckApproval_complete (47.98s)
--- PASS: TestAccCheckApproval_update (50.99s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        80.420s
</pre>

## Related Issue(s)

Fix #1581
