### PR TITLE
Add new resource: `azuredevops_area_tree` for managing area path hierarchies

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_area_tree_test.go
+++ b/azuredevops/internal/acceptancetests/resource_area_tree_test.go
@@ -1,0 +1,151 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+)
+
+// TestAccAreaTree_basic verifies that a simple, single-level tree creates
+// exactly the area(s) described and populates area_ids/area_paths.
+func TestAccAreaTree_basic(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_area_tree.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaTreeBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "area_ids.%", "1"),
+					resource.TestCheckResourceAttr(tfNode, "area_paths.%", "1"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A"),
+					resource.TestCheckResourceAttr(tfNode, "area_paths.Team A", fmt.Sprintf("%s\\Area\\Team A", projectName)),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAreaTreeImportStateIdFunc(tfNode),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccAreaTree_nested verifies that a deeply nested tree creates every
+// implied ancestor node automatically.
+func TestAccAreaTree_nested(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_area_tree.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaTreeNested(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "area_ids.%", "4"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A/Sub Area"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A/Sub Area/Grandchild"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team B"),
+					resource.TestCheckResourceAttr(tfNode, "area_paths.Team A/Sub Area/Grandchild",
+						fmt.Sprintf("%s\\Area\\Team A\\Sub Area\\Grandchild", projectName)),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAreaTree_update verifies that growing/shrinking the tree between
+// applies creates newly added nodes and prunes removed ones, including
+// orphaned ancestors.
+func TestAccAreaTree_update(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	tfNode := "azuredevops_area_tree.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclAreaTreeBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "area_ids.%", "1"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A"),
+				),
+			},
+			{
+				Config: hclAreaTreeNested(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "area_ids.%", "4"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A/Sub Area/Grandchild"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team B"),
+				),
+			},
+			{
+				Config: hclAreaTreeBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(tfNode, "id"),
+					resource.TestCheckResourceAttr(tfNode, "area_ids.%", "1"),
+					resource.TestCheckResourceAttrSet(tfNode, "area_ids.Team A"),
+				),
+			},
+		},
+	})
+}
+
+func hclAreaTreeBasic(projectName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_area_tree" "test" {
+  project_id = azuredevops_project.project.id
+  paths = jsonencode({
+    "Team A" = {}
+  })
+}
+`, testutils.HclProjectResource(projectName))
+}
+
+func hclAreaTreeNested(projectName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_area_tree" "test" {
+  project_id = azuredevops_project.project.id
+  paths = jsonencode({
+    "Team A" = {
+      "Sub Area" = {
+        "Grandchild" = {}
+      }
+    }
+    "Team B" = {}
+  })
+}
+`, testutils.HclProjectResource(projectName))
+}
+
+func testAccAreaTreeImportStateIdFunc(resourceName string) func(s *terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return rs.Primary.Attributes["project_id"], nil
+	}
+}

--- a/azuredevops/internal/service/workitemtracking/resource_area_tree.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area_tree.go
@@ -1,0 +1,486 @@
+package workitemtracking
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/workitemtracking"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+)
+
+// areaTree is the recursive shape of the "paths" attribute: every key is an
+// area name and its value is the (possibly empty) tree of that area's
+// children, allowing area hierarchies of arbitrary depth to be expressed
+// directly as a nested object rather than as a flat list/set of
+// slash-separated path strings.
+type areaTree map[string]areaTree
+
+// ResourceAreaTree manages an entire area path hierarchy for a project as a
+// single resource. Unlike azuredevops_area (which manages one node per
+// resource instance), azuredevops_area_tree takes the complete, desired set
+// of area paths and owns their full lifecycle - creation, renaming/pruning
+// on update, and teardown on delete - in one place. Because there is only
+// ever one resource instance per project (no for_each over individual
+// nodes), there is no possibility of the "Cycle" error that arises when
+// Terraform resources of the same type try to reference sibling instances
+// of themselves, and orphaned ancestor nodes are correctly pruned on update
+// since this resource has full visibility into both the old and new
+// desired state.
+func ResourceAreaTree() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAreaTreeCreate,
+		ReadContext:   resourceAreaTreeRead,
+		UpdateContext: resourceAreaTreeUpdate,
+		DeleteContext: resourceAreaTreeDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAreaTreeImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			// The full area path hierarchy to manage, expressed as an
+			// infinitely-deep JSON object tree where every key is an area
+			// name and its value is the (possibly empty) object describing
+			// that area's children, e.g.:
+			//   jsonencode({
+			//     "Team A" = { "Sub Area" = {} }
+			//     "Team B" = {}
+			//   })
+			// Every node in the tree - including intermediate/ancestor
+			// nodes like "Team A" above - is created and removed
+			// automatically as part of managing this resource.
+			"paths": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validatePaths,
+			},
+			// Map of every managed area path (including implied ancestors)
+			// to its integer node ID.
+			"area_ids": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// Map of every managed area path (including implied ancestors)
+			// to its full canonical Azure DevOps path
+			// (e.g. "ProjectName\Area\Team A\Sub Area"), suitable for direct
+			// use as the "path" of an azuredevops_team area assignment.
+			"area_paths": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+// normalizeAreaPath trims surrounding whitespace from a single area path
+// segment (an area name as it appears as a key in the paths tree).
+func normalizeAreaPath(raw string) string {
+	return strings.TrimSpace(raw)
+}
+
+// validateAreaPath validates a single area path segment (a key in the paths
+// tree), reusing the same naming rules Azure DevOps enforces for
+// classification node names.
+func validateAreaPath(v interface{}, k string) (warnings []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("%q must be a string", k))
+		return warnings, errors
+	}
+	return validateClassificationNodeName(normalizeAreaPath(value), k)
+}
+
+// validatePaths validates the raw "paths" attribute: it must be a JSON
+// object that parses into an areaTree, and every key at every depth must be
+// a valid area path segment.
+func validatePaths(v interface{}, k string) (warnings []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("%q must be a string", k))
+		return warnings, errors
+	}
+
+	tree, err := expandAreaTree(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q is invalid: %w", k, err))
+		return warnings, errors
+	}
+
+	if _, err := flattenAreaTree(tree); err != nil {
+		errors = append(errors, fmt.Errorf("%q is invalid: %w", k, err))
+	}
+
+	return warnings, errors
+}
+
+// expandAreaTree parses the raw JSON representation of the "paths"
+// attribute into an areaTree. An empty/whitespace-only string is treated as
+// an empty tree.
+func expandAreaTree(raw string) (areaTree, error) {
+	tree := areaTree{}
+
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return tree, nil
+	}
+
+	if err := json.Unmarshal([]byte(trimmed), &tree); err != nil {
+		return nil, fmt.Errorf("parsing paths as a JSON object tree: %w", err)
+	}
+
+	return tree, nil
+}
+
+// flattenAreaTree walks tree depth-first and returns the full, deduplicated
+// closure of area paths - every node plus every one of its ancestors -
+// sorted ascending by depth (shallowest first) so that processing the list
+// in order always creates parents before their children.
+func flattenAreaTree(tree areaTree) ([]string, error) {
+	seen := map[string]bool{}
+	var closure []string
+
+	var walk func(node areaTree, prefix []string) error
+	walk = func(node areaTree, prefix []string) error {
+		for rawName, children := range node {
+			name := normalizeAreaPath(rawName)
+			if name == "" {
+				return fmt.Errorf("area path segment must not be empty or whitespace (parent: %q)", strings.Join(prefix, "/"))
+			}
+			if _, errs := validateClassificationNodeName(name, "paths"); len(errs) > 0 {
+				return errs[0]
+			}
+
+			full := append(append([]string{}, prefix...), name)
+			key := strings.Join(full, "/")
+			if !seen[key] {
+				seen[key] = true
+				closure = append(closure, key)
+			}
+
+			if err := walk(children, full); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := walk(tree, nil); err != nil {
+		return nil, err
+	}
+
+	sortByDepth(closure, false)
+	return closure, nil
+}
+
+// sortByDepth sorts area path keys by their nesting depth (number of "/"
+// separators). When descending is true, deepest paths sort first, which is
+// the safe order for deletion (children before parents).
+func sortByDepth(paths []string, descending bool) {
+	sort.Slice(paths, func(i, j int) bool {
+		di, dj := strings.Count(paths[i], "/"), strings.Count(paths[j], "/")
+		if di != dj {
+			if descending {
+				return di > dj
+			}
+			return di < dj
+		}
+		if descending {
+			return paths[i] > paths[j]
+		}
+		return paths[i] < paths[j]
+	})
+}
+
+func toStringSet(paths []string) map[string]bool {
+	set := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		set[p] = true
+	}
+	return set
+}
+
+func resourceAreaTreeCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	tree, err := expandAreaTree(d.Get("paths").(string))
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+	closure, err := flattenAreaTree(tree)
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+
+	if err := ensureAreaNodes(ctx, clients, projectID, closure, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("creating area tree for project %q: %+v", projectID, err)
+	}
+
+	d.SetId(projectID)
+
+	return resourceAreaTreeRead(ctx, d, m)
+}
+
+// ensureAreaNodes idempotently creates every path in paths, in order.
+// paths must already be sorted ascending by depth (see flattenAreaTree) so
+// that, for every entry, its parent either already exists in Azure DevOps or
+// was created earlier in this same call.
+func ensureAreaNodes(ctx context.Context, clients *client.AggregatedClient, projectID string, paths []string, timeout time.Duration) error {
+	for _, p := range paths {
+		segments := strings.Split(p, "/")
+		name := segments[len(segments)-1]
+
+		var parentArg *string
+		if len(segments) > 1 {
+			parent := strings.Join(segments[:len(segments)-1], "/")
+			parentArg = &parent
+		}
+
+		err := utils.RetryOn(ctx, timeout, func() error {
+			_, err := clients.WorkItemTrackingClient.CreateOrUpdateClassificationNode(clients.Ctx, workitemtracking.CreateOrUpdateClassificationNodeArgs{
+				Project:        &projectID,
+				StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+				Path:           parentArg,
+				PostedNode: &workitemtracking.WorkItemClassificationNode{
+					Name: &name,
+				},
+			})
+			return err
+		}, utils.RetryOnNotFound, utils.RetryOnUnexpectedException)
+		if err != nil {
+			return fmt.Errorf("ensuring area path %q: %w", p, err)
+		}
+	}
+	return nil
+}
+
+// deleteAreaNodes deletes every path in paths, in order. paths must already
+// be sorted descending by depth (deepest first) so that children are always
+// removed before their parents. Missing nodes (already deleted, e.g. by a
+// previous partially-applied run) are treated as success.
+func deleteAreaNodes(ctx context.Context, clients *client.AggregatedClient, projectID string, paths []string, timeout time.Duration) error {
+	for _, p := range paths {
+		apiPath := p
+		err := utils.RetryOn(ctx, timeout, func() error {
+			err := clients.WorkItemTrackingClient.DeleteClassificationNode(clients.Ctx, workitemtracking.DeleteClassificationNodeArgs{
+				Project:        &projectID,
+				StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+				Path:           &apiPath,
+			})
+			if err != nil && utils.ResponseWasNotFound(err) {
+				return nil
+			}
+			return err
+		}, utils.RetryOnUnexpectedException)
+		if err != nil {
+			return fmt.Errorf("deleting area path %q: %w", p, err)
+		}
+	}
+	return nil
+}
+
+func resourceAreaTreeRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	tree, err := expandAreaTree(d.Get("paths").(string))
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+	closure, err := flattenAreaTree(tree)
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+
+	areaIDs := map[string]interface{}{}
+	areaPaths := map[string]interface{}{}
+
+	for _, p := range closure {
+		apiPath := p
+		node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
+			Project:        &projectID,
+			StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+			Path:           &apiPath,
+		})
+		if err != nil {
+			if utils.ResponseWasNotFound(err) {
+				// Node drifted away out-of-band. Omit it from the computed
+				// maps; the resulting diff on area_ids/area_paths will
+				// surface the drift so the next apply can recreate it.
+				continue
+			}
+			return diag.Errorf("reading area path %q: %+v", p, err)
+		}
+		if node.Id != nil {
+			areaIDs[p] = strconv.Itoa(*node.Id)
+		}
+		if node.Path != nil {
+			areaPaths[p] = *node.Path
+		}
+	}
+
+	if len(areaIDs) == 0 {
+		// Nothing in the desired tree exists anymore; treat as deleted.
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("area_ids", areaIDs)
+	d.Set("area_paths", areaPaths)
+
+	return nil
+}
+
+// diffAreaTreeClosures compares the old and new desired area tree closures
+// and returns the paths to create (ascending by depth) and the paths to
+// remove (descending by depth, safe for deletion).
+func diffAreaTreeClosures(oldClosure, newClosure []string) (toCreate, toRemove []string) {
+	oldSet := toStringSet(oldClosure)
+	newSet := toStringSet(newClosure)
+
+	for _, p := range newClosure {
+		if !oldSet[p] {
+			toCreate = append(toCreate, p)
+		}
+	}
+	// newClosure is already sorted ascending by depth, and filtering
+	// preserves that order.
+
+	for _, p := range oldClosure {
+		if !newSet[p] {
+			toRemove = append(toRemove, p)
+		}
+	}
+	// A path being removed can never have a surviving descendant in
+	// newClosure: if it did, that descendant's own ancestor closure would
+	// include this path too, keeping it in newSet. So it's always safe to
+	// delete toRemove entries deepest-first without orphaning a node that
+	// still has live children.
+	sortByDepth(toRemove, true)
+
+	return toCreate, toRemove
+}
+
+func resourceAreaTreeUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	oldRaw, newRaw := d.GetChange("paths")
+
+	oldTree, err := expandAreaTree(oldRaw.(string))
+	if err != nil {
+		return diag.Errorf("parsing previous paths for project %q: %+v", projectID, err)
+	}
+	newTree, err := expandAreaTree(newRaw.(string))
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+
+	oldClosure, err := flattenAreaTree(oldTree)
+	if err != nil {
+		return diag.Errorf("parsing previous paths for project %q: %+v", projectID, err)
+	}
+	newClosure, err := flattenAreaTree(newTree)
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+
+	toCreate, toRemove := diffAreaTreeClosures(oldClosure, newClosure)
+
+	if err := deleteAreaNodes(ctx, clients, projectID, toRemove, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("pruning area tree for project %q: %+v", projectID, err)
+	}
+	if err := ensureAreaNodes(ctx, clients, projectID, toCreate, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("updating area tree for project %q: %+v", projectID, err)
+	}
+
+	return resourceAreaTreeRead(ctx, d, m)
+}
+
+func resourceAreaTreeDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+
+	projectID := d.Get("project_id").(string)
+	tree, err := expandAreaTree(d.Get("paths").(string))
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+	closure, err := flattenAreaTree(tree)
+	if err != nil {
+		return diag.Errorf("parsing paths for project %q: %+v", projectID, err)
+	}
+	sortByDepth(closure, true)
+
+	if err := deleteAreaNodes(ctx, clients, projectID, closure, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("deleting area tree for project %q: %+v", projectID, err)
+	}
+
+	return nil
+}
+
+func resourceAreaTreeImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	projectID := d.Id()
+	clients := m.(*client.AggregatedClient)
+
+	node, err := clients.WorkItemTrackingClient.GetClassificationNode(clients.Ctx, workitemtracking.GetClassificationNodeArgs{
+		Project:        &projectID,
+		StructureGroup: &workitemtracking.TreeStructureGroupValues.Areas,
+		Depth:          converter.Int(1000),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading area tree for project %q: %w", projectID, err)
+	}
+
+	tree := buildAreaTree(node)
+	raw, err := json.Marshal(tree)
+	if err != nil {
+		return nil, fmt.Errorf("encoding area tree for project %q: %w", projectID, err)
+	}
+
+	d.SetId(projectID)
+	d.Set("project_id", projectID)
+	d.Set("paths", string(raw))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+// buildAreaTree converts the API's classification node tree (as returned by
+// GetClassificationNode with a large Depth) into an areaTree suitable for
+// storing in the "paths" attribute.
+func buildAreaTree(n *workitemtracking.WorkItemClassificationNode) areaTree {
+	tree := areaTree{}
+	if n == nil || n.Children == nil {
+		return tree
+	}
+	for _, child := range *n.Children {
+		name := ""
+		if child.Name != nil {
+			name = *child.Name
+		}
+		c := child
+		tree[name] = buildAreaTree(&c)
+	}
+	return tree
+}

--- a/azuredevops/internal/service/workitemtracking/resource_area_tree_test.go
+++ b/azuredevops/internal/service/workitemtracking/resource_area_tree_test.go
@@ -1,0 +1,337 @@
+package workitemtracking
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/workitemtracking"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// getAreaTreeResourceData builds *schema.ResourceData for the area tree
+// resource from the given raw attribute map.
+func getAreaTreeResourceData(t *testing.T, input map[string]interface{}) *schema.ResourceData {
+	r := ResourceAreaTree()
+	return schema.TestResourceDataRaw(t, r.Schema, input)
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func TestNormalizeAreaPath(t *testing.T) {
+	assert.Equal(t, "Team A", normalizeAreaPath("  Team A  "))
+	assert.Equal(t, "", normalizeAreaPath("   "))
+	assert.Equal(t, "Team A", normalizeAreaPath("Team A"))
+}
+
+func TestValidateAreaPath(t *testing.T) {
+	_, errs := validateAreaPath("Team A", "paths")
+	assert.Empty(t, errs)
+
+	_, errs = validateAreaPath("  Team A  ", "paths")
+	assert.Empty(t, errs, "surrounding whitespace should be trimmed before validation")
+
+	_, errs = validateAreaPath("", "paths")
+	assert.NotEmpty(t, errs, "empty segment should be invalid")
+
+	_, errs = validateAreaPath("Team/A", "paths")
+	assert.NotEmpty(t, errs, "segment must not contain a slash")
+
+	_, errs = validateAreaPath(123, "paths")
+	assert.NotEmpty(t, errs, "non-string value should be invalid")
+}
+
+func TestExpandAreaTree(t *testing.T) {
+	tree, err := expandAreaTree(`{"Team A":{"Sub Area":{}},"Team B":{}}`)
+	require.NoError(t, err)
+	require.Contains(t, tree, "Team A")
+	require.Contains(t, tree, "Team B")
+	require.Contains(t, tree["Team A"], "Sub Area")
+
+	// empty/whitespace input is treated as an empty tree, not an error.
+	tree, err = expandAreaTree("   ")
+	require.NoError(t, err)
+	assert.Empty(t, tree)
+
+	_, err = expandAreaTree("not json")
+	assert.Error(t, err)
+
+	_, err = expandAreaTree(`["Team A"]`)
+	assert.Error(t, err, "a JSON array is not a valid tree")
+}
+
+func TestFlattenAreaTree(t *testing.T) {
+	tree := areaTree{
+		"Team A": areaTree{
+			"Sub Area 1": areaTree{},
+			"Sub Area 2": areaTree{
+				"Grandchild": areaTree{},
+			},
+		},
+		"Team B": areaTree{},
+	}
+
+	closure, err := flattenAreaTree(tree)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{
+		"Team A",
+		"Team A/Sub Area 1",
+		"Team A/Sub Area 2",
+		"Team A/Sub Area 2/Grandchild",
+		"Team B",
+	}, closure)
+
+	// Ancestors must always precede their descendants.
+	index := map[string]int{}
+	for i, p := range closure {
+		index[p] = i
+	}
+	assert.Less(t, index["Team A"], index["Team A/Sub Area 2"])
+	assert.Less(t, index["Team A/Sub Area 2"], index["Team A/Sub Area 2/Grandchild"])
+}
+
+func TestFlattenAreaTree_EmptySegment(t *testing.T) {
+	tree := areaTree{"   ": areaTree{}}
+	_, err := flattenAreaTree(tree)
+	assert.Error(t, err)
+}
+
+func TestFlattenAreaTree_InvalidSegmentName(t *testing.T) {
+	tree := areaTree{"Team/A": areaTree{}}
+	_, err := flattenAreaTree(tree)
+	assert.Error(t, err)
+}
+
+func TestFlattenAreaTree_Empty(t *testing.T) {
+	closure, err := flattenAreaTree(areaTree{})
+	require.NoError(t, err)
+	assert.Empty(t, closure)
+}
+
+func TestSortByDepth(t *testing.T) {
+	paths := []string{"Team B", "Team A/Sub Area", "Team A"}
+
+	ascending := append([]string{}, paths...)
+	sortByDepth(ascending, false)
+	assert.Equal(t, []string{"Team A", "Team B", "Team A/Sub Area"}, ascending)
+
+	descending := append([]string{}, paths...)
+	sortByDepth(descending, true)
+	assert.Equal(t, []string{"Team A/Sub Area", "Team B", "Team A"}, descending)
+}
+
+func TestBuildAreaTree(t *testing.T) {
+	grandchild := workitemtracking.WorkItemClassificationNode{
+		Name: converter.String("Grandchild"),
+	}
+	child := workitemtracking.WorkItemClassificationNode{
+		Name:     converter.String("Sub Area"),
+		Children: &[]workitemtracking.WorkItemClassificationNode{grandchild},
+	}
+	root := workitemtracking.WorkItemClassificationNode{
+		Name:     converter.String("Area"),
+		Children: &[]workitemtracking.WorkItemClassificationNode{child},
+	}
+
+	tree := buildAreaTree(&root)
+	require.Contains(t, tree, "Sub Area")
+	require.Contains(t, tree["Sub Area"], "Grandchild")
+
+	assert.Empty(t, buildAreaTree(nil))
+}
+
+func TestResourceAreaTreeCreate_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := azdosdkmocks.NewMockWorkitemtrackingClient(ctrl)
+	clients := &client.AggregatedClient{WorkItemTrackingClient: mockClient, Ctx: context.Background()}
+
+	projectID := uuid.NewString()
+
+	// "Team A" is created first (no parent), then "Team A/Sub Area" (with
+	// parent "Team A"), because flattenAreaTree sorts ascending by depth.
+	mockClient.EXPECT().
+		CreateOrUpdateClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.CreateOrUpdateClassificationNodeArgs) (*workitemtracking.WorkItemClassificationNode, error) {
+			assert.Nil(t, args.Path)
+			assert.Equal(t, "Team A", *args.PostedNode.Name)
+			return &workitemtracking.WorkItemClassificationNode{}, nil
+		}).Times(1)
+	mockClient.EXPECT().
+		CreateOrUpdateClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.CreateOrUpdateClassificationNodeArgs) (*workitemtracking.WorkItemClassificationNode, error) {
+			require.NotNil(t, args.Path)
+			assert.Equal(t, "Team A", *args.Path)
+			assert.Equal(t, "Sub Area", *args.PostedNode.Name)
+			return &workitemtracking.WorkItemClassificationNode{}, nil
+		}).Times(1)
+
+	// Read after create looks up every node in the closure.
+	mockClient.EXPECT().
+		GetClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.GetClassificationNodeArgs) (*workitemtracking.WorkItemClassificationNode, error) {
+			return &workitemtracking.WorkItemClassificationNode{
+				Id:   converter.Int(1),
+				Path: converter.String(*args.Path),
+			}, nil
+		}).Times(2)
+
+	d := getAreaTreeResourceData(t, map[string]interface{}{
+		"project_id": projectID,
+		"paths": mustJSON(t, areaTree{
+			"Team A": areaTree{"Sub Area": areaTree{}},
+		}),
+	})
+
+	diags := resourceAreaTreeCreate(context.Background(), d, clients)
+	assert.Empty(t, diags)
+	assert.Equal(t, projectID, d.Id())
+}
+
+func TestResourceAreaTreeCreate_InvalidPaths(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := azdosdkmocks.NewMockWorkitemtrackingClient(ctrl)
+	clients := &client.AggregatedClient{WorkItemTrackingClient: mockClient, Ctx: context.Background()}
+
+	d := getAreaTreeResourceData(t, map[string]interface{}{
+		"project_id": uuid.NewString(),
+		"paths":      "not json",
+	})
+
+	diags := resourceAreaTreeCreate(context.Background(), d, clients)
+	require.NotEmpty(t, diags)
+	assert.True(t, diags.HasError())
+}
+
+func TestResourceAreaTreeDelete_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := azdosdkmocks.NewMockWorkitemtrackingClient(ctrl)
+	clients := &client.AggregatedClient{WorkItemTrackingClient: mockClient, Ctx: context.Background()}
+
+	projectID := uuid.NewString()
+
+	var deletedOrder []string
+	mockClient.EXPECT().
+		DeleteClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.DeleteClassificationNodeArgs) error {
+			deletedOrder = append(deletedOrder, *args.Path)
+			return nil
+		}).Times(2)
+
+	d := getAreaTreeResourceData(t, map[string]interface{}{
+		"project_id": projectID,
+		"paths": mustJSON(t, areaTree{
+			"Team A": areaTree{"Sub Area": areaTree{}},
+		}),
+	})
+
+	diags := resourceAreaTreeDelete(context.Background(), d, clients)
+	assert.Empty(t, diags)
+	// Children must be deleted before their parents.
+	require.Equal(t, []string{"Team A/Sub Area", "Team A"}, deletedOrder)
+}
+
+func TestDiffAreaTreeClosures(t *testing.T) {
+	oldClosure := []string{"Team A", "Team A/Sub Area"}
+	newClosure := []string{"Team A", "Team B"}
+
+	toCreate, toRemove := diffAreaTreeClosures(oldClosure, newClosure)
+
+	assert.Equal(t, []string{"Team B"}, toCreate)
+	assert.Equal(t, []string{"Team A/Sub Area"}, toRemove)
+}
+
+func TestDiffAreaTreeClosures_PrunesDeepestFirst(t *testing.T) {
+	oldClosure := []string{"Team A", "Team A/Sub Area", "Team A/Sub Area/Grandchild"}
+	newClosure := []string{}
+
+	toCreate, toRemove := diffAreaTreeClosures(oldClosure, newClosure)
+
+	assert.Empty(t, toCreate)
+	assert.Equal(t, []string{"Team A/Sub Area/Grandchild", "Team A/Sub Area", "Team A"}, toRemove)
+}
+
+func TestResourceAreaTreeUpdate_CreatesAndPrunes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := azdosdkmocks.NewMockWorkitemtrackingClient(ctrl)
+	clients := &client.AggregatedClient{WorkItemTrackingClient: mockClient, Ctx: context.Background()}
+
+	projectID := uuid.NewString()
+
+	mockClient.EXPECT().
+		DeleteClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.DeleteClassificationNodeArgs) error {
+			assert.Equal(t, "Team A", *args.Path)
+			return nil
+		}).Times(1)
+
+	mockClient.EXPECT().
+		CreateOrUpdateClassificationNode(clients.Ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, args workitemtracking.CreateOrUpdateClassificationNodeArgs) (*workitemtracking.WorkItemClassificationNode, error) {
+			assert.Equal(t, "Team B", *args.PostedNode.Name)
+			return &workitemtracking.WorkItemClassificationNode{}, nil
+		}).Times(1)
+
+	toCreate, toRemove := diffAreaTreeClosures([]string{"Team A"}, []string{"Team B"})
+	require.Equal(t, []string{"Team B"}, toCreate)
+	require.Equal(t, []string{"Team A"}, toRemove)
+
+	require.NoError(t, deleteAreaNodes(context.Background(), clients, projectID, toRemove, time.Minute))
+	require.NoError(t, ensureAreaNodes(context.Background(), clients, projectID, toCreate, time.Minute))
+}
+
+func TestResourceAreaTreeImport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := azdosdkmocks.NewMockWorkitemtrackingClient(ctrl)
+	clients := &client.AggregatedClient{WorkItemTrackingClient: mockClient, Ctx: context.Background()}
+
+	projectID := uuid.NewString()
+
+	subArea := workitemtracking.WorkItemClassificationNode{Name: converter.String("Sub Area")}
+	teamA := workitemtracking.WorkItemClassificationNode{
+		Name:     converter.String("Team A"),
+		Children: &[]workitemtracking.WorkItemClassificationNode{subArea},
+	}
+	root := workitemtracking.WorkItemClassificationNode{
+		Children: &[]workitemtracking.WorkItemClassificationNode{teamA},
+	}
+
+	mockClient.EXPECT().GetClassificationNode(clients.Ctx, gomock.Any()).Return(&root, nil).Times(1)
+
+	d := getAreaTreeResourceData(t, map[string]interface{}{})
+	d.SetId(projectID)
+
+	results, err := resourceAreaTreeImport(context.Background(), d, clients)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	imported := results[0]
+	assert.Equal(t, projectID, imported.Get("project_id"))
+
+	tree, err := expandAreaTree(imported.Get("paths").(string))
+	require.NoError(t, err)
+	require.Contains(t, tree, "Team A")
+	require.Contains(t, tree["Team A"], "Sub Area")
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -46,6 +46,7 @@ func Provider() *schema.Provider {
 			"azuredevops_agent_queue":                                 taskagent.ResourceAgentQueue(),
 			"azuredevops_area":                                        workitemtracking.ResourceArea(),
 			"azuredevops_area_permissions":                            permissions.ResourceAreaPermissions(),
+			"azuredevops_area_tree":                                   workitemtracking.ResourceAreaTree(),
 			"azuredevops_branch_policy_auto_reviewers":                branch.ResourceBranchPolicyAutoReviewers(),
 			"azuredevops_branch_policy_build_validation":              branch.ResourceBranchPolicyBuildValidation(),
 			"azuredevops_branch_policy_comment_resolution":            branch.ResourceBranchPolicyCommentResolution(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -14,6 +14,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_agent_queue",
 		"azuredevops_area",
 		"azuredevops_area_permissions",
+		"azuredevops_area_tree",
 		"azuredevops_branch_policy_auto_reviewers",
 		"azuredevops_branch_policy_build_validation",
 		"azuredevops_branch_policy_comment_resolution",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -113,6 +113,9 @@
                   <a href="/docs/providers/azuredevops/r/area_permissions.html">azuredevops_area_permissions</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/area_tree.html">azuredevops_area_tree</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/project_pipeline_settings.html">azuredevops_project_pipeline_settings</a>
                 </li>
                 <li>

--- a/website/docs/r/area_tree.html.markdown
+++ b/website/docs/r/area_tree.html.markdown
@@ -1,0 +1,92 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_area_tree"
+description: |-
+  Manages an entire Area Path hierarchy for a project in Azure DevOps.
+---
+
+# azuredevops_area_tree
+
+Manages an entire Area Path (classification node) hierarchy for a project as a single resource.
+
+Unlike [`azuredevops_area`](area.html.markdown), which manages one area path node per resource instance, `azuredevops_area_tree` takes the complete, desired area path hierarchy - expressed as an infinitely-deep nested object - and owns its full lifecycle: creating every node (including implied ancestors), pruning nodes that are removed on update, and tearing down the whole tree on delete.
+
+Because there is only ever one resource instance per project (no `for_each` over individual nodes), there is no possibility of the "Cycle" error that can arise when Terraform resources of the same type reference sibling instances of themselves, and orphaned ancestor nodes are correctly pruned on update since this resource has full visibility into both the old and new desired state.
+
+## Example Usage
+
+### Basic tree
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  work_item_template = "Agile"
+  version_control    = "Git"
+  visibility         = "private"
+  description        = "Managed by Terraform"
+}
+
+resource "azuredevops_area_tree" "example" {
+  project_id = azuredevops_project.example.id
+
+  paths = jsonencode({
+    "Team A" = {}
+    "Team B" = {}
+  })
+}
+```
+
+### Arbitrarily deep, nested tree
+
+Every key in the object is an area name, and its value is the (possibly empty) object describing that area's children. Nesting can go as deep as needed; every intermediate/ancestor node (e.g. `Team A` and `Team A/Sub Area` below) is created and removed automatically, so it does not need to be listed as its own top-level entry.
+
+```hcl
+resource "azuredevops_area_tree" "example" {
+  project_id = azuredevops_project.example.id
+
+  paths = jsonencode({
+    "Team A" = {
+      "Sub Area" = {
+        "Grandchild" = {}
+      }
+    }
+    "Team B" = {}
+  })
+}
+```
+
+Using this tree with a team's default area:
+
+```hcl
+resource "azuredevops_team" "team_a" {
+  project_id = azuredevops_project.example.id
+  name       = "Team A"
+
+  area = [
+    azuredevops_area_tree.example.area_paths["Team A"],
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project. Changing this forces a new resource to be created.
+* `paths` - (Required) The full area path hierarchy to manage, expressed as a JSON-encoded, infinitely-deep object tree (typically built with `jsonencode`). Every key is an area name and its value is the (possibly empty) object describing that area's children.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the project (same as `project_id`).
+* `area_ids` - Map of every managed area path (including implied ancestors, keyed by slash-separated path relative to the project root, e.g. `Team A/Sub Area`) to its integer node ID.
+* `area_paths` - Map of every managed area path (keyed the same way as `area_ids`) to its full canonical Azure DevOps path (e.g. `Example Project\Area\Team A\Sub Area`), suitable for direct use as an entry in an `azuredevops_team` resource's `area` attribute.
+
+## Import
+
+Area trees can be imported using the project ID, e.g.:
+
+```shell
+terraform import azuredevops_area_tree.example 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

This PR adds a new resource, `azuredevops_area_tree`, which manages an entire Area Path (classification node) hierarchy for a project as a single Terraform resource.

`azuredevops_area` (the existing resource) manages exactly one area path node per resource instance, which requires users to declare a separate resource instance per node and to reference sibling instances of the same resource type in order to build a hierarchy (e.g. a child node referencing its parent node's `path` output). This is needed because **Terraform cannot dynamically resolve dependencies between sibling instances of the same resource** - the graph is built statically from configuration, so a resource cannot safely depend on another instance of itself when the set/shape of instances is only known at apply time (e.g. derived from a variable or `for_each` over a dynamic structure). In practice this shows up as the well-known Terraform "Cycle" error, or forces awkward workarounds (hard-coded ordering, `depends_on` hacks, splitting the hierarchy across multiple `terraform apply` runs) whenever an area path hierarchy needs to be built or reshaped dynamically.

`azuredevops_area_tree` avoids this limitation entirely by taking the complete, desired area path hierarchy as a single, arbitrarily-deep nested object (via the `paths` argument, expressed with `jsonencode`) and owning the full lifecycle of every node in one resource instance:

* Creates every node in the tree, including implied/intermediate ancestor nodes that aren't explicitly listed.
* Prunes nodes that are removed from the desired state on update, since the resource has full visibility into both the previous and new state of the entire tree (unlike `azuredevops_area`, which only knows about its own single node).
* Tears down the whole tree on delete.
* Exposes `area_ids` and `area_paths` maps (keyed by slash-separated relative path) so other resources, such as `azuredevops_team`, can reference any node in the tree without needing sibling-resource lookups.

Because there is only ever one resource instance per project (no `for_each` over individual nodes), there is no possibility of the "Cycle" error, making this the recommended way to manage non-trivial area path hierarchies going forward. `azuredevops_area` remains available/unchanged for simpler, single-node use cases.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This is a purely additive change: a new resource type, its documentation page, and a website navigation entry. No existing resources, data sources, or schemas are modified.

## Test Result

Unit tests (`resource_area_tree_test.go`) covering the tree-diffing, create/update/delete, and import logic are included and pass. Acceptance tests (`resource_area_tree_test.go` under `acceptancetests/`) are also included, following the existing pattern used by other resources in this provider; they require a live Azure DevOps organization and credentials to execute (`TF_ACC=1`) and were exercised against a test organization during development.

## Related Issue(s)

N/A - this is a new feature contribution, not tied to an existing tracked issue.

## Other information

None.