### PR TITLE
New Resource - `azuredevops_release_definition`

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_release_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_release_definition_test.go
@@ -2,6 +2,7 @@ package acceptancetests
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -89,8 +90,42 @@ func TestAccReleaseDefinition_variables(t *testing.T) {
 				Config: hclReleaseDefinitionVariables(name),
 				Check: resource.ComposeTestCheckFunc(
 					checkReleaseDefinitionExists(name),
-					resource.TestCheckResourceAttr(tfNode, "variable.#", "2"),
+					resource.TestCheckResourceAttr(tfNode, "variable.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "variable.0.name", "FOO_VAR"),
+					resource.TestCheckResourceAttr(tfNode, "variable.0.value", "foo"),
+					resource.TestCheckResourceAttr(tfNode, "secret_variable.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "secret_variable.0.name", "BAR_VAR"),
+					resource.TestCheckResourceAttr(tfNode, "secret_variable.0.value", "bar"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.variable.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.variable.0.name", "STAGE_VAR"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.variable.0.value", "stage"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.secret_variable.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.secret_variable.0.name", "STAGE_SECRET"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.secret_variable.0.value", "stagesecret"),
 				),
+			},
+			{
+				ResourceName:            tfNode,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportStateVerifyIgnore: []string{"secret_variable.0.value", "stage.0.secret_variable.0.value"},
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_duplicateVariableName(t *testing.T) {
+	name := testutils.GenerateResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config:      hclReleaseDefinitionDuplicateVariable(name),
+				ExpectError: regexp.MustCompile("`DUPE_VAR` is declared as both a `variable` and a `secret_variable`"),
 			},
 		},
 	})
@@ -114,6 +149,68 @@ func TestAccReleaseDefinition_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(tfNode, "stage.1.environment_trigger.0.trigger_type", "rollbackRedeploy"),
 					resource.TestCheckResourceAttr(tfNode, "stage.1.pre_deployment_gates.#", "1"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_sourceRepoAndPullRequestTriggers(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionRepoTriggers(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttr(tfNode, "source_repo_trigger.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "source_repo_trigger.0.artifact_alias", "sourceRepo"),
+					resource.TestCheckResourceAttr(tfNode, "source_repo_trigger.0.branch_filter.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "source_repo_trigger.0.branch_filter.0.include.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "pull_request_trigger.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "pull_request_trigger.0.artifact_alias", "sourceRepo"),
+					resource.TestCheckResourceAttr(tfNode, "pull_request_trigger.0.use_artifact_reference", "true"),
+					resource.TestCheckResourceAttr(tfNode, "pull_request_trigger.0.trigger_condition.0.target_branch", "refs/heads/master"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_packageTrigger(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionPackageTrigger(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttr(tfNode, "artifact.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "artifact.0.type", "PackageManagement"),
+					resource.TestCheckResourceAttr(tfNode, "package_trigger.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "package_trigger.0.artifact_alias", "mypackage"),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
 			},
 		},
 	})
@@ -274,10 +371,56 @@ resource "azuredevops_release_definition" "test" {
     value = "foo"
   }
 
+  secret_variable {
+    name  = "BAR_VAR"
+    value = "bar"
+  }
+
+  stage {
+    name = "Stage 1"
+
+    variable {
+      name  = "STAGE_VAR"
+      value = "stage"
+    }
+
+    secret_variable {
+      name  = "STAGE_SECRET"
+      value = "stagesecret"
+    }
+
+    deploy_phase {
+      name           = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo $(FOO_VAR)"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionDuplicateVariable(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+
   variable {
-    name         = "BAR_VAR"
-    is_secret    = true
-    secret_value = "bar"
+    name  = "DUPE_VAR"
+    value = "plain"
+  }
+
+  secret_variable {
+    name  = "DUPE_VAR"
+    value = "secret"
   }
 
   stage {
@@ -291,7 +434,7 @@ resource "azuredevops_release_definition" "test" {
         task_id = "%[3]s"
         version = "2.*"
         inputs = {
-          script = "echo $(FOO_VAR)"
+          script = "echo hello"
         }
       }
     }
@@ -436,6 +579,143 @@ resource "azuredevops_release_definition" "test" {
         version = "2.*"
         inputs = {
           script = "echo Deploying $(app_name) to $(target_url)"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionRepoTriggers(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuredevops_git_repository" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s-repo"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+
+  artifact {
+    alias      = "sourceRepo"
+    type       = "Git"
+    is_primary = true
+
+    definition_reference {
+      key  = "project"
+      id   = azuredevops_project.test.id
+      name = azuredevops_project.test.name
+    }
+    definition_reference {
+      key  = "definition"
+      id   = azuredevops_git_repository.test.id
+      name = azuredevops_git_repository.test.name
+    }
+    definition_reference {
+      key  = "defaultVersionType"
+      id   = "latestFromBranchType"
+      name = "Latest from a specific branch"
+    }
+    definition_reference {
+      key  = "branches"
+      id   = "refs/heads/master"
+      name = "refs/heads/master"
+    }
+  }
+
+  source_repo_trigger {
+    artifact_alias = "sourceRepo"
+
+    branch_filter {
+      include = ["refs/heads/master"]
+    }
+  }
+
+  pull_request_trigger {
+    artifact_alias         = "sourceRepo"
+    use_artifact_reference = true
+
+    trigger_condition {
+      target_branch = "refs/heads/master"
+    }
+  }
+
+  stage {
+    name = "Stage 1"
+
+    deploy_phase {
+      name           = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo hello"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionPackageTrigger(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuredevops_feed" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s-feed"
+}
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+
+  artifact {
+    alias      = "mypackage"
+    type       = "PackageManagement"
+    is_primary = true
+
+    definition_reference {
+      key  = "feed"
+      id   = azuredevops_feed.test.id
+      name = azuredevops_feed.test.name
+    }
+    definition_reference {
+      key  = "definition"
+      id   = "%[2]s-package"
+      name = "%[2]s-package"
+    }
+    definition_reference {
+      key  = "defaultVersionType"
+      id   = "latestType"
+      name = "Latest"
+    }
+  }
+
+  package_trigger {
+    artifact_alias = "mypackage"
+  }
+
+  stage {
+    name = "Stage 1"
+
+    deploy_phase {
+      name           = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo hello"
         }
       }
     }

--- a/azuredevops/internal/acceptancetests/resource_release_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_release_definition_test.go
@@ -1,0 +1,444 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/release"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+)
+
+const releaseCmdLineTaskID = "d9bafed4-0b18-4f58-968d-86655b4d2ce9"
+
+func TestAccReleaseDefinition_basic(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "revision"),
+					resource.TestCheckResourceAttr(tfNode, "name", name),
+					resource.TestCheckResourceAttr(tfNode, "stage.#", "1"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.name", "Stage 1"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.deploy_phase.0.task.0.task_id", releaseCmdLineTaskID),
+				),
+			},
+			{
+				ResourceName:      tfNode,
+				ImportStateIdFunc: testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_update(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	nameUpdated := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttr(tfNode, "name", name),
+					resource.TestCheckResourceAttr(tfNode, "path", `\`),
+				),
+			},
+			{
+				Config: hclReleaseDefinitionUpdated(nameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(nameUpdated),
+					resource.TestCheckResourceAttr(tfNode, "name", nameUpdated),
+					resource.TestCheckResourceAttr(tfNode, "path", `\ExampleFolder`),
+					resource.TestCheckResourceAttr(tfNode, "stage.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_variables(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionVariables(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttr(tfNode, "variable.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccReleaseDefinition_complete(t *testing.T) {
+	name := testutils.GenerateResourceName()
+	tfNode := "azuredevops_release_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: checkReleaseDefinitionDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: hclReleaseDefinitionComplete(name),
+				Check: resource.ComposeTestCheckFunc(
+					checkReleaseDefinitionExists(name),
+					resource.TestCheckResourceAttr(tfNode, "stage.#", "2"),
+					resource.TestCheckResourceAttr(tfNode, "stage.0.execution_policy.0.concurrency_count", "2"),
+					resource.TestCheckResourceAttr(tfNode, "stage.1.environment_trigger.0.trigger_type", "rollbackRedeploy"),
+					resource.TestCheckResourceAttr(tfNode, "stage.1.pre_deployment_gates.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func checkReleaseDefinitionExists(expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.RootModule().Resources["azuredevops_release_definition.test"]
+		if !ok {
+			return fmt.Errorf("Did not find a release definition in the TF state")
+		}
+
+		releaseDefinition, err := getReleaseDefinitionFromResource(res)
+		if err != nil {
+			return err
+		}
+
+		if *releaseDefinition.Name != expectedName {
+			return fmt.Errorf("Release Definition has Name=%s, but expected Name=%s", *releaseDefinition.Name, expectedName)
+		}
+
+		return nil
+	}
+}
+
+func checkReleaseDefinitionDestroyed(s *terraform.State) error {
+	for _, res := range s.RootModule().Resources {
+		if res.Type != "azuredevops_release_definition" {
+			continue
+		}
+
+		if _, err := getReleaseDefinitionFromResource(res); err == nil {
+			return fmt.Errorf("Unexpectedly found a release definition that should be deleted")
+		}
+	}
+
+	return nil
+}
+
+func getReleaseDefinitionFromResource(res *terraform.ResourceState) (*release.ReleaseDefinition, error) {
+	releaseDefID, err := strconv.Atoi(res.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	projectID := res.Primary.Attributes["project_id"]
+	clients := testutils.GetProvider().Meta().(*client.AggregatedClient)
+	return clients.ReleaseClient.GetReleaseDefinition(clients.Ctx, release.GetReleaseDefinitionArgs{
+		Project:      &projectID,
+		DefinitionId: &releaseDefID,
+	})
+}
+
+func hclReleaseDefinitionProject(name string) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name               = "%[1]s"
+  description        = "%[1]s-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+data "azuredevops_agent_queue" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "Azure Pipelines"
+}`, name)
+}
+
+func hclReleaseDefinitionBasic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+
+  stage {
+    name = "Stage 1"
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo hello"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionUpdated(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+  path       = "\\ExampleFolder"
+
+  stage {
+    name = "Stage 1"
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo hello"
+        }
+      }
+    }
+  }
+
+  stage {
+    name = "Stage 2"
+
+    condition {
+      condition_type = "environmentState"
+      name           = "Stage 1"
+      value          = "4"
+    }
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo world"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionVariables(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_release_definition" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "%[2]s"
+
+  variable {
+    name  = "FOO_VAR"
+    value = "foo"
+  }
+
+  variable {
+    name         = "BAR_VAR"
+    is_secret    = true
+    secret_value = "bar"
+  }
+
+  stage {
+    name = "Stage 1"
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo $(FOO_VAR)"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}
+
+func hclReleaseDefinitionComplete(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuredevops_group" "test" {
+  project_id = azuredevops_project.test.id
+  name       = "Contributors"
+}
+
+resource "azuredevops_serviceendpoint_generic" "test" {
+  project_id            = azuredevops_project.test.id
+  service_endpoint_name = "%[2]s-gate"
+  server_url            = "https://api.example.com"
+}
+
+resource "azuredevops_release_definition" "test" {
+  project_id          = azuredevops_project.test.id
+  name                = "%[2]s"
+  release_name_format = "Release-$(rev:r)"
+
+  variable {
+    name  = "app_name"
+    value = "myapp"
+  }
+
+  stage {
+    name = "Dev"
+
+    condition {
+      condition_type = "event"
+      name           = "ReleaseStarted"
+    }
+
+    execution_policy {
+      concurrency_count = 2
+      queue_depth_count = 0
+    }
+
+    variable {
+      name  = "target_url"
+      value = "https://dev.example.com"
+    }
+
+    retention_policy {
+      days_to_keep     = 15
+      releases_to_keep = 5
+      retain_build     = true
+    }
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo Deploying $(app_name) to $(target_url)"
+        }
+      }
+    }
+
+    deploy_phase {
+      name       = "Agentless job"
+      phase_type = "runOnServer"
+
+      task {
+        task_id = "9C3E8943-130D-4C78-AC63-8AF81DF62DFB"
+        version = "1.*"
+        inputs = {
+          connectionType       = "connectedServiceName"
+          connectedServiceName = azuredevops_serviceendpoint_generic.test.id
+          method               = "GET"
+        }
+      }
+    }
+  }
+
+  stage {
+    name = "Prod"
+
+    condition {
+      condition_type = "environmentState"
+      name           = "Dev"
+      value          = "4"
+    }
+
+    environment_trigger {
+      trigger_type = "rollbackRedeploy"
+      action       = "LatestSuccessfulDeployment"
+      event_types  = ["MS.TF.DistributedTask.DeploymentFailed"]
+    }
+
+    pre_deployment_gates {
+      sampling_interval        = 5
+      stabilization_time       = 0
+      minimum_success_duration = 0
+      timeout                  = 120
+
+      gate {
+        task {
+          task_id = "9C3E8943-130D-4C78-AC63-8AF81DF62DFB"
+          version = "1.*"
+          inputs = {
+            connectionType       = "connectedServiceName"
+            connectedServiceName = azuredevops_serviceendpoint_generic.test.id
+            method               = "GET"
+          }
+        }
+      }
+    }
+
+    pre_deploy_approval {
+      approval {
+        approver_id        = data.azuredevops_group.test.group_id
+        is_automated       = false
+        is_notification_on = true
+      }
+
+      approval_options {
+        required_approver_count         = 1
+        release_creator_can_be_approver = false
+        enforce_identity_revalidation   = false
+        timeout_in_minutes              = 1440
+        execution_order                 = "beforeGates"
+      }
+    }
+
+    deploy_phase {
+      name          = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.test.id
+
+      task {
+        task_id = "%[3]s"
+        version = "2.*"
+        inputs = {
+          script = "echo Deploying $(app_name) to $(target_url)"
+        }
+      }
+    }
+  }
+}`, hclReleaseDefinitionProject(name), name, releaseCmdLineTaskID)
+}

--- a/azuredevops/internal/acceptancetests/resource_release_definition_test.go
+++ b/azuredevops/internal/acceptancetests/resource_release_definition_test.go
@@ -195,7 +195,7 @@ resource "azuredevops_release_definition" "test" {
     name = "Stage 1"
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {
@@ -223,7 +223,7 @@ resource "azuredevops_release_definition" "test" {
     name = "Stage 1"
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {
@@ -246,7 +246,7 @@ resource "azuredevops_release_definition" "test" {
     }
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {
@@ -284,7 +284,7 @@ resource "azuredevops_release_definition" "test" {
     name = "Stage 1"
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {
@@ -349,7 +349,7 @@ resource "azuredevops_release_definition" "test" {
     }
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {
@@ -428,7 +428,7 @@ resource "azuredevops_release_definition" "test" {
     }
 
     deploy_phase {
-      name          = "Agent job"
+      name           = "Agent job"
       agent_queue_id = data.azuredevops_agent_queue.test.id
 
       task {

--- a/azuredevops/internal/service/release/resource_release_definition.go
+++ b/azuredevops/internal/service/release/resource_release_definition.go
@@ -1309,8 +1309,13 @@ var scheduleDayBits = []struct {
 	bit  int
 	name string
 }{
-	{1, "monday"}, {2, "tuesday"}, {4, "wednesday"}, {8, "thursday"},
-	{16, "friday"}, {32, "saturday"}, {64, "sunday"},
+	{1, "monday"},
+	{2, "tuesday"},
+	{4, "wednesday"},
+	{8, "thursday"},
+	{16, "friday"},
+	{32, "saturday"},
+	{64, "sunday"},
 }
 
 func flattenScheduleDays(input interface{}) []interface{} {

--- a/azuredevops/internal/service/release/resource_release_definition.go
+++ b/azuredevops/internal/service/release/resource_release_definition.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -21,12 +22,38 @@ import (
 
 const (
 	rdVariable          = "variable"
+	rdSecretVariable    = "secret_variable"
 	rdVariableName      = "name"
 	rdVariableValue     = "value"
-	rdVariableSecretVal = "secret_value"
-	rdVariableIsSecret  = "is_secret"
 	rdVariableCanOverwr = "allow_override"
 )
+
+func releaseVariableSchema(secret bool) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				rdVariableName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotWhiteSpace,
+				},
+				rdVariableValue: {
+					Type:      schema.TypeString,
+					Optional:  true,
+					Default:   "",
+					Sensitive: secret,
+				},
+				rdVariableCanOverwr: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
 
 func ResourceReleaseDefinition() *schema.Resource {
 	return &schema.Resource{
@@ -35,6 +62,7 @@ func ResourceReleaseDefinition() *schema.Resource {
 		UpdateContext: resourceReleaseDefinitionUpdate,
 		DeleteContext: resourceReleaseDefinitionDelete,
 		Importer:      tfhelper.ImportProjectQualifiedResource(),
+		CustomizeDiff: resourceReleaseDefinitionCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -69,40 +97,8 @@ func ResourceReleaseDefinition() *schema.Resource {
 					ValidateFunc: validation.IntAtLeast(1),
 				},
 			},
-			rdVariable: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						rdVariableName: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotWhiteSpace,
-						},
-						rdVariableValue: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "",
-						},
-						rdVariableSecretVal: {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-							Default:   "",
-						},
-						rdVariableIsSecret: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						rdVariableCanOverwr: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
+			rdVariable:       releaseVariableSchema(false),
+			rdSecretVariable: releaseVariableSchema(true),
 			"artifact": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -114,19 +110,9 @@ func ResourceReleaseDefinition() *schema.Resource {
 							ValidateFunc: validation.StringIsNotWhiteSpace,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"Build",
-								"Jenkins",
-								"GitHub",
-								"Nuget",
-								"Team Build (external)",
-								"ExternalTFSBuild",
-								"Git",
-								"TFVC",
-								"ExternalTfsXamlBuild",
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
 						},
 						"is_primary": {
 							Type:     schema.TypeBool,
@@ -252,6 +238,151 @@ func ResourceReleaseDefinition() *schema.Resource {
 					},
 				},
 			},
+			"source_repo_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"branch_filter": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"include": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"exclude": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"container_image_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"tag_filter": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"package_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+					},
+				},
+			},
+			"pull_request_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"status_policy_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"use_artifact_reference": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"code_repository_reference": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"system_type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(release.PullRequestSystemTypeValues.TfsGit),
+											string(release.PullRequestSystemTypeValues.GitHub),
+										}, false),
+									},
+									"repository_reference": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotWhiteSpace,
+												},
+												"value": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotWhiteSpace,
+												},
+												"display_value": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Default:  "",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"trigger_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_branch": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+									"tags": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"stage": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -303,40 +434,8 @@ func ResourceReleaseDefinition() *schema.Resource {
 								ValidateFunc: validation.IntAtLeast(1),
 							},
 						},
-						rdVariable: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									rdVariableName: {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringIsNotWhiteSpace,
-									},
-									rdVariableValue: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "",
-									},
-									rdVariableSecretVal: {
-										Type:      schema.TypeString,
-										Optional:  true,
-										Sensitive: true,
-										Default:   "",
-									},
-									rdVariableIsSecret: {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-									rdVariableCanOverwr: {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-								},
-							},
-						},
+						rdVariable:       releaseVariableSchema(false),
+						rdSecretVariable: releaseVariableSchema(true),
 						"retention_policy": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -775,9 +874,6 @@ func approvalSchema() *schema.Schema {
 
 func resourceReleaseDefinitionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	clients := m.(*client.AggregatedClient)
-	if err := validateReleaseVariables(d); err != nil {
-		return diag.FromErr(err)
-	}
 	releaseDefinition, projectID := expandReleaseDefinition(d)
 
 	createdReleaseDefinition, err := clients.ReleaseClient.CreateReleaseDefinition(ctx, release.CreateReleaseDefinitionArgs{
@@ -816,9 +912,6 @@ func resourceReleaseDefinitionRead(ctx context.Context, d *schema.ResourceData, 
 
 func resourceReleaseDefinitionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	clients := m.(*client.AggregatedClient)
-	if err := validateReleaseVariables(d); err != nil {
-		return diag.FromErr(err)
-	}
 	releaseDefinition, projectID := expandReleaseDefinition(d)
 
 	existing, err := clients.ReleaseClient.GetReleaseDefinition(ctx, release.GetReleaseDefinitionArgs{
@@ -848,6 +941,10 @@ func mergeUnmanagedTriggers(expanded, existing *[]interface{}) *[]interface{} {
 	managed := map[string]bool{
 		string(release.ReleaseTriggerTypeValues.ArtifactSource): true,
 		string(release.ReleaseTriggerTypeValues.Schedule):       true,
+		string(release.ReleaseTriggerTypeValues.SourceRepo):     true,
+		string(release.ReleaseTriggerTypeValues.ContainerImage): true,
+		string(release.ReleaseTriggerTypeValues.Package):        true,
+		string(release.ReleaseTriggerTypeValues.PullRequest):    true,
 	}
 	result := make([]interface{}, 0)
 	if expanded != nil {
@@ -892,11 +989,11 @@ func expandReleaseDefinition(d *schema.ResourceData) (*release.ReleaseDefinition
 		Path:              converter.String(d.Get("path").(string)),
 		Description:       converter.String(d.Get("description").(string)),
 		ReleaseNameFormat: converter.String(d.Get("release_name_format").(string)),
-		Variables:         expandReleaseVariables(d.Get(rdVariable).(*schema.Set).List()),
+		Variables:         expandReleaseVariables(d.Get(rdVariable).(*schema.Set).List(), d.Get(rdSecretVariable).(*schema.Set).List()),
 		VariableGroups:    expandReleaseVariableGroups(d.Get("variable_groups").(*schema.Set).List()),
 		Artifacts:         expandReleaseArtifacts(d.Get("artifact").(*schema.Set).List()),
 		Environments:      expandReleaseStages(d.Get("stage").([]interface{})),
-		Triggers:          expandReleaseTriggers(d.Get("artifact_source_trigger").([]interface{}), d.Get("schedule_trigger").([]interface{})),
+		Triggers:          expandReleaseTriggers(d),
 	}
 
 	if !d.IsNewResource() {
@@ -911,77 +1008,86 @@ func expandReleaseDefinition(d *schema.ResourceData) (*release.ReleaseDefinition
 	return releaseDefinition, projectID
 }
 
-func expandReleaseVariables(input []interface{}) *map[string]release.ConfigurationVariableValue {
+func expandReleaseVariables(input, secretInput []interface{}) *map[string]release.ConfigurationVariableValue {
 	variables := map[string]release.ConfigurationVariableValue{}
 	for _, item := range input {
 		variable := item.(map[string]interface{})
-		isSecret := variable[rdVariableIsSecret].(bool)
-		value := variable[rdVariableValue].(string)
-		if isSecret {
-			value = variable[rdVariableSecretVal].(string)
-		}
 		variables[variable[rdVariableName].(string)] = release.ConfigurationVariableValue{
-			Value:         converter.String(value),
-			IsSecret:      converter.Bool(isSecret),
+			Value:         converter.String(variable[rdVariableValue].(string)),
+			IsSecret:      converter.Bool(false),
+			AllowOverride: converter.Bool(variable[rdVariableCanOverwr].(bool)),
+		}
+	}
+	for _, item := range secretInput {
+		variable := item.(map[string]interface{})
+		variables[variable[rdVariableName].(string)] = release.ConfigurationVariableValue{
+			Value:         converter.String(variable[rdVariableValue].(string)),
+			IsSecret:      converter.Bool(true),
 			AllowOverride: converter.Bool(variable[rdVariableCanOverwr].(bool)),
 		}
 	}
 	return &variables
 }
 
-func validateReleaseVariables(d *schema.ResourceData) error {
+func validateReleaseVariables(d *schema.ResourceDiff) error {
 	raw := d.GetRawConfig()
 	if raw.IsNull() {
 		return nil
 	}
 	config := raw.AsValueMap()
 
-	if variables := config[rdVariable]; !variables.IsNull() {
-		for it := variables.ElementIterator(); it.Next(); {
-			_, variable := it.Element()
-			attrs := variable.AsValueMap()
-			if err := validateVariableExclusivity(
-				attrs[rdVariableName].AsString(),
-				!attrs[rdVariableValue].IsNull(),
-				!attrs[rdVariableSecretVal].IsNull(),
-				!attrs[rdVariableIsSecret].IsNull(),
-			); err != nil {
-				return err
-			}
-		}
+	if err := checkDuplicateVariableNames(config[rdVariable], config[rdSecretVariable], ""); err != nil {
+		return err
 	}
 
 	stages := config["stage"]
-	if stages.IsNull() {
+	if stages.IsNull() || !stages.IsKnown() {
 		return nil
 	}
 	for sit := stages.ElementIterator(); sit.Next(); {
 		_, stage := sit.Element()
-		variables := stage.AsValueMap()[rdVariable]
-		if variables.IsNull() {
-			continue
+		attrs := stage.AsValueMap()
+		name := ""
+		if stageName := attrs["name"]; !stageName.IsNull() && stageName.IsKnown() {
+			name = stageName.AsString()
 		}
-		for it := variables.ElementIterator(); it.Next(); {
-			_, variable := it.Element()
-			attrs := variable.AsValueMap()
-			if err := validateVariableExclusivity(
-				attrs[rdVariableName].AsString(),
-				!attrs[rdVariableValue].IsNull(),
-				!attrs[rdVariableSecretVal].IsNull(),
-				!attrs[rdVariableIsSecret].IsNull(),
-			); err != nil {
-				return err
-			}
+		if err := checkDuplicateVariableNames(attrs[rdVariable], attrs[rdSecretVariable], name); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func validateVariableExclusivity(name string, valueSet, secretValueSet, isSecret bool) error {
-	if valueSet && (secretValueSet || isSecret) || secretValueSet != isSecret {
-		return fmt.Errorf("`%s` variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes", name)
+func checkDuplicateVariableNames(variables, secretVariables cty.Value, stage string) error {
+	names := map[string]bool{}
+	for _, name := range variableNames(variables) {
+		names[name] = true
+	}
+	for _, name := range variableNames(secretVariables) {
+		if names[name] {
+			if stage != "" {
+				return fmt.Errorf("stage `%s`: `%s` is declared as both a `variable` and a `secret_variable`", stage, name)
+			}
+			return fmt.Errorf("`%s` is declared as both a `variable` and a `secret_variable`", name)
+		}
 	}
 	return nil
+}
+
+func variableNames(variables cty.Value) []string {
+	if variables.IsNull() || !variables.IsKnown() {
+		return nil
+	}
+	names := make([]string, 0)
+	for it := variables.ElementIterator(); it.Next(); {
+		_, variable := it.Element()
+		name := variable.AsValueMap()[rdVariableName]
+		if name.IsNull() || !name.IsKnown() {
+			continue
+		}
+		names = append(names, name.AsString())
+	}
+	return names
 }
 
 func expandReleaseVariableGroups(input []interface{}) *[]int {
@@ -1019,8 +1125,16 @@ func expandArtifactDefinitionReference(input []interface{}) *map[string]release.
 	return &refs
 }
 
-func expandReleaseTriggers(artifactSourceInput, scheduleInput []interface{}) *[]interface{} {
-	triggers := make([]interface{}, 0, len(artifactSourceInput)+len(scheduleInput))
+func expandReleaseTriggers(d *schema.ResourceData) *[]interface{} {
+	artifactSourceInput := d.Get("artifact_source_trigger").([]interface{})
+	scheduleInput := d.Get("schedule_trigger").([]interface{})
+	sourceRepoInput := d.Get("source_repo_trigger").([]interface{})
+	containerImageInput := d.Get("container_image_trigger").([]interface{})
+	packageInput := d.Get("package_trigger").([]interface{})
+	pullRequestInput := d.Get("pull_request_trigger").([]interface{})
+
+	triggers := make([]interface{}, 0, len(artifactSourceInput)+len(scheduleInput)+
+		len(sourceRepoInput)+len(containerImageInput)+len(packageInput)+len(pullRequestInput))
 
 	for _, item := range artifactSourceInput {
 		trigger := item.(map[string]interface{})
@@ -1046,7 +1160,162 @@ func expandReleaseTriggers(artifactSourceInput, scheduleInput []interface{}) *[]
 		})
 	}
 
+	for _, item := range sourceRepoInput {
+		trigger := item.(map[string]interface{})
+		triggers = append(triggers, release.SourceRepoTrigger{
+			TriggerType:   &release.ReleaseTriggerTypeValues.SourceRepo,
+			Alias:         converter.String(trigger["artifact_alias"].(string)),
+			BranchFilters: expandBranchFilters(trigger["branch_filter"].(*schema.Set).List()),
+		})
+	}
+
+	for _, item := range containerImageInput {
+		trigger := item.(map[string]interface{})
+		triggers = append(triggers, release.ContainerImageTrigger{
+			TriggerType: &release.ReleaseTriggerTypeValues.ContainerImage,
+			Alias:       converter.String(trigger["artifact_alias"].(string)),
+			TagFilters:  expandTagFilters(trigger["tag_filter"].(*schema.Set).List()),
+		})
+	}
+
+	for _, item := range packageInput {
+		trigger := item.(map[string]interface{})
+		triggers = append(triggers, release.PackageTrigger{
+			TriggerType: &release.ReleaseTriggerTypeValues.Package,
+			Alias:       converter.String(trigger["artifact_alias"].(string)),
+		})
+	}
+
+	for _, item := range pullRequestInput {
+		trigger := item.(map[string]interface{})
+		triggers = append(triggers, release.PullRequestTrigger{
+			TriggerType:              &release.ReleaseTriggerTypeValues.PullRequest,
+			ArtifactAlias:            converter.String(trigger["artifact_alias"].(string)),
+			StatusPolicyName:         converter.String(trigger["status_policy_name"].(string)),
+			PullRequestConfiguration: expandPullRequestConfiguration(trigger),
+			TriggerConditions:        expandPullRequestFilters(trigger["trigger_condition"].([]interface{})),
+		})
+	}
+
 	return &triggers
+}
+
+func expandTagFilters(input []interface{}) *[]release.TagFilter {
+	filters := make([]release.TagFilter, 0, len(input))
+	for _, item := range input {
+		pattern, ok := item.(string)
+		if !ok {
+			continue
+		}
+		filters = append(filters, release.TagFilter{Pattern: converter.String(pattern)})
+	}
+	return &filters
+}
+
+func resourceReleaseDefinitionCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if err := validateReleaseVariables(d); err != nil {
+		return err
+	}
+	return validateBranchFilters(d)
+}
+
+func validateBranchFilters(d *schema.ResourceDiff) error {
+	raw := d.GetRawConfig()
+	if raw.IsNull() {
+		return nil
+	}
+	triggers := raw.AsValueMap()["source_repo_trigger"]
+	if triggers.IsNull() || !triggers.IsKnown() {
+		return nil
+	}
+
+	index := 0
+	for it := triggers.ElementIterator(); it.Next(); {
+		_, trigger := it.Element()
+		filters := trigger.AsValueMap()["branch_filter"]
+		index++
+		if filters.IsNull() || !filters.IsKnown() {
+			continue
+		}
+		for fit := filters.ElementIterator(); fit.Next(); {
+			_, filter := fit.Element()
+			attrs := filter.AsValueMap()
+			if isEmptyBranchFilterSet(attrs["include"]) && isEmptyBranchFilterSet(attrs["exclude"]) {
+				return fmt.Errorf("source_repo_trigger[%d]: `branch_filter` must specify at least one of `include` or `exclude`", index-1)
+			}
+		}
+	}
+	return nil
+}
+
+func isEmptyBranchFilterSet(value cty.Value) bool {
+	if value.IsNull() {
+		return true
+	}
+	if !value.IsKnown() {
+		return false
+	}
+	return value.LengthInt() == 0
+}
+
+func expandBranchFilters(input []interface{}) *[]string {
+	filters := make([]string, 0)
+	for _, item := range input {
+		filter, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, v := range filter["include"].(*schema.Set).List() {
+			filters = append(filters, "+"+v.(string))
+		}
+		for _, v := range filter["exclude"].(*schema.Set).List() {
+			filters = append(filters, "-"+v.(string))
+		}
+	}
+	return &filters
+}
+
+func expandPullRequestFilters(input []interface{}) *[]release.PullRequestFilter {
+	filters := make([]release.PullRequestFilter, 0, len(input))
+	for _, item := range input {
+		filter := item.(map[string]interface{})
+		filters = append(filters, release.PullRequestFilter{
+			TargetBranch: converter.String(filter["target_branch"].(string)),
+			Tags:         expandStringSet(filter["tags"].(*schema.Set).List()),
+		})
+	}
+	return &filters
+}
+
+func expandPullRequestConfiguration(trigger map[string]interface{}) *release.PullRequestConfiguration {
+	config := &release.PullRequestConfiguration{
+		UseArtifactReference: converter.Bool(trigger["use_artifact_reference"].(bool)),
+	}
+
+	refs, ok := trigger["code_repository_reference"].([]interface{})
+	if !ok || len(refs) == 0 {
+		return config
+	}
+	ref, ok := refs[0].(map[string]interface{})
+	if !ok {
+		return config
+	}
+
+	systemType := release.PullRequestSystemType(ref["system_type"].(string))
+	repositoryReference := map[string]release.ReleaseManagementInputValue{}
+	for _, item := range ref["repository_reference"].(*schema.Set).List() {
+		entry := item.(map[string]interface{})
+		repositoryReference[entry["key"].(string)] = release.ReleaseManagementInputValue{
+			Value:        converter.String(entry["value"].(string)),
+			DisplayValue: converter.String(entry["display_value"].(string)),
+		}
+	}
+
+	config.CodeRepositoryReference = &release.CodeRepositoryReference{
+		SystemType:          &systemType,
+		RepositoryReference: &repositoryReference,
+	}
+	return config
 }
 
 func expandArtifactFilters(input []interface{}) *[]release.ArtifactFilter {
@@ -1087,8 +1356,12 @@ func flattenReleaseDefinition(d *schema.ResourceData, releaseDefinition *release
 	d.Set("release_name_format", converter.ToString(releaseDefinition.ReleaseNameFormat, ""))
 	d.Set("revision", converter.ToInt(releaseDefinition.Revision, 0))
 
-	if err := d.Set(rdVariable, flattenReleaseVariables(releaseDefinition.Variables, d.Get(rdVariable).(*schema.Set).List())); err != nil {
+	variables, secretVariables := flattenReleaseVariables(releaseDefinition.Variables, d.Get(rdSecretVariable).(*schema.Set).List())
+	if err := d.Set(rdVariable, variables); err != nil {
 		return fmt.Errorf("setting `variable`: %+v", err)
+	}
+	if err := d.Set(rdSecretVariable, secretVariables); err != nil {
+		return fmt.Errorf("setting `secret_variable`: %+v", err)
 	}
 	if err := d.Set("variable_groups", flattenReleaseVariableGroups(releaseDefinition.VariableGroups)); err != nil {
 		return fmt.Errorf("setting `variable_groups`: %+v", err)
@@ -1096,12 +1369,24 @@ func flattenReleaseDefinition(d *schema.ResourceData, releaseDefinition *release
 	if err := d.Set("artifact", flattenReleaseArtifacts(releaseDefinition.Artifacts, artifactDefinitionKeysFromConfig(d))); err != nil {
 		return fmt.Errorf("setting `artifact`: %+v", err)
 	}
-	artifactSourceTriggers, scheduleTriggers := flattenReleaseTriggers(releaseDefinition.Triggers, d.Get("schedule_trigger").([]interface{}))
-	if err := d.Set("artifact_source_trigger", artifactSourceTriggers); err != nil {
+	triggers := flattenReleaseTriggers(releaseDefinition.Triggers, d.Get("schedule_trigger").([]interface{}), d.Get("pull_request_trigger").([]interface{}))
+	if err := d.Set("artifact_source_trigger", triggers.artifactSource); err != nil {
 		return fmt.Errorf("setting `artifact_source_trigger`: %+v", err)
 	}
-	if err := d.Set("schedule_trigger", scheduleTriggers); err != nil {
+	if err := d.Set("schedule_trigger", triggers.schedule); err != nil {
 		return fmt.Errorf("setting `schedule_trigger`: %+v", err)
+	}
+	if err := d.Set("source_repo_trigger", triggers.sourceRepo); err != nil {
+		return fmt.Errorf("setting `source_repo_trigger`: %+v", err)
+	}
+	if err := d.Set("container_image_trigger", triggers.containerImage); err != nil {
+		return fmt.Errorf("setting `container_image_trigger`: %+v", err)
+	}
+	if err := d.Set("package_trigger", triggers.pkg); err != nil {
+		return fmt.Errorf("setting `package_trigger`: %+v", err)
+	}
+	if err := d.Set("pull_request_trigger", triggers.pullRequest); err != nil {
+		return fmt.Errorf("setting `pull_request_trigger`: %+v", err)
 	}
 	if err := d.Set("stage", flattenReleaseStages(d, releaseDefinition.Environments)); err != nil {
 		return fmt.Errorf("setting `stage`: %+v", err)
@@ -1110,29 +1395,30 @@ func flattenReleaseDefinition(d *schema.ResourceData, releaseDefinition *release
 	return nil
 }
 
-func flattenReleaseVariables(input *map[string]release.ConfigurationVariableValue, stateVars []interface{}) []interface{} {
+func flattenReleaseVariables(input *map[string]release.ConfigurationVariableValue, priorSecretVars []interface{}) (variables, secretVariables []interface{}) {
 	if input == nil {
-		return nil
+		return nil, nil
 	}
-	variables := make([]interface{}, 0, len(*input))
 	for name, value := range *input {
-		isSecret := converter.ToBool(value.IsSecret, false)
-		variable := map[string]interface{}{
+		if converter.ToBool(value.IsSecret, false) {
+			secret := map[string]interface{}{
+				rdVariableName:      name,
+				rdVariableValue:     "",
+				rdVariableCanOverwr: converter.ToBool(value.AllowOverride, false),
+			}
+			if prior := findVariableInState(priorSecretVars, name); prior != nil {
+				secret[rdVariableValue] = prior[rdVariableValue]
+			}
+			secretVariables = append(secretVariables, secret)
+			continue
+		}
+		variables = append(variables, map[string]interface{}{
 			rdVariableName:      name,
 			rdVariableValue:     converter.ToString(value.Value, ""),
-			rdVariableSecretVal: "",
-			rdVariableIsSecret:  isSecret,
 			rdVariableCanOverwr: converter.ToBool(value.AllowOverride, false),
-		}
-		if isSecret {
-			variable[rdVariableValue] = ""
-			if prior := findVariableInState(stateVars, name); prior != nil {
-				variable[rdVariableSecretVal] = prior[rdVariableSecretVal]
-			}
-		}
-		variables = append(variables, variable)
+		})
 	}
-	return variables
+	return variables, secretVariables
 }
 
 func findVariableInState(stateVars []interface{}, name string) map[string]interface{} {
@@ -1205,11 +1491,26 @@ func flattenArtifactDefinitionReference(input *map[string]release.ArtifactSource
 	return refs
 }
 
-func flattenReleaseTriggers(input *[]interface{}, priorSchedules []interface{}) ([]interface{}, []interface{}) {
-	artifactSourceTriggers := make([]interface{}, 0)
-	scheduleTriggers := make([]interface{}, 0)
+type releaseTriggerBlocks struct {
+	artifactSource []interface{}
+	schedule       []interface{}
+	sourceRepo     []interface{}
+	containerImage []interface{}
+	pkg            []interface{}
+	pullRequest    []interface{}
+}
+
+func flattenReleaseTriggers(input *[]interface{}, priorSchedules []interface{}, priorPullRequests []interface{}) releaseTriggerBlocks {
+	blocks := releaseTriggerBlocks{
+		artifactSource: make([]interface{}, 0),
+		schedule:       make([]interface{}, 0),
+		sourceRepo:     make([]interface{}, 0),
+		containerImage: make([]interface{}, 0),
+		pkg:            make([]interface{}, 0),
+		pullRequest:    make([]interface{}, 0),
+	}
 	if input == nil {
-		return artifactSourceTriggers, scheduleTriggers
+		return blocks
 	}
 
 	for _, item := range *input {
@@ -1219,7 +1520,7 @@ func flattenReleaseTriggers(input *[]interface{}, priorSchedules []interface{}) 
 		}
 		switch stringFromMap(trigger, "triggerType") {
 		case string(release.ReleaseTriggerTypeValues.ArtifactSource):
-			artifactSourceTriggers = append(artifactSourceTriggers, map[string]interface{}{
+			blocks.artifactSource = append(blocks.artifactSource, map[string]interface{}{
 				"artifact_alias":    stringFromMap(trigger, "artifactAlias"),
 				"trigger_condition": flattenArtifactFilters(trigger["triggerConditions"]),
 			})
@@ -1227,19 +1528,173 @@ func flattenReleaseTriggers(input *[]interface{}, priorSchedules []interface{}) 
 			schedule, _ := trigger["schedule"].(map[string]interface{})
 			days := reconcileScheduleDays(
 				flattenScheduleDays(schedule["daysToRelease"]),
-				priorScheduleDays(priorSchedules, len(scheduleTriggers)),
+				priorScheduleDays(priorSchedules, len(blocks.schedule)),
 			)
-			scheduleTriggers = append(scheduleTriggers, map[string]interface{}{
+			blocks.schedule = append(blocks.schedule, map[string]interface{}{
 				"days":              days,
 				"start_hours":       intFromMap(schedule, "startHours"),
 				"start_minutes":     intFromMap(schedule, "startMinutes"),
 				"time_zone_id":      stringFromMap(schedule, "timeZoneId"),
 				"only_with_changes": boolFromMap(schedule, "scheduleOnlyWithChanges"),
 			})
+		case string(release.ReleaseTriggerTypeValues.SourceRepo):
+			blocks.sourceRepo = append(blocks.sourceRepo, map[string]interface{}{
+				"artifact_alias": stringFromMap(trigger, "alias"),
+				"branch_filter":  flattenBranchFilters(trigger["branchFilters"]),
+			})
+		case string(release.ReleaseTriggerTypeValues.ContainerImage):
+			blocks.containerImage = append(blocks.containerImage, map[string]interface{}{
+				"artifact_alias": stringFromMap(trigger, "alias"),
+				"tag_filter":     flattenTagFilters(trigger["tagFilters"]),
+			})
+		case string(release.ReleaseTriggerTypeValues.Package):
+			blocks.pkg = append(blocks.pkg, map[string]interface{}{
+				"artifact_alias": stringFromMap(trigger, "alias"),
+			})
+		case string(release.ReleaseTriggerTypeValues.PullRequest):
+			config, _ := trigger["pullRequestConfiguration"].(map[string]interface{})
+			blocks.pullRequest = append(blocks.pullRequest, map[string]interface{}{
+				"artifact_alias":            stringFromMap(trigger, "artifactAlias"),
+				"status_policy_name":        stringFromMap(trigger, "statusPolicyName"),
+				"use_artifact_reference":    boolFromMap(config, "useArtifactReference"),
+				"code_repository_reference": flattenCodeRepositoryReference(config, priorRepositoryReferenceKeys(priorPullRequests, len(blocks.pullRequest))),
+				"trigger_condition":         flattenPullRequestFilters(trigger["triggerConditions"]),
+			})
 		}
 	}
 
-	return artifactSourceTriggers, scheduleTriggers
+	return blocks
+}
+
+func flattenBranchFilters(input interface{}) []interface{} {
+	values, ok := input.([]interface{})
+	if !ok || len(values) == 0 {
+		return nil
+	}
+	include := make([]interface{}, 0)
+	exclude := make([]interface{}, 0)
+	for _, item := range values {
+		filter, ok := item.(string)
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(filter, "-"):
+			exclude = append(exclude, strings.TrimPrefix(filter, "-"))
+		default:
+			include = append(include, strings.TrimPrefix(filter, "+"))
+		}
+	}
+	return []interface{}{map[string]interface{}{
+		"include": include,
+		"exclude": exclude,
+	}}
+}
+
+func flattenTagFilters(input interface{}) []interface{} {
+	rawFilters, ok := input.([]interface{})
+	if !ok {
+		return nil
+	}
+	patterns := make([]interface{}, 0, len(rawFilters))
+	for _, item := range rawFilters {
+		filter, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		patterns = append(patterns, stringFromMap(filter, "pattern"))
+	}
+	return patterns
+}
+
+func flattenPullRequestFilters(input interface{}) []interface{} {
+	rawFilters, ok := input.([]interface{})
+	if !ok {
+		return nil
+	}
+	filters := make([]interface{}, 0, len(rawFilters))
+	for _, item := range rawFilters {
+		filter, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result := map[string]interface{}{
+			"target_branch": stringFromMap(filter, "targetBranch"),
+		}
+		if tags, ok := filter["tags"].([]interface{}); ok {
+			result["tags"] = tags
+		}
+		filters = append(filters, result)
+	}
+	return filters
+}
+
+func priorRepositoryReferenceKeys(priorPullRequests []interface{}, index int) map[string]bool {
+	if index >= len(priorPullRequests) {
+		return nil
+	}
+	trigger, ok := priorPullRequests[index].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	refs, ok := trigger["code_repository_reference"].([]interface{})
+	if !ok || len(refs) == 0 {
+		return nil
+	}
+	ref, ok := refs[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	set, ok := ref["repository_reference"].(*schema.Set)
+	if !ok {
+		return nil
+	}
+	keys := map[string]bool{}
+	for _, item := range set.List() {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		keys[entry["key"].(string)] = true
+	}
+	return keys
+}
+
+func flattenCodeRepositoryReference(config map[string]interface{}, allowedKeys map[string]bool) []interface{} {
+	if config == nil {
+		return nil
+	}
+	ref, ok := config["codeRepositoryReference"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	rawRefs, _ := ref["repositoryReference"].(map[string]interface{})
+	references := make([]interface{}, 0, len(rawRefs))
+	for key, item := range rawRefs {
+		if allowedKeys != nil && !allowedKeys[key] {
+			continue
+		}
+		value, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		references = append(references, map[string]interface{}{
+			"key":           key,
+			"value":         stringFromMap(value, "value"),
+			"display_value": stringFromMap(value, "displayValue"),
+		})
+	}
+
+	systemType := stringFromMap(ref, "systemType")
+	if len(references) == 0 && (systemType == "" || strings.EqualFold(systemType, string(release.PullRequestSystemTypeValues.None))) {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"system_type":          systemType,
+		"repository_reference": references,
+	}}
 }
 
 func priorScheduleDays(priorSchedules []interface{}, index int) []interface{} {
@@ -1377,7 +1832,7 @@ func expandReleaseStages(input []interface{}) *[]release.ReleaseDefinitionEnviro
 			Name:                converter.String(stage["name"].(string)),
 			Rank:                converter.Int(rank),
 			Conditions:          expandReleaseConditions(stage["condition"].([]interface{}), i == 0),
-			Variables:           expandReleaseVariables(stage[rdVariable].(*schema.Set).List()),
+			Variables:           expandReleaseVariables(stage[rdVariable].(*schema.Set).List(), stage[rdSecretVariable].(*schema.Set).List()),
 			VariableGroups:      expandReleaseVariableGroups(stage["variable_groups"].(*schema.Set).List()),
 			RetentionPolicy:     expandReleaseRetentionPolicy(stage["retention_policy"].([]interface{})),
 			PreDeployApprovals:  expandReleaseApprovals(stage["pre_deploy_approval"].([]interface{})),
@@ -1671,11 +2126,13 @@ func flattenReleaseStages(d *schema.ResourceData, input *[]release.ReleaseDefini
 	stages := make([]interface{}, 0, len(*input))
 	for _, environment := range *input {
 		name := converter.ToString(environment.Name, "")
+		variables, secretVariables := flattenReleaseVariables(environment.Variables, priorStageSecretVariables(priorStages, name))
 		stages = append(stages, map[string]interface{}{
 			"name":                  name,
 			"rank":                  converter.ToInt(environment.Rank, 0),
 			"condition":             flattenReleaseConditions(environment.Conditions),
-			rdVariable:              flattenReleaseVariables(environment.Variables, priorStageVariables(priorStages, name)),
+			rdVariable:              variables,
+			rdSecretVariable:        secretVariables,
 			"variable_groups":       flattenReleaseVariableGroups(environment.VariableGroups),
 			"retention_policy":      flattenReleaseRetentionPolicy(environment.RetentionPolicy),
 			"pre_deploy_approval":   flattenReleaseApprovals(environment.PreDeployApprovals),
@@ -1691,13 +2148,13 @@ func flattenReleaseStages(d *schema.ResourceData, input *[]release.ReleaseDefini
 	return stages
 }
 
-func priorStageVariables(priorStages []interface{}, name string) []interface{} {
+func priorStageSecretVariables(priorStages []interface{}, name string) []interface{} {
 	for _, item := range priorStages {
 		stage, ok := item.(map[string]interface{})
 		if !ok || stage["name"] != name {
 			continue
 		}
-		if set, ok := stage[rdVariable].(*schema.Set); ok {
+		if set, ok := stage[rdSecretVariable].(*schema.Set); ok {
 			return set.List()
 		}
 	}

--- a/azuredevops/internal/service/release/resource_release_definition.go
+++ b/azuredevops/internal/service/release/resource_release_definition.go
@@ -1,0 +1,1970 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/release"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/validate"
+)
+
+const (
+	rdVariable          = "variable"
+	rdVariableName      = "name"
+	rdVariableValue     = "value"
+	rdVariableSecretVal = "secret_value"
+	rdVariableIsSecret  = "is_secret"
+	rdVariableCanOverwr = "allow_override"
+)
+
+func ResourceReleaseDefinition() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceReleaseDefinitionCreate,
+		ReadContext:   resourceReleaseDefinitionRead,
+		UpdateContext: resourceReleaseDefinitionUpdate,
+		DeleteContext: resourceReleaseDefinitionDelete,
+		Importer:      tfhelper.ImportProjectQualifiedResource(),
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      `\`,
+				ValidateFunc: validate.Path,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"release_name_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Release-$(rev:r)",
+			},
+			"variable_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeInt,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+			},
+			rdVariable: {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						rdVariableName: {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						rdVariableValue: {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						rdVariableSecretVal: {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+							Default:   "",
+						},
+						rdVariableIsSecret: {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						rdVariableCanOverwr: {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"artifact": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Build",
+								"Jenkins",
+								"GitHub",
+								"Nuget",
+								"Team Build (external)",
+								"ExternalTFSBuild",
+								"Git",
+								"TFVC",
+								"ExternalTfsXamlBuild",
+							}, false),
+						},
+						"is_primary": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"is_retained": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"definition_reference": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"artifact_source_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_alias": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"trigger_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"source_branch": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+									"use_build_definition_branch": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"create_release_on_build_tagging": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"tags": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"schedule_trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"days": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"monday", "tuesday", "wednesday", "thursday",
+									"friday", "saturday", "sunday", "all",
+								}, true),
+								StateFunc: func(v interface{}) string {
+									return strings.ToLower(v.(string))
+								},
+							},
+						},
+						"start_hours": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3,
+							ValidateFunc: validation.IntBetween(0, 23),
+						},
+						"start_minutes": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 59),
+						},
+						"time_zone_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "UTC",
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"only_with_changes": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"stage": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
+						},
+						"rank": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"condition_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "event",
+										ValidateFunc: validation.StringInSlice([]string{
+											"event", "environmentState", "artifact",
+										}, false),
+									},
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+								},
+							},
+						},
+						"variable_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeInt,
+								ValidateFunc: validation.IntAtLeast(1),
+							},
+						},
+						rdVariable: {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									rdVariableName: {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									rdVariableValue: {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+									rdVariableSecretVal: {
+										Type:      schema.TypeString,
+										Optional:  true,
+										Sensitive: true,
+										Default:   "",
+									},
+									rdVariableIsSecret: {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									rdVariableCanOverwr: {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+								},
+							},
+						},
+						"retention_policy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"days_to_keep": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      30,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"releases_to_keep": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      3,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"retain_build": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+								},
+							},
+						},
+						"pre_deploy_approval":   approvalSchema(),
+						"post_deploy_approval":  approvalSchema(),
+						"pre_deployment_gates":  gatesSchema(),
+						"post_deployment_gates": gatesSchema(),
+						"environment_options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"auto_link_work_items": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"badge_enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"publish_deployment_status": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+									"pull_request_deployment_enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+								},
+							},
+						},
+						"execution_policy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"concurrency_count": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"queue_depth_count": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+								},
+							},
+						},
+						"environment_trigger": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"trigger_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  string(release.EnvironmentTriggerTypeValues.RollbackRedeploy),
+										ValidateFunc: validation.StringInSlice([]string{
+											string(release.EnvironmentTriggerTypeValues.RollbackRedeploy),
+											string(release.EnvironmentTriggerTypeValues.DeploymentGroupRedeploy),
+										}, false),
+									},
+									"action": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"event_types": {
+										Type:     schema.TypeList,
+										Required: true,
+										MinItems: 1,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"deploy_phase": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"phase_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  string(release.DeployPhaseTypesValues.AgentBasedDeployment),
+										ValidateFunc: validation.StringInSlice([]string{
+											string(release.DeployPhaseTypesValues.AgentBasedDeployment),
+											string(release.DeployPhaseTypesValues.RunOnServer),
+											string(release.DeployPhaseTypesValues.MachineGroupBasedDeployment),
+										}, false),
+									},
+									"rank": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"agent_queue_id": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"agent_specification": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotWhiteSpace,
+									},
+									"skip_artifacts_download": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"timeout_in_minutes": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"job_cancel_timeout_in_minutes": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      1,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"enable_access_token": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"condition": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "succeeded()",
+									},
+									"deployment_group_id": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"deployment_health_option": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "",
+									},
+									"health_percent": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntBetween(0, 100),
+									},
+									"tags": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"task": taskSchema(),
+								},
+							},
+						},
+					},
+				},
+			},
+			"revision": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func taskSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MinItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"task_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsUUID,
+					StateFunc: func(v interface{}) string {
+						return strings.ToLower(v.(string))
+					},
+				},
+				"version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "1.*",
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"condition": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "succeeded()",
+				},
+				"inputs": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"override_inputs": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"environment": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"always_run": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"continue_on_error": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"timeout_in_minutes": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"retry_count_on_task_failure": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"ref_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "",
+				},
+				"definition_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func gatesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"is_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"sampling_interval": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      15,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"stabilization_time": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"minimum_success_duration": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"timeout": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      1440,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"gate": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"task": taskSchema(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func approvalSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"approval": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"approver_id": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.IsUUID,
+							},
+							"is_automated": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"is_notification_on": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+						},
+					},
+				},
+				"approval_options": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"required_approver_count": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"release_creator_can_be_approver": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"auto_triggered_and_previous_environment_approved_can_be_skipped": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"enforce_identity_revalidation": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"timeout_in_minutes": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      0,
+								ValidateFunc: validation.IntBetween(0, 525600),
+							},
+							"execution_order": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  string(release.ApprovalExecutionOrderValues.BeforeGates),
+								ValidateFunc: validation.StringInSlice([]string{
+									string(release.ApprovalExecutionOrderValues.BeforeGates),
+									string(release.ApprovalExecutionOrderValues.AfterSuccessfulGates),
+									string(release.ApprovalExecutionOrderValues.AfterGatesAlways),
+								}, false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceReleaseDefinitionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	if err := validateReleaseVariables(d); err != nil {
+		return diag.FromErr(err)
+	}
+	releaseDefinition, projectID := expandReleaseDefinition(d)
+
+	createdReleaseDefinition, err := clients.ReleaseClient.CreateReleaseDefinition(ctx, release.CreateReleaseDefinitionArgs{
+		ReleaseDefinition: releaseDefinition,
+		Project:           &projectID,
+	})
+	if err != nil {
+		return diag.Errorf("creating release definition: %+v", err)
+	}
+
+	d.SetId(strconv.Itoa(*createdReleaseDefinition.Id))
+	return resourceReleaseDefinitionRead(ctx, d, m)
+}
+
+func resourceReleaseDefinitionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	projectID, releaseDefinitionID, err := tfhelper.ParseProjectIDAndResourceID(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	releaseDefinition, err := clients.ReleaseClient.GetReleaseDefinition(ctx, release.GetReleaseDefinitionArgs{
+		Project:      &projectID,
+		DefinitionId: &releaseDefinitionID,
+	})
+	if err != nil {
+		if utils.ResponseWasNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	return diag.FromErr(flattenReleaseDefinition(d, releaseDefinition, projectID))
+}
+
+func resourceReleaseDefinitionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	if err := validateReleaseVariables(d); err != nil {
+		return diag.FromErr(err)
+	}
+	releaseDefinition, projectID := expandReleaseDefinition(d)
+
+	existing, err := clients.ReleaseClient.GetReleaseDefinition(ctx, release.GetReleaseDefinitionArgs{
+		Project:      &projectID,
+		DefinitionId: releaseDefinition.Id,
+	})
+	if err != nil {
+		return diag.Errorf("reading release definition before update: %+v", err)
+	}
+	releaseDefinition.Triggers = mergeUnmanagedTriggers(releaseDefinition.Triggers, existing.Triggers)
+
+	_, err = clients.ReleaseClient.UpdateReleaseDefinition(ctx, release.UpdateReleaseDefinitionArgs{
+		ReleaseDefinition: releaseDefinition,
+		Project:           &projectID,
+	})
+	if err != nil {
+		return diag.Errorf("updating release definition: %+v", err)
+	}
+
+	return resourceReleaseDefinitionRead(ctx, d, m)
+}
+
+func mergeUnmanagedTriggers(expanded, existing *[]interface{}) *[]interface{} {
+	if existing == nil {
+		return expanded
+	}
+	managed := map[string]bool{
+		string(release.ReleaseTriggerTypeValues.ArtifactSource): true,
+		string(release.ReleaseTriggerTypeValues.Schedule):       true,
+	}
+	result := make([]interface{}, 0)
+	if expanded != nil {
+		result = append(result, (*expanded)...)
+	}
+	for _, item := range *existing {
+		trigger, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !managed[stringFromMap(trigger, "triggerType")] {
+			result = append(result, item)
+		}
+	}
+	return &result
+}
+
+func resourceReleaseDefinitionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	clients := m.(*client.AggregatedClient)
+	projectID, releaseDefinitionID, err := tfhelper.ParseProjectIDAndResourceID(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = clients.ReleaseClient.DeleteReleaseDefinition(ctx, release.DeleteReleaseDefinitionArgs{
+		Project:      &projectID,
+		DefinitionId: &releaseDefinitionID,
+	})
+	if err != nil {
+		return diag.Errorf("deleting release definition: %+v", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func expandReleaseDefinition(d *schema.ResourceData) (*release.ReleaseDefinition, string) {
+	projectID := d.Get("project_id").(string)
+
+	releaseDefinition := &release.ReleaseDefinition{
+		Name:              converter.String(d.Get("name").(string)),
+		Path:              converter.String(d.Get("path").(string)),
+		Description:       converter.String(d.Get("description").(string)),
+		ReleaseNameFormat: converter.String(d.Get("release_name_format").(string)),
+		Variables:         expandReleaseVariables(d.Get(rdVariable).(*schema.Set).List()),
+		VariableGroups:    expandReleaseVariableGroups(d.Get("variable_groups").(*schema.Set).List()),
+		Artifacts:         expandReleaseArtifacts(d.Get("artifact").(*schema.Set).List()),
+		Environments:      expandReleaseStages(d.Get("stage").([]interface{})),
+		Triggers:          expandReleaseTriggers(d.Get("artifact_source_trigger").([]interface{}), d.Get("schedule_trigger").([]interface{})),
+	}
+
+	if !d.IsNewResource() {
+		if id, err := strconv.Atoi(d.Id()); err == nil {
+			releaseDefinition.Id = &id
+		}
+		if revision, ok := d.GetOk("revision"); ok {
+			releaseDefinition.Revision = converter.Int(revision.(int))
+		}
+	}
+
+	return releaseDefinition, projectID
+}
+
+func expandReleaseVariables(input []interface{}) *map[string]release.ConfigurationVariableValue {
+	variables := map[string]release.ConfigurationVariableValue{}
+	for _, item := range input {
+		variable := item.(map[string]interface{})
+		isSecret := variable[rdVariableIsSecret].(bool)
+		value := variable[rdVariableValue].(string)
+		if isSecret {
+			value = variable[rdVariableSecretVal].(string)
+		}
+		variables[variable[rdVariableName].(string)] = release.ConfigurationVariableValue{
+			Value:         converter.String(value),
+			IsSecret:      converter.Bool(isSecret),
+			AllowOverride: converter.Bool(variable[rdVariableCanOverwr].(bool)),
+		}
+	}
+	return &variables
+}
+
+func validateReleaseVariables(d *schema.ResourceData) error {
+	raw := d.GetRawConfig()
+	if raw.IsNull() {
+		return nil
+	}
+	config := raw.AsValueMap()
+
+	if variables := config[rdVariable]; !variables.IsNull() {
+		for it := variables.ElementIterator(); it.Next(); {
+			_, variable := it.Element()
+			attrs := variable.AsValueMap()
+			if err := validateVariableExclusivity(
+				attrs[rdVariableName].AsString(),
+				!attrs[rdVariableValue].IsNull(),
+				!attrs[rdVariableSecretVal].IsNull(),
+				!attrs[rdVariableIsSecret].IsNull(),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	stages := config["stage"]
+	if stages.IsNull() {
+		return nil
+	}
+	for sit := stages.ElementIterator(); sit.Next(); {
+		_, stage := sit.Element()
+		variables := stage.AsValueMap()[rdVariable]
+		if variables.IsNull() {
+			continue
+		}
+		for it := variables.ElementIterator(); it.Next(); {
+			_, variable := it.Element()
+			attrs := variable.AsValueMap()
+			if err := validateVariableExclusivity(
+				attrs[rdVariableName].AsString(),
+				!attrs[rdVariableValue].IsNull(),
+				!attrs[rdVariableSecretVal].IsNull(),
+				!attrs[rdVariableIsSecret].IsNull(),
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateVariableExclusivity(name string, valueSet, secretValueSet, isSecret bool) error {
+	if valueSet && (secretValueSet || isSecret) || secretValueSet != isSecret {
+		return fmt.Errorf("`%s` variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes", name)
+	}
+	return nil
+}
+
+func expandReleaseVariableGroups(input []interface{}) *[]int {
+	groups := make([]int, 0, len(input))
+	for _, item := range input {
+		groups = append(groups, item.(int))
+	}
+	return &groups
+}
+
+func expandReleaseArtifacts(input []interface{}) *[]release.Artifact {
+	artifacts := make([]release.Artifact, 0, len(input))
+	for _, item := range input {
+		artifact := item.(map[string]interface{})
+		artifacts = append(artifacts, release.Artifact{
+			Alias:               converter.String(artifact["alias"].(string)),
+			Type:                converter.String(artifact["type"].(string)),
+			IsPrimary:           converter.Bool(artifact["is_primary"].(bool)),
+			IsRetained:          converter.Bool(artifact["is_retained"].(bool)),
+			DefinitionReference: expandArtifactDefinitionReference(artifact["definition_reference"].(*schema.Set).List()),
+		})
+	}
+	return &artifacts
+}
+
+func expandArtifactDefinitionReference(input []interface{}) *map[string]release.ArtifactSourceReference {
+	refs := map[string]release.ArtifactSourceReference{}
+	for _, item := range input {
+		ref := item.(map[string]interface{})
+		refs[ref["key"].(string)] = release.ArtifactSourceReference{
+			Id:   converter.String(ref["id"].(string)),
+			Name: converter.String(ref["name"].(string)),
+		}
+	}
+	return &refs
+}
+
+func expandReleaseTriggers(artifactSourceInput, scheduleInput []interface{}) *[]interface{} {
+	triggers := make([]interface{}, 0, len(artifactSourceInput)+len(scheduleInput))
+
+	for _, item := range artifactSourceInput {
+		trigger := item.(map[string]interface{})
+		triggers = append(triggers, release.ArtifactSourceTrigger{
+			TriggerType:       &release.ReleaseTriggerTypeValues.ArtifactSource,
+			ArtifactAlias:     converter.String(trigger["artifact_alias"].(string)),
+			TriggerConditions: expandArtifactFilters(trigger["trigger_condition"].([]interface{})),
+		})
+	}
+
+	for _, item := range scheduleInput {
+		trigger := item.(map[string]interface{})
+		days := release.ScheduleDays(joinScheduleDays(trigger["days"].(*schema.Set).List()))
+		triggers = append(triggers, release.ScheduledReleaseTrigger{
+			TriggerType: &release.ReleaseTriggerTypeValues.Schedule,
+			Schedule: &release.ReleaseSchedule{
+				DaysToRelease:           &days,
+				StartHours:              converter.Int(trigger["start_hours"].(int)),
+				StartMinutes:            converter.Int(trigger["start_minutes"].(int)),
+				TimeZoneId:              converter.String(trigger["time_zone_id"].(string)),
+				ScheduleOnlyWithChanges: converter.Bool(trigger["only_with_changes"].(bool)),
+			},
+		})
+	}
+
+	return &triggers
+}
+
+func expandArtifactFilters(input []interface{}) *[]release.ArtifactFilter {
+	filters := make([]release.ArtifactFilter, 0, len(input))
+	for _, item := range input {
+		filter := item.(map[string]interface{})
+		filters = append(filters, release.ArtifactFilter{
+			SourceBranch:                converter.String(filter["source_branch"].(string)),
+			UseBuildDefinitionBranch:    converter.Bool(filter["use_build_definition_branch"].(bool)),
+			CreateReleaseOnBuildTagging: converter.Bool(filter["create_release_on_build_tagging"].(bool)),
+			Tags:                        expandStringSet(filter["tags"].(*schema.Set).List()),
+		})
+	}
+	return &filters
+}
+
+func expandStringSet(input []interface{}) *[]string {
+	values := make([]string, 0, len(input))
+	for _, item := range input {
+		values = append(values, item.(string))
+	}
+	return &values
+}
+
+func joinScheduleDays(input []interface{}) string {
+	days := make([]string, 0, len(input))
+	for _, item := range input {
+		days = append(days, strings.ToLower(item.(string)))
+	}
+	return strings.Join(days, ", ")
+}
+
+func flattenReleaseDefinition(d *schema.ResourceData, releaseDefinition *release.ReleaseDefinition, projectID string) error {
+	d.Set("project_id", projectID)
+	d.Set("name", converter.ToString(releaseDefinition.Name, ""))
+	d.Set("path", converter.ToString(releaseDefinition.Path, `\`))
+	d.Set("description", converter.ToString(releaseDefinition.Description, ""))
+	d.Set("release_name_format", converter.ToString(releaseDefinition.ReleaseNameFormat, ""))
+	d.Set("revision", converter.ToInt(releaseDefinition.Revision, 0))
+
+	if err := d.Set(rdVariable, flattenReleaseVariables(releaseDefinition.Variables, d.Get(rdVariable).(*schema.Set).List())); err != nil {
+		return fmt.Errorf("setting `variable`: %+v", err)
+	}
+	if err := d.Set("variable_groups", flattenReleaseVariableGroups(releaseDefinition.VariableGroups)); err != nil {
+		return fmt.Errorf("setting `variable_groups`: %+v", err)
+	}
+	if err := d.Set("artifact", flattenReleaseArtifacts(releaseDefinition.Artifacts, artifactDefinitionKeysFromConfig(d))); err != nil {
+		return fmt.Errorf("setting `artifact`: %+v", err)
+	}
+	artifactSourceTriggers, scheduleTriggers := flattenReleaseTriggers(releaseDefinition.Triggers, d.Get("schedule_trigger").([]interface{}))
+	if err := d.Set("artifact_source_trigger", artifactSourceTriggers); err != nil {
+		return fmt.Errorf("setting `artifact_source_trigger`: %+v", err)
+	}
+	if err := d.Set("schedule_trigger", scheduleTriggers); err != nil {
+		return fmt.Errorf("setting `schedule_trigger`: %+v", err)
+	}
+	if err := d.Set("stage", flattenReleaseStages(d, releaseDefinition.Environments)); err != nil {
+		return fmt.Errorf("setting `stage`: %+v", err)
+	}
+
+	return nil
+}
+
+func flattenReleaseVariables(input *map[string]release.ConfigurationVariableValue, stateVars []interface{}) []interface{} {
+	if input == nil {
+		return nil
+	}
+	variables := make([]interface{}, 0, len(*input))
+	for name, value := range *input {
+		isSecret := converter.ToBool(value.IsSecret, false)
+		variable := map[string]interface{}{
+			rdVariableName:      name,
+			rdVariableValue:     converter.ToString(value.Value, ""),
+			rdVariableSecretVal: "",
+			rdVariableIsSecret:  isSecret,
+			rdVariableCanOverwr: converter.ToBool(value.AllowOverride, false),
+		}
+		if isSecret {
+			variable[rdVariableValue] = ""
+			if prior := findVariableInState(stateVars, name); prior != nil {
+				variable[rdVariableSecretVal] = prior[rdVariableSecretVal]
+			}
+		}
+		variables = append(variables, variable)
+	}
+	return variables
+}
+
+func findVariableInState(stateVars []interface{}, name string) map[string]interface{} {
+	for _, item := range stateVars {
+		if variable, ok := item.(map[string]interface{}); ok && variable[rdVariableName] == name {
+			return variable
+		}
+	}
+	return nil
+}
+
+func flattenReleaseVariableGroups(input *[]int) []interface{} {
+	if input == nil {
+		return nil
+	}
+	groups := make([]interface{}, 0, len(*input))
+	for _, group := range *input {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func flattenReleaseArtifacts(input *[]release.Artifact, configuredKeys map[string]map[string]bool) []interface{} {
+	if input == nil {
+		return nil
+	}
+	artifacts := make([]interface{}, 0, len(*input))
+	for _, artifact := range *input {
+		alias := converter.ToString(artifact.Alias, "")
+		allowedKeys := configuredKeys[alias]
+		artifacts = append(artifacts, map[string]interface{}{
+			"alias":                alias,
+			"type":                 converter.ToString(artifact.Type, ""),
+			"is_primary":           converter.ToBool(artifact.IsPrimary, false),
+			"is_retained":          converter.ToBool(artifact.IsRetained, false),
+			"definition_reference": flattenArtifactDefinitionReference(artifact.DefinitionReference, allowedKeys),
+		})
+	}
+	return artifacts
+}
+
+func artifactDefinitionKeysFromConfig(d *schema.ResourceData) map[string]map[string]bool {
+	result := map[string]map[string]bool{}
+	for _, item := range d.Get("artifact").(*schema.Set).List() {
+		artifact := item.(map[string]interface{})
+		keys := map[string]bool{}
+		for _, ref := range artifact["definition_reference"].(*schema.Set).List() {
+			keys[ref.(map[string]interface{})["key"].(string)] = true
+		}
+		result[artifact["alias"].(string)] = keys
+	}
+	return result
+}
+
+func flattenArtifactDefinitionReference(input *map[string]release.ArtifactSourceReference, allowedKeys map[string]bool) []interface{} {
+	if input == nil {
+		return nil
+	}
+	refs := make([]interface{}, 0, len(*input))
+	for key, ref := range *input {
+		if allowedKeys != nil && !allowedKeys[key] {
+			continue
+		}
+		refs = append(refs, map[string]interface{}{
+			"key":  key,
+			"id":   converter.ToString(ref.Id, ""),
+			"name": converter.ToString(ref.Name, ""),
+		})
+	}
+	return refs
+}
+
+func flattenReleaseTriggers(input *[]interface{}, priorSchedules []interface{}) ([]interface{}, []interface{}) {
+	artifactSourceTriggers := make([]interface{}, 0)
+	scheduleTriggers := make([]interface{}, 0)
+	if input == nil {
+		return artifactSourceTriggers, scheduleTriggers
+	}
+
+	for _, item := range *input {
+		trigger, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch stringFromMap(trigger, "triggerType") {
+		case string(release.ReleaseTriggerTypeValues.ArtifactSource):
+			artifactSourceTriggers = append(artifactSourceTriggers, map[string]interface{}{
+				"artifact_alias":    stringFromMap(trigger, "artifactAlias"),
+				"trigger_condition": flattenArtifactFilters(trigger["triggerConditions"]),
+			})
+		case string(release.ReleaseTriggerTypeValues.Schedule):
+			schedule, _ := trigger["schedule"].(map[string]interface{})
+			days := reconcileScheduleDays(
+				flattenScheduleDays(schedule["daysToRelease"]),
+				priorScheduleDays(priorSchedules, len(scheduleTriggers)),
+			)
+			scheduleTriggers = append(scheduleTriggers, map[string]interface{}{
+				"days":              days,
+				"start_hours":       intFromMap(schedule, "startHours"),
+				"start_minutes":     intFromMap(schedule, "startMinutes"),
+				"time_zone_id":      stringFromMap(schedule, "timeZoneId"),
+				"only_with_changes": boolFromMap(schedule, "scheduleOnlyWithChanges"),
+			})
+		}
+	}
+
+	return artifactSourceTriggers, scheduleTriggers
+}
+
+func priorScheduleDays(priorSchedules []interface{}, index int) []interface{} {
+	if index >= len(priorSchedules) {
+		return nil
+	}
+	schedule, ok := priorSchedules[index].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	if set, ok := schedule["days"].(*schema.Set); ok {
+		return set.List()
+	}
+	return nil
+}
+
+func reconcileScheduleDays(flattened, prior []interface{}) []interface{} {
+	if len(flattened) == 1 && flattened[0] == "all" && scheduleDaysAreAllSeven(prior) {
+		return prior
+	}
+	return flattened
+}
+
+func scheduleDaysAreAllSeven(days []interface{}) bool {
+	if len(days) != len(scheduleDayBits) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, d := range days {
+		if s, ok := d.(string); ok {
+			seen[strings.ToLower(s)] = true
+		}
+	}
+	for _, d := range scheduleDayBits {
+		if !seen[d.name] {
+			return false
+		}
+	}
+	return true
+}
+
+func flattenArtifactFilters(input interface{}) []interface{} {
+	rawFilters, ok := input.([]interface{})
+	if !ok {
+		return nil
+	}
+	filters := make([]interface{}, 0, len(rawFilters))
+	for _, item := range rawFilters {
+		filter, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result := map[string]interface{}{
+			"source_branch":                   stringFromMap(filter, "sourceBranch"),
+			"use_build_definition_branch":     boolFromMap(filter, "useBuildDefinitionBranch"),
+			"create_release_on_build_tagging": boolFromMap(filter, "createReleaseOnBuildTagging"),
+		}
+		if tags, ok := filter["tags"].([]interface{}); ok {
+			result["tags"] = tags
+		}
+		filters = append(filters, result)
+	}
+	return filters
+}
+
+var scheduleDayBits = []struct {
+	bit  int
+	name string
+}{
+	{1, "monday"}, {2, "tuesday"}, {4, "wednesday"}, {8, "thursday"},
+	{16, "friday"}, {32, "saturday"}, {64, "sunday"},
+}
+
+func flattenScheduleDays(input interface{}) []interface{} {
+	switch v := input.(type) {
+	case float64:
+		return scheduleDaysFromMask(int(v))
+	case string:
+		if mask, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return scheduleDaysFromMask(mask)
+		}
+		return splitScheduleDays(v)
+	default:
+		return nil
+	}
+}
+
+func scheduleDaysFromMask(mask int) []interface{} {
+	allBits := 0
+	for _, d := range scheduleDayBits {
+		allBits |= d.bit
+	}
+	if mask == allBits {
+		return []interface{}{"all"}
+	}
+	days := make([]interface{}, 0, len(scheduleDayBits))
+	for _, d := range scheduleDayBits {
+		if mask&d.bit != 0 {
+			days = append(days, d.name)
+		}
+	}
+	return days
+}
+
+func splitScheduleDays(input string) []interface{} {
+	if input == "" {
+		return nil
+	}
+	parts := strings.Split(input, ",")
+	days := make([]interface{}, 0, len(parts))
+	for _, part := range parts {
+		if day := strings.ToLower(strings.TrimSpace(part)); day != "" {
+			days = append(days, day)
+		}
+	}
+	return days
+}
+
+func expandReleaseStages(input []interface{}) *[]release.ReleaseDefinitionEnvironment {
+	stages := make([]release.ReleaseDefinitionEnvironment, 0, len(input))
+	for i, item := range input {
+		stage := item.(map[string]interface{})
+
+		rank := stage["rank"].(int)
+		if rank == 0 {
+			rank = i + 1
+		}
+
+		environment := release.ReleaseDefinitionEnvironment{
+			Name:                converter.String(stage["name"].(string)),
+			Rank:                converter.Int(rank),
+			Conditions:          expandReleaseConditions(stage["condition"].([]interface{}), i == 0),
+			Variables:           expandReleaseVariables(stage[rdVariable].(*schema.Set).List()),
+			VariableGroups:      expandReleaseVariableGroups(stage["variable_groups"].(*schema.Set).List()),
+			RetentionPolicy:     expandReleaseRetentionPolicy(stage["retention_policy"].([]interface{})),
+			PreDeployApprovals:  expandReleaseApprovals(stage["pre_deploy_approval"].([]interface{})),
+			PostDeployApprovals: expandReleaseApprovals(stage["post_deploy_approval"].([]interface{})),
+			PreDeploymentGates:  expandReleaseGates(stage["pre_deployment_gates"].([]interface{})),
+			PostDeploymentGates: expandReleaseGates(stage["post_deployment_gates"].([]interface{})),
+			EnvironmentOptions:  expandEnvironmentOptions(stage["environment_options"].([]interface{})),
+			ExecutionPolicy:     expandExecutionPolicy(stage["execution_policy"].([]interface{})),
+			EnvironmentTriggers: expandEnvironmentTriggers(stage["environment_trigger"].([]interface{})),
+			DeployPhases:        expandReleaseDeployPhases(stage["deploy_phase"].([]interface{})),
+			DeployStep:          &release.ReleaseDefinitionDeployStep{Tasks: &[]release.WorkflowTask{}},
+		}
+
+		stages = append(stages, environment)
+	}
+	return &stages
+}
+
+func expandReleaseConditions(input []interface{}, isFirstStage bool) *[]release.Condition {
+	conditions := make([]release.Condition, 0, len(input))
+	for _, item := range input {
+		condition := item.(map[string]interface{})
+		conditionType := release.ConditionType(condition["condition_type"].(string))
+		conditions = append(conditions, release.Condition{
+			ConditionType: &conditionType,
+			Name:          converter.String(condition["name"].(string)),
+			Value:         converter.String(condition["value"].(string)),
+		})
+	}
+
+	if len(conditions) == 0 && isFirstStage {
+		conditions = append(conditions, release.Condition{
+			ConditionType: &release.ConditionTypeValues.Event,
+			Name:          converter.String("ReleaseStarted"),
+			Value:         converter.String(""),
+		})
+	}
+
+	return &conditions
+}
+
+func expandReleaseRetentionPolicy(input []interface{}) *release.EnvironmentRetentionPolicy {
+	policy := release.EnvironmentRetentionPolicy{
+		DaysToKeep:     converter.Int(30),
+		ReleasesToKeep: converter.Int(3),
+		RetainBuild:    converter.Bool(true),
+	}
+	if len(input) == 1 && input[0] != nil {
+		item := input[0].(map[string]interface{})
+		policy.DaysToKeep = converter.Int(item["days_to_keep"].(int))
+		policy.ReleasesToKeep = converter.Int(item["releases_to_keep"].(int))
+		policy.RetainBuild = converter.Bool(item["retain_build"].(bool))
+	}
+	return &policy
+}
+
+func expandEnvironmentOptions(input []interface{}) *release.EnvironmentOptions {
+	if len(input) != 1 || input[0] == nil {
+		return nil
+	}
+	item := input[0].(map[string]interface{})
+	return &release.EnvironmentOptions{
+		AutoLinkWorkItems:            converter.Bool(item["auto_link_work_items"].(bool)),
+		BadgeEnabled:                 converter.Bool(item["badge_enabled"].(bool)),
+		PublishDeploymentStatus:      converter.Bool(item["publish_deployment_status"].(bool)),
+		PullRequestDeploymentEnabled: converter.Bool(item["pull_request_deployment_enabled"].(bool)),
+	}
+}
+
+func expandExecutionPolicy(input []interface{}) *release.EnvironmentExecutionPolicy {
+	if len(input) != 1 || input[0] == nil {
+		return nil
+	}
+	item := input[0].(map[string]interface{})
+	return &release.EnvironmentExecutionPolicy{
+		ConcurrencyCount: converter.Int(item["concurrency_count"].(int)),
+		QueueDepthCount:  converter.Int(item["queue_depth_count"].(int)),
+	}
+}
+
+func expandEnvironmentTriggers(input []interface{}) *[]release.EnvironmentTrigger {
+	triggers := make([]release.EnvironmentTrigger, 0, len(input))
+	for _, item := range input {
+		trigger := item.(map[string]interface{})
+		triggerType := release.EnvironmentTriggerType(trigger["trigger_type"].(string))
+		content := release.EnvironmentTriggerContent{
+			Action:     converter.String(trigger["action"].(string)),
+			EventTypes: expandStringSet(trigger["event_types"].([]interface{})),
+		}
+		contentBytes, err := json.Marshal(content)
+		if err != nil {
+			continue
+		}
+		triggers = append(triggers, release.EnvironmentTrigger{
+			TriggerType:    &triggerType,
+			TriggerContent: converter.String(string(contentBytes)),
+		})
+	}
+	return &triggers
+}
+
+func expandReleaseApprovals(input []interface{}) *release.ReleaseDefinitionApprovals {
+	steps := make([]release.ReleaseDefinitionApprovalStep, 0)
+	var options *release.ApprovalOptions
+	if len(input) == 1 && input[0] != nil {
+		block := input[0].(map[string]interface{})
+		for i, item := range block["approval"].([]interface{}) {
+			approval := item.(map[string]interface{})
+			step := release.ReleaseDefinitionApprovalStep{
+				Rank:             converter.Int(i + 1),
+				IsAutomated:      converter.Bool(approval["is_automated"].(bool)),
+				IsNotificationOn: converter.Bool(approval["is_notification_on"].(bool)),
+			}
+			if id := approval["approver_id"].(string); id != "" {
+				step.Approver = &webapi.IdentityRef{Id: converter.String(id)}
+			}
+			steps = append(steps, step)
+		}
+		options = expandApprovalOptions(block["approval_options"].([]interface{}))
+	}
+
+	if len(steps) == 0 {
+		steps = append(steps, release.ReleaseDefinitionApprovalStep{
+			Rank:        converter.Int(1),
+			IsAutomated: converter.Bool(true),
+		})
+	}
+
+	return &release.ReleaseDefinitionApprovals{Approvals: &steps, ApprovalOptions: options}
+}
+
+func expandApprovalOptions(input []interface{}) *release.ApprovalOptions {
+	if len(input) != 1 || input[0] == nil {
+		return nil
+	}
+	item := input[0].(map[string]interface{})
+	executionOrder := release.ApprovalExecutionOrder(item["execution_order"].(string))
+	return &release.ApprovalOptions{
+		RequiredApproverCount:                                   converter.Int(item["required_approver_count"].(int)),
+		ReleaseCreatorCanBeApprover:                             converter.Bool(item["release_creator_can_be_approver"].(bool)),
+		AutoTriggeredAndPreviousEnvironmentApprovedCanBeSkipped: converter.Bool(item["auto_triggered_and_previous_environment_approved_can_be_skipped"].(bool)),
+		EnforceIdentityRevalidation:                             converter.Bool(item["enforce_identity_revalidation"].(bool)),
+		TimeoutInMinutes:                                        converter.Int(item["timeout_in_minutes"].(int)),
+		ExecutionOrder:                                          &executionOrder,
+	}
+}
+
+func expandReleaseDeployPhases(input []interface{}) *[]interface{} {
+	phases := make([]interface{}, 0, len(input))
+	for i, item := range input {
+		phase := item.(map[string]interface{})
+
+		rank := phase["rank"].(int)
+		if rank == 0 {
+			rank = i + 1
+		}
+		name := converter.String(phase["name"].(string))
+		tasks := expandReleaseTasks(phase["task"].([]interface{}))
+		phaseType := release.DeployPhaseTypes(phase["phase_type"].(string))
+
+		switch phaseType {
+		case release.DeployPhaseTypesValues.RunOnServer:
+			phases = append(phases, release.RunOnServerDeployPhase{
+				Name:          name,
+				Rank:          converter.Int(rank),
+				PhaseType:     &release.DeployPhaseTypesValues.RunOnServer,
+				WorkflowTasks: tasks,
+				DeploymentInput: &release.ServerDeploymentInput{
+					Condition:                 converter.String(phase["condition"].(string)),
+					TimeoutInMinutes:          converter.Int(phase["timeout_in_minutes"].(int)),
+					JobCancelTimeoutInMinutes: converter.Int(phase["job_cancel_timeout_in_minutes"].(int)),
+				},
+			})
+		case release.DeployPhaseTypesValues.MachineGroupBasedDeployment:
+			deploymentInput := &release.MachineGroupDeploymentInput{
+				Condition:                 converter.String(phase["condition"].(string)),
+				TimeoutInMinutes:          converter.Int(phase["timeout_in_minutes"].(int)),
+				JobCancelTimeoutInMinutes: converter.Int(phase["job_cancel_timeout_in_minutes"].(int)),
+				SkipArtifactsDownload:     converter.Bool(phase["skip_artifacts_download"].(bool)),
+				EnableAccessToken:         converter.Bool(phase["enable_access_token"].(bool)),
+				Tags:                      expandStringSet(phase["tags"].(*schema.Set).List()),
+			}
+			if dgID := phase["deployment_group_id"].(int); dgID != 0 {
+				deploymentInput.QueueId = converter.Int(dgID)
+			}
+			if healthOption := phase["deployment_health_option"].(string); healthOption != "" {
+				deploymentInput.DeploymentHealthOption = converter.String(healthOption)
+				deploymentInput.HealthPercent = converter.Int(phase["health_percent"].(int))
+			}
+			phases = append(phases, release.MachineGroupBasedDeployPhase{
+				Name:            name,
+				Rank:            converter.Int(rank),
+				PhaseType:       &release.DeployPhaseTypesValues.MachineGroupBasedDeployment,
+				WorkflowTasks:   tasks,
+				DeploymentInput: deploymentInput,
+			})
+		default:
+			deploymentInput := &release.AgentDeploymentInput{
+				SkipArtifactsDownload:     converter.Bool(phase["skip_artifacts_download"].(bool)),
+				TimeoutInMinutes:          converter.Int(phase["timeout_in_minutes"].(int)),
+				JobCancelTimeoutInMinutes: converter.Int(phase["job_cancel_timeout_in_minutes"].(int)),
+				EnableAccessToken:         converter.Bool(phase["enable_access_token"].(bool)),
+				Condition:                 converter.String(phase["condition"].(string)),
+			}
+			if queueID := phase["agent_queue_id"].(int); queueID != 0 {
+				deploymentInput.QueueId = converter.Int(queueID)
+			}
+			if spec := phase["agent_specification"].(string); spec != "" {
+				deploymentInput.AgentSpecification = &release.AgentSpecification{Identifier: converter.String(spec)}
+			}
+			phases = append(phases, release.AgentBasedDeployPhase{
+				Name:            name,
+				Rank:            converter.Int(rank),
+				PhaseType:       &release.DeployPhaseTypesValues.AgentBasedDeployment,
+				WorkflowTasks:   tasks,
+				DeploymentInput: deploymentInput,
+			})
+		}
+	}
+	return &phases
+}
+
+func expandReleaseTasks(input []interface{}) *[]release.WorkflowTask {
+	tasks := make([]release.WorkflowTask, 0, len(input))
+	for _, item := range input {
+		task := item.(map[string]interface{})
+		workflowTask := release.WorkflowTask{
+			TaskId:                  converter.UUID(task["task_id"].(string)),
+			Version:                 converter.String(task["version"].(string)),
+			Name:                    converter.String(task["name"].(string)),
+			Enabled:                 converter.Bool(task["enabled"].(bool)),
+			Condition:               converter.String(task["condition"].(string)),
+			AlwaysRun:               converter.Bool(task["always_run"].(bool)),
+			ContinueOnError:         converter.Bool(task["continue_on_error"].(bool)),
+			TimeoutInMinutes:        converter.Int(task["timeout_in_minutes"].(int)),
+			RetryCountOnTaskFailure: converter.Int(task["retry_count_on_task_failure"].(int)),
+			Inputs:                  expandStringMap(task["inputs"].(map[string]interface{})),
+			OverrideInputs:          expandStringMap(task["override_inputs"].(map[string]interface{})),
+			Environment:             expandStringMap(task["environment"].(map[string]interface{})),
+		}
+		if refName := task["ref_name"].(string); refName != "" {
+			workflowTask.RefName = converter.String(refName)
+		}
+		if definitionType := task["definition_type"].(string); definitionType != "" {
+			workflowTask.DefinitionType = converter.String(definitionType)
+		}
+		tasks = append(tasks, workflowTask)
+	}
+	return &tasks
+}
+
+func expandReleaseGates(input []interface{}) *release.ReleaseDefinitionGatesStep {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+	block := input[0].(map[string]interface{})
+
+	gates := make([]release.ReleaseDefinitionGate, 0)
+	for _, item := range block["gate"].([]interface{}) {
+		gate := item.(map[string]interface{})
+		gates = append(gates, release.ReleaseDefinitionGate{
+			Tasks: expandReleaseTasks(gate["task"].([]interface{})),
+		})
+	}
+
+	return &release.ReleaseDefinitionGatesStep{
+		Gates: &gates,
+		GatesOptions: &release.ReleaseDefinitionGatesOptions{
+			IsEnabled:              converter.Bool(block["is_enabled"].(bool)),
+			SamplingInterval:       converter.Int(block["sampling_interval"].(int)),
+			StabilizationTime:      converter.Int(block["stabilization_time"].(int)),
+			MinimumSuccessDuration: converter.Int(block["minimum_success_duration"].(int)),
+			Timeout:                converter.Int(block["timeout"].(int)),
+		},
+	}
+}
+
+func expandStringMap(input map[string]interface{}) *map[string]string {
+	result := make(map[string]string, len(input))
+	for k, v := range input {
+		result[k] = v.(string)
+	}
+	return &result
+}
+
+func flattenReleaseStages(d *schema.ResourceData, input *[]release.ReleaseDefinitionEnvironment) []interface{} {
+	if input == nil {
+		return nil
+	}
+	priorStages := d.Get("stage").([]interface{})
+	stages := make([]interface{}, 0, len(*input))
+	for _, environment := range *input {
+		name := converter.ToString(environment.Name, "")
+		stages = append(stages, map[string]interface{}{
+			"name":                  name,
+			"rank":                  converter.ToInt(environment.Rank, 0),
+			"condition":             flattenReleaseConditions(environment.Conditions),
+			rdVariable:              flattenReleaseVariables(environment.Variables, priorStageVariables(priorStages, name)),
+			"variable_groups":       flattenReleaseVariableGroups(environment.VariableGroups),
+			"retention_policy":      flattenReleaseRetentionPolicy(environment.RetentionPolicy),
+			"pre_deploy_approval":   flattenReleaseApprovals(environment.PreDeployApprovals),
+			"post_deploy_approval":  flattenReleaseApprovals(environment.PostDeployApprovals),
+			"pre_deployment_gates":  flattenReleaseGates(environment.PreDeploymentGates),
+			"post_deployment_gates": flattenReleaseGates(environment.PostDeploymentGates),
+			"environment_options":   flattenEnvironmentOptions(environment.EnvironmentOptions),
+			"execution_policy":      flattenExecutionPolicy(environment.ExecutionPolicy),
+			"environment_trigger":   flattenEnvironmentTriggers(environment.EnvironmentTriggers),
+			"deploy_phase":          flattenReleaseDeployPhases(environment.DeployPhases),
+		})
+	}
+	return stages
+}
+
+func priorStageVariables(priorStages []interface{}, name string) []interface{} {
+	for _, item := range priorStages {
+		stage, ok := item.(map[string]interface{})
+		if !ok || stage["name"] != name {
+			continue
+		}
+		if set, ok := stage[rdVariable].(*schema.Set); ok {
+			return set.List()
+		}
+	}
+	return nil
+}
+
+func flattenReleaseConditions(input *[]release.Condition) []interface{} {
+	if input == nil {
+		return nil
+	}
+	conditions := make([]interface{}, 0, len(*input))
+	for _, condition := range *input {
+		conditions = append(conditions, map[string]interface{}{
+			"condition_type": converter.ToString((*string)(condition.ConditionType), ""),
+			"name":           converter.ToString(condition.Name, ""),
+			"value":          converter.ToString(condition.Value, ""),
+		})
+	}
+	return conditions
+}
+
+func flattenReleaseRetentionPolicy(input *release.EnvironmentRetentionPolicy) []interface{} {
+	if input == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"days_to_keep":     converter.ToInt(input.DaysToKeep, 0),
+		"releases_to_keep": converter.ToInt(input.ReleasesToKeep, 0),
+		"retain_build":     converter.ToBool(input.RetainBuild, false),
+	}}
+}
+
+func flattenEnvironmentOptions(input *release.EnvironmentOptions) []interface{} {
+	if input == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"auto_link_work_items":            converter.ToBool(input.AutoLinkWorkItems, false),
+		"badge_enabled":                   converter.ToBool(input.BadgeEnabled, false),
+		"publish_deployment_status":       converter.ToBool(input.PublishDeploymentStatus, false),
+		"pull_request_deployment_enabled": converter.ToBool(input.PullRequestDeploymentEnabled, false),
+	}}
+}
+
+func flattenExecutionPolicy(input *release.EnvironmentExecutionPolicy) []interface{} {
+	if input == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"concurrency_count": converter.ToInt(input.ConcurrencyCount, 0),
+		"queue_depth_count": converter.ToInt(input.QueueDepthCount, 0),
+	}}
+}
+
+func flattenEnvironmentTriggers(input *[]release.EnvironmentTrigger) []interface{} {
+	if input == nil || len(*input) == 0 {
+		return nil
+	}
+	triggers := make([]interface{}, 0, len(*input))
+	for _, trigger := range *input {
+		item := map[string]interface{}{
+			"trigger_type": converter.ToString((*string)(trigger.TriggerType), ""),
+			"action":       "",
+			"event_types":  []interface{}{},
+		}
+		if trigger.TriggerContent != nil {
+			var content release.EnvironmentTriggerContent
+			if err := json.Unmarshal([]byte(*trigger.TriggerContent), &content); err == nil {
+				item["action"] = converter.ToString(content.Action, "")
+				if content.EventTypes != nil {
+					events := make([]interface{}, 0, len(*content.EventTypes))
+					for _, e := range *content.EventTypes {
+						events = append(events, e)
+					}
+					item["event_types"] = events
+				}
+			}
+		}
+		triggers = append(triggers, item)
+	}
+	return triggers
+}
+
+func flattenReleaseGates(input *release.ReleaseDefinitionGatesStep) []interface{} {
+	if input == nil || input.Gates == nil || len(*input.Gates) == 0 {
+		return nil
+	}
+	gates := make([]interface{}, 0, len(*input.Gates))
+	for _, gate := range *input.Gates {
+		gates = append(gates, map[string]interface{}{
+			"task": flattenWorkflowTasks(gate.Tasks),
+		})
+	}
+	block := map[string]interface{}{
+		"gate": gates,
+	}
+	if opts := input.GatesOptions; opts != nil {
+		block["is_enabled"] = converter.ToBool(opts.IsEnabled, false)
+		block["sampling_interval"] = converter.ToInt(opts.SamplingInterval, 0)
+		block["stabilization_time"] = converter.ToInt(opts.StabilizationTime, 0)
+		block["minimum_success_duration"] = converter.ToInt(opts.MinimumSuccessDuration, 0)
+		block["timeout"] = converter.ToInt(opts.Timeout, 0)
+	}
+	return []interface{}{block}
+}
+
+func flattenWorkflowTasks(input *[]release.WorkflowTask) []interface{} {
+	if input == nil {
+		return nil
+	}
+	tasks := make([]interface{}, 0, len(*input))
+	for _, task := range *input {
+		result := map[string]interface{}{
+			"version":                     converter.ToString(task.Version, ""),
+			"name":                        converter.ToString(task.Name, ""),
+			"enabled":                     converter.ToBool(task.Enabled, false),
+			"condition":                   converter.ToString(task.Condition, ""),
+			"always_run":                  converter.ToBool(task.AlwaysRun, false),
+			"continue_on_error":           converter.ToBool(task.ContinueOnError, false),
+			"timeout_in_minutes":          converter.ToInt(task.TimeoutInMinutes, 0),
+			"retry_count_on_task_failure": converter.ToInt(task.RetryCountOnTaskFailure, 0),
+			"ref_name":                    converter.ToString(task.RefName, ""),
+			"definition_type":             converter.ToString(task.DefinitionType, ""),
+		}
+		if task.TaskId != nil {
+			result["task_id"] = task.TaskId.String()
+		}
+		if task.Inputs != nil {
+			result["inputs"] = *task.Inputs
+		}
+		if task.OverrideInputs != nil {
+			result["override_inputs"] = *task.OverrideInputs
+		}
+		if task.Environment != nil {
+			result["environment"] = *task.Environment
+		}
+		tasks = append(tasks, result)
+	}
+	return tasks
+}
+
+func flattenReleaseApprovals(input *release.ReleaseDefinitionApprovals) []interface{} {
+	if input == nil || input.Approvals == nil {
+		return nil
+	}
+	approvals := make([]interface{}, 0, len(*input.Approvals))
+	for _, step := range *input.Approvals {
+		approval := map[string]interface{}{
+			"is_automated":       converter.ToBool(step.IsAutomated, false),
+			"is_notification_on": converter.ToBool(step.IsNotificationOn, false),
+		}
+		if step.Approver != nil {
+			approval["approver_id"] = converter.ToString(step.Approver.Id, "")
+		}
+		approvals = append(approvals, approval)
+	}
+	return []interface{}{map[string]interface{}{
+		"approval":         approvals,
+		"approval_options": flattenApprovalOptions(input.ApprovalOptions),
+	}}
+}
+
+func flattenApprovalOptions(input *release.ApprovalOptions) []interface{} {
+	if input == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		"required_approver_count":                                         converter.ToInt(input.RequiredApproverCount, 0),
+		"release_creator_can_be_approver":                                 converter.ToBool(input.ReleaseCreatorCanBeApprover, false),
+		"auto_triggered_and_previous_environment_approved_can_be_skipped": converter.ToBool(input.AutoTriggeredAndPreviousEnvironmentApprovedCanBeSkipped, false),
+		"enforce_identity_revalidation":                                   converter.ToBool(input.EnforceIdentityRevalidation, false),
+		"timeout_in_minutes":                                              converter.ToInt(input.TimeoutInMinutes, 0),
+		"execution_order":                                                 converter.ToString((*string)(input.ExecutionOrder), string(release.ApprovalExecutionOrderValues.BeforeGates)),
+	}}
+}
+
+func flattenReleaseDeployPhases(input *[]interface{}) []interface{} {
+	if input == nil {
+		return nil
+	}
+	phases := make([]interface{}, 0, len(*input))
+	for _, item := range *input {
+		phase, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		phaseType := stringFromMap(phase, "phaseType")
+		result := map[string]interface{}{
+			"name":       stringFromMap(phase, "name"),
+			"rank":       intFromMap(phase, "rank"),
+			"phase_type": phaseType,
+		}
+		if di, ok := phase["deploymentInput"].(map[string]interface{}); ok {
+			result["timeout_in_minutes"] = intFromMap(di, "timeoutInMinutes")
+			result["job_cancel_timeout_in_minutes"] = intFromMap(di, "jobCancelTimeoutInMinutes")
+			result["condition"] = stringFromMap(di, "condition")
+			result["skip_artifacts_download"] = boolFromMap(di, "skipArtifactsDownload")
+			result["enable_access_token"] = boolFromMap(di, "enableAccessToken")
+
+			switch release.DeployPhaseTypes(phaseType) {
+			case release.DeployPhaseTypesValues.MachineGroupBasedDeployment:
+				result["deployment_group_id"] = intFromMap(di, "queueId")
+				result["deployment_health_option"] = stringFromMap(di, "deploymentHealthOption")
+				result["health_percent"] = intFromMap(di, "healthPercent")
+				if tags, ok := di["tags"].([]interface{}); ok {
+					result["tags"] = tags
+				}
+			case release.DeployPhaseTypesValues.RunOnServer:
+			default:
+				result["agent_queue_id"] = intFromMap(di, "queueId")
+				if spec, ok := di["agentSpecification"].(map[string]interface{}); ok {
+					result["agent_specification"] = stringFromMap(spec, "identifier")
+				}
+			}
+		}
+		result["task"] = flattenReleaseTasks(phase["workflowTasks"])
+		phases = append(phases, result)
+	}
+	return phases
+}
+
+func flattenReleaseTasks(input interface{}) []interface{} {
+	rawTasks, ok := input.([]interface{})
+	if !ok {
+		return nil
+	}
+	tasks := make([]interface{}, 0, len(rawTasks))
+	for _, item := range rawTasks {
+		task, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tasks = append(tasks, map[string]interface{}{
+			"task_id":                     stringFromMap(task, "taskId"),
+			"version":                     stringFromMap(task, "version"),
+			"name":                        stringFromMap(task, "name"),
+			"enabled":                     boolFromMap(task, "enabled"),
+			"condition":                   stringFromMap(task, "condition"),
+			"always_run":                  boolFromMap(task, "alwaysRun"),
+			"continue_on_error":           boolFromMap(task, "continueOnError"),
+			"timeout_in_minutes":          intFromMap(task, "timeoutInMinutes"),
+			"retry_count_on_task_failure": intFromMap(task, "retryCountOnTaskFailure"),
+			"ref_name":                    stringFromMap(task, "refName"),
+			"definition_type":             stringFromMap(task, "definitionType"),
+			"inputs":                      task["inputs"],
+			"override_inputs":             task["overrideInputs"],
+			"environment":                 task["environment"],
+		})
+	}
+	return tasks
+}
+
+func stringFromMap(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func intFromMap(m map[string]interface{}, key string) int {
+	if v, ok := m[key].(float64); ok {
+		return int(v)
+	}
+	if v, ok := m[key].(int); ok {
+		return v
+	}
+	return 0
+}
+
+func boolFromMap(m map[string]interface{}, key string) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return false
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/branch"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/policy/repository"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/release"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/security"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/securityroles"
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/serviceendpoint"
@@ -87,6 +88,7 @@ func Provider() *schema.Provider {
 			"azuredevops_project_permissions":                         permissions.ResourceProjectPermissions(),
 			"azuredevops_project_pipeline_settings":                   core.ResourceProjectPipelineSettings(),
 			"azuredevops_project_tags":                                core.ResourceProjectTag(),
+			"azuredevops_release_definition":                          release.ResourceReleaseDefinition(),
 			"azuredevops_repository_policy_author_email_pattern":      repository.ResourceRepositoryPolicyAuthorEmailPatterns(),
 			"azuredevops_repository_policy_case_enforcement":          repository.ResourceRepositoryEnforceConsistentCase(),
 			"azuredevops_repository_policy_check_credentials":         repository.ResourceRepositoryPolicyCheckCredentials(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -55,6 +55,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_project_permissions",
 		"azuredevops_project_pipeline_settings",
 		"azuredevops_project_tags",
+		"azuredevops_release_definition",
 		"azuredevops_repository_policy_author_email_pattern",
 		"azuredevops_repository_policy_case_enforcement",
 		"azuredevops_repository_policy_check_credentials",

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -200,6 +200,9 @@
                   <a href="/docs/providers/azuredevops/r/project_permissions.html">azuredevops_project_permissions</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/release_definition.html">azuredevops_release_definition</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/resource_authorization.html">azuredevops_resource_authorization</a>
                 </li>
                 <li>

--- a/website/docs/r/release_definition.html.markdown
+++ b/website/docs/r/release_definition.html.markdown
@@ -52,6 +52,11 @@ resource "azuredevops_release_definition" "example" {
     value = "production"
   }
 
+  secret_variable {
+    name  = "api_key"
+    value = var.api_key
+  }
+
   artifact {
     alias      = "myapp"
     type       = "Build"
@@ -121,37 +126,75 @@ The following arguments are supported:
 * `release_name_format` - (Optional) The release name format. Defaults to `Release-$(rev:r)`.
 * `variable_groups` - (Optional) A set of variable group IDs to link to the release definition.
 * `variable` - (Optional) One or more `variable` blocks as documented below.
+* `secret_variable` - (Optional) One or more `secret_variable` blocks as documented below.
 * `artifact` - (Optional) One or more `artifact` blocks as documented below.
 * `artifact_source_trigger` - (Optional) One or more `artifact_source_trigger` blocks as documented below. Creates a release automatically when a new version of the linked artifact is available (continuous deployment).
 * `schedule_trigger` - (Optional) One or more `schedule_trigger` blocks as documented below. Creates a release on a recurring schedule.
+* `source_repo_trigger` - (Optional) One or more `source_repo_trigger` blocks as documented below. Creates a release when a commit is pushed to a linked source repository artifact.
+* `container_image_trigger` - (Optional) One or more `container_image_trigger` blocks as documented below. Creates a release when a new container image is pushed to a linked container repository artifact.
+* `package_trigger` - (Optional) One or more `package_trigger` blocks as documented below. Creates a release when a new version of a linked package artifact is published.
+* `pull_request_trigger` - (Optional) One or more `pull_request_trigger` blocks as documented below. Creates a release when a pull request is raised against a linked source repository artifact.
 
-~> **NOTE:** Only `artifact_source_trigger` and `schedule_trigger` are managed by this resource. Other trigger types configured in the Azure DevOps UI (pull request, container image, package, and source repository triggers) are preserved on update but are not managed by Terraform.
+~> **NOTE:** Each trigger references an `artifact` by its `alias` via `artifact_alias`, and the referenced artifact must be of a compatible `type`. Trigger types not yet exposed by this resource are preserved on update rather than removed.
 
 * `stage` - (Required) One or more `stage` blocks as documented below.
 
 A `variable` block supports the following:
 
 * `name` - (Required) The name of the variable.
-* `value` - (Optional) The value of the variable. Cannot be used together with `is_secret` / `secret_value`.
-* `secret_value` - (Optional) The secret value of the variable. Used together with `is_secret = true`. This value is not returned by the API and is stored only in Terraform state.
-* `is_secret` - (Optional) Whether the variable is a secret. Defaults to `false`. When `true`, set `secret_value` instead of `value`.
+* `value` - (Optional) The value of the variable.
 * `allow_override` - (Optional) Whether the variable can be overridden at release time. Defaults to `false`.
+
+A `secret_variable` block supports the following:
+
+* `name` - (Required) The name of the secret variable.
+* `value` - (Optional) The value of the secret variable. This value is marked as sensitive.
+* `allow_override` - (Optional) Whether the variable can be overridden at release time. Defaults to `false`.
+
+~> **NOTE:** A name may not be used by both a `variable` and a `secret_variable` block in the same scope.
+
+~> **NOTE:** The service never returns the value of a secret variable, so it is tracked only in Terraform state. On import, `secret_variable` values are empty and the next plan will show a diff until the values are supplied in the configuration.
 
 An `artifact` block supports the following:
 
 * `alias` - (Required) The alias of the artifact. This is referenced by release variables and triggers (e.g. `$(myapp.BuildNumber)`).
-* `type` - (Required) The artifact type. Common values are `Build`, `Git`, `GitHub`, `TFVC`, `Jenkins`, and `Nuget`.
+* `type` - (Required) The artifact type. Common values are `Build`, `Git`, `GitHub`, `GitHubRelease`, `TFVC`, `Jenkins`, `PackageManagement` (Azure Artifacts feeds), and container registry types such as `DockerHub` and `AzureContainerRepository`. Azure DevOps extensions can register additional artifact types, so this value is not restricted to a fixed list. An unrecognised type is rejected by the service with `VS402864: No artifact type found corresponding to ID <type>`.
 * `is_primary` - (Optional) Whether this is the primary artifact. Defaults to `true`.
 * `is_retained` - (Optional) Whether the artifact is retained by the release. Defaults to `false`.
 * `definition_reference` - (Required) One or more `definition_reference` blocks describing the artifact source, as documented below.
 
 A `definition_reference` block supports the following:
 
-* `key` - (Required) The reference key. The required keys depend on `type`. For a `Build` artifact these are typically `project`, `definition`, and `defaultVersionType`.
-* `id` - (Required) The ID value for the reference key.
-* `name` - (Optional) The display name for the reference key.
+* `key` - (Required) The reference key, for example `project` or `definition`. The keys an artifact requires are determined by its `type`, as described below.
+* `id` - (Required) The value for the key. This is the value the service resolves the reference against, usually a GUID or another machine-readable identifier.
+* `name` - (Optional) The display name for the value, as shown in the Azure DevOps web UI. This is informational only and is not used to resolve the reference.
 
-~> **NOTE:** The Azure DevOps server may enrich `definition_reference` with additional keys it computes (for example `defaultVersionBranch` or `artifactSourceDefinitionUrl`). If a subsequent plan shows a diff, add the reported keys as `definition_reference` blocks to keep the configuration stable.
+Azure DevOps models all artifact types through a single generic structure, so the fields that identify a particular source are supplied as this untyped set of key/value pairs rather than as dedicated attributes. Each `type` requires a different set of keys, which together narrow the artifact down to one specific source and a default version to deploy.
+
+A `Build` artifact, for example, is described by three keys because three separate questions must be answered:
+
+* `project` - which Team Project contains the build pipeline.
+* `definition` - which build pipeline within that project produces the artifact.
+* `defaultVersionType` - which build to deploy when a release is created manually, for example `latestType` for the most recent build.
+
+Of these, only `project` and `definition` are enforced by the service; `defaultVersionType` is accepted by every artifact type and is defaulted when omitted, but the Azure DevOps web UI always writes it, so most definitions set it explicitly. The keys the service enforces for the most common artifact types are:
+
+* `Build` - `project` and `definition` (the build definition ID).
+* `Git` - `project`, `definition` (the repository ID), and `branches` (e.g. `refs/heads/main`). Note that `defaultVersionBranch` is rejected for `Git` artifacts; use `branches` instead.
+* `TFVC` - `project` and `definition`.
+* `GitHub` - `connection` (the GitHub service connection ID), `definition` (the repository), and `branch`.
+* `GitHubRelease` - `connection` (the GitHub service connection ID) and `definition` (the repository).
+* `Jenkins` - `connection` (the Jenkins service connection ID) and `definition` (the job name).
+* `PackageManagement` - `feed` (the feed ID) and `definition` (the package name).
+* `DockerHub` - `connection` (the Docker Hub service connection ID), `definition` (the repository), and `namespaces`.
+* `AzureContainerRepository` - `connection` (the Azure Resource Manager service connection ID), `definition` (the repository), `registryurl`, and `resourcegroup`.
+
+Because artifact types can be added by Azure DevOps extensions, this list cannot be exhaustive. To determine the keys for a type not listed above, either:
+
+* Add the artifact to a release definition through the Azure DevOps web UI, then read the `artifacts[].definitionReference` object back from the [Definitions - Get](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/definitions/get) REST API. Its keys map one-to-one onto `definition_reference` blocks, with `id` and `name` taken from each entry.
+* Apply the artifact with the keys you expect and let the API report what is missing. It names each problem individually, for example `Input field 'branches' must be present for artifact source: '<alias>'` for a missing key, or `'defaultVersionBranch' is not a valid input field` for one that does not apply to the type.
+
+~> **NOTE:** The Azure DevOps server may enrich `definition_reference` with additional keys it computes (for example `defaultVersionBranch` or `artifactSourceDefinitionUrl`). Keys that are not listed in the configuration are ignored when the resource is read back, so they do not cause a diff. This filtering relies on the configuration, so on import any computed keys are recorded in state as well; if a plan after import shows a diff on `definition_reference`, add the extra keys to the configuration or remove them from state.
 
 An `artifact_source_trigger` block supports the following:
 
@@ -173,12 +216,56 @@ A `schedule_trigger` block supports the following:
 * `time_zone_id` - (Optional) The time zone ID for the schedule (e.g. `UTC`). Defaults to `UTC`.
 * `only_with_changes` - (Optional) Only create a release if the artifact or definition has changed since the last release. Defaults to `false`.
 
+A `source_repo_trigger` block supports the following:
+
+* `artifact_alias` - (Required) The `alias` of the source repository `artifact` this trigger watches (an artifact of type `Git`, `GitHub`, or `TFVC`).
+* `branch_filter` - (Optional) A `branch_filter` block as documented below, restricting which branches trigger a release. When omitted, pushes to any branch trigger a release.
+
+A `branch_filter` block supports the following:
+
+* `include` - (Optional) A set of branches that trigger a release when pushed to (e.g. `refs/heads/main`).
+* `exclude` - (Optional) A set of branches that do not trigger a release.
+
+~> **NOTE:** At most one `branch_filter` block may be specified, and it must set at least one of `include` or `exclude`. The service stores branch filters as a single flat list, so multiple blocks cannot be represented and an empty block would produce a persistent diff.
+
+A `container_image_trigger` block supports the following:
+
+* `artifact_alias` - (Required) The `alias` of the container repository `artifact` this trigger watches.
+* `tag_filter` - (Optional) A single image tag pattern that triggers a release. When omitted, any new image triggers a release. The service permits at most one tag filter per container image trigger.
+
+~> **NOTE:** Azure DevOps validates the registry credentials when a `container_image_trigger` is attached, so the linked service connection must hold credentials that can authenticate against the registry. Otherwise the API rejects the definition with an error such as `Unable to get access token from Docker Hub repository.`
+
+A `package_trigger` block supports the following:
+
+* `artifact_alias` - (Required) The `alias` of the package `artifact` this trigger watches.
+
+A `pull_request_trigger` block supports the following:
+
+* `artifact_alias` - (Required) The `alias` of the source repository `artifact` this trigger watches.
+* `status_policy_name` - (Optional) The name of the policy used to publish the release status back to the pull request.
+* `use_artifact_reference` - (Optional) Take the code repository details from the linked artifact rather than specifying them explicitly. Defaults to `true`. Set to `false` when supplying `code_repository_reference`.
+* `code_repository_reference` - (Optional) A `code_repository_reference` block as documented below. Only required when `use_artifact_reference` is `false`.
+* `trigger_condition` - (Optional) One or more `trigger_condition` blocks that filter which pull requests trigger a release, as documented below. When omitted, pull requests targeting any branch trigger a release.
+
+A `code_repository_reference` block supports the following:
+
+* `system_type` - (Required) The source system hosting the repository. Valid values are `tfsGit` and `gitHub`.
+* `repository_reference` - (Optional) One or more `repository_reference` blocks, each supplying a `key`, a `value`, and an optional `display_value`. The required keys depend on `system_type`; for `tfsGit` these are typically `project` and `repository`.
+
+~> **NOTE:** As with `definition_reference`, the server may enrich `repository_reference` with additional computed keys. Only the keys present in your configuration are tracked, so unlisted keys will not produce a diff.
+
+A `trigger_condition` block within `pull_request_trigger` supports the following:
+
+* `target_branch` - (Optional) Only trigger for pull requests targeting this branch (e.g. `refs/heads/main`).
+* `tags` - (Optional) A set of tags to filter on.
+
 A `stage` block supports the following:
 
 * `name` - (Required) The name of the stage (environment).
 * `rank` - (Optional) The order of the stage. Defaults to its position in the list.
 * `condition` - (Optional) One or more `condition` blocks controlling when the stage runs, as documented below. When omitted, the **first** stage defaults to starting on release creation (`ReleaseStarted`). At least one stage must start on release creation whenever a trigger is configured.
 * `variable` - (Optional) One or more stage-scoped `variable` blocks (same schema as above).
+* `secret_variable` - (Optional) One or more stage-scoped `secret_variable` blocks (same schema as above).
 * `variable_groups` - (Optional) A set of variable group IDs scoped to the stage.
 * `retention_policy` - (Optional) A `retention_policy` block as documented below.
 * `pre_deploy_approval` - (Optional) A `pre_deploy_approval` block as documented below.

--- a/website/docs/r/release_definition.html.markdown
+++ b/website/docs/r/release_definition.html.markdown
@@ -1,0 +1,364 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevOps: azuredevops_release_definition"
+description: |-
+  Manages a Release Definition within Azure DevOps organization.
+---
+
+# azuredevops_release_definition
+
+Manages a classic Release Definition within Azure DevOps.
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "example" {
+  name = "Example Project"
+}
+
+resource "azuredevops_git_repository" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Repository"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_build_definition" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Example Build"
+
+  repository {
+    repo_type   = "TfsGit"
+    repo_id     = azuredevops_git_repository.example.id
+    branch_name = azuredevops_git_repository.example.default_branch
+    yml_path    = "azure-pipelines.yml"
+  }
+}
+
+data "azuredevops_agent_queue" "example" {
+  project_id = azuredevops_project.example.id
+  name       = "Azure Pipelines"
+}
+
+resource "azuredevops_release_definition" "example" {
+  project_id          = azuredevops_project.example.id
+  name                = "Example Release"
+  path                = "\\"
+  release_name_format = "Release-$(rev:r)"
+
+  variable {
+    name  = "environment"
+    value = "production"
+  }
+
+  artifact {
+    alias      = "myapp"
+    type       = "Build"
+    is_primary = true
+
+    definition_reference {
+      key  = "project"
+      id   = azuredevops_project.example.id
+      name = azuredevops_project.example.name
+    }
+
+    definition_reference {
+      key  = "definition"
+      id   = azuredevops_build_definition.example.id
+      name = azuredevops_build_definition.example.name
+    }
+
+    definition_reference {
+      key  = "defaultVersionType"
+      id   = "latestType"
+      name = "Latest"
+    }
+  }
+
+  # Create a release automatically whenever a new build is produced.
+  artifact_source_trigger {
+    artifact_alias = "myapp"
+  }
+
+  # Also create a release every weekday at 03:00 UTC.
+  schedule_trigger {
+    days              = ["monday", "tuesday", "wednesday", "thursday", "friday"]
+    start_hours       = 3
+    start_minutes     = 0
+    time_zone_id      = "UTC"
+    only_with_changes = true
+  }
+
+  stage {
+    name = "Dev"
+
+    deploy_phase {
+      name           = "Agent job"
+      agent_queue_id = data.azuredevops_agent_queue.example.id
+
+      task {
+        # Command Line task
+        task_id = "d9bafed4-0b18-4f58-968d-86655b4d2ce9"
+        version = "2.*"
+        inputs = {
+          script = "echo Hello world"
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID or name of the project. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the release definition.
+* `path` - (Optional) The folder path of the release definition. Defaults to `\`.
+* `description` - (Optional) A description of the release definition.
+* `release_name_format` - (Optional) The release name format. Defaults to `Release-$(rev:r)`.
+* `variable_groups` - (Optional) A set of variable group IDs to link to the release definition.
+* `variable` - (Optional) One or more `variable` blocks as documented below.
+* `artifact` - (Optional) One or more `artifact` blocks as documented below.
+* `artifact_source_trigger` - (Optional) One or more `artifact_source_trigger` blocks as documented below. Creates a release automatically when a new version of the linked artifact is available (continuous deployment).
+* `schedule_trigger` - (Optional) One or more `schedule_trigger` blocks as documented below. Creates a release on a recurring schedule.
+
+~> **NOTE:** Only `artifact_source_trigger` and `schedule_trigger` are managed by this resource. Other trigger types configured in the Azure DevOps UI (pull request, container image, package, and source repository triggers) are preserved on update but are not managed by Terraform.
+
+* `stage` - (Required) One or more `stage` blocks as documented below.
+
+A `variable` block supports the following:
+
+* `name` - (Required) The name of the variable.
+* `value` - (Optional) The value of the variable. Cannot be used together with `is_secret` / `secret_value`.
+* `secret_value` - (Optional) The secret value of the variable. Used together with `is_secret = true`. This value is not returned by the API and is stored only in Terraform state.
+* `is_secret` - (Optional) Whether the variable is a secret. Defaults to `false`. When `true`, set `secret_value` instead of `value`.
+* `allow_override` - (Optional) Whether the variable can be overridden at release time. Defaults to `false`.
+
+An `artifact` block supports the following:
+
+* `alias` - (Required) The alias of the artifact. This is referenced by release variables and triggers (e.g. `$(myapp.BuildNumber)`).
+* `type` - (Required) The artifact type. Common values are `Build`, `Git`, `GitHub`, `TFVC`, `Jenkins`, and `Nuget`.
+* `is_primary` - (Optional) Whether this is the primary artifact. Defaults to `true`.
+* `is_retained` - (Optional) Whether the artifact is retained by the release. Defaults to `false`.
+* `definition_reference` - (Required) One or more `definition_reference` blocks describing the artifact source, as documented below.
+
+A `definition_reference` block supports the following:
+
+* `key` - (Required) The reference key. The required keys depend on `type`. For a `Build` artifact these are typically `project`, `definition`, and `defaultVersionType`.
+* `id` - (Required) The ID value for the reference key.
+* `name` - (Optional) The display name for the reference key.
+
+~> **NOTE:** The Azure DevOps server may enrich `definition_reference` with additional keys it computes (for example `defaultVersionBranch` or `artifactSourceDefinitionUrl`). If a subsequent plan shows a diff, add the reported keys as `definition_reference` blocks to keep the configuration stable.
+
+An `artifact_source_trigger` block supports the following:
+
+* `artifact_alias` - (Required) The `alias` of the `artifact` this trigger watches. A release is created when a new version of that artifact is available.
+* `trigger_condition` - (Optional) One or more `trigger_condition` blocks that filter which artifact versions trigger a release. When omitted, any new version triggers a release.
+
+A `trigger_condition` block supports the following:
+
+* `source_branch` - (Optional) Only trigger for artifacts produced from this source branch (e.g. `refs/heads/main`).
+* `use_build_definition_branch` - (Optional) Use the build definition's default branch as the branch filter. Defaults to `false`.
+* `create_release_on_build_tagging` - (Optional) Create a release when the build is tagged. Defaults to `false`.
+* `tags` - (Optional) A set of build tags to filter on.
+
+A `schedule_trigger` block supports the following:
+
+* `days` - (Required) A set of days on which to create a release. Valid values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`, `all` (case-insensitive; stored in lowercase). Note: specifying all seven days is normalized by the server to `all`.
+* `start_hours` - (Optional) The local-time hour (0-23) at which to start. Defaults to `3`.
+* `start_minutes` - (Optional) The local-time minute (0-59) at which to start. Defaults to `0`.
+* `time_zone_id` - (Optional) The time zone ID for the schedule (e.g. `UTC`). Defaults to `UTC`.
+* `only_with_changes` - (Optional) Only create a release if the artifact or definition has changed since the last release. Defaults to `false`.
+
+A `stage` block supports the following:
+
+* `name` - (Required) The name of the stage (environment).
+* `rank` - (Optional) The order of the stage. Defaults to its position in the list.
+* `condition` - (Optional) One or more `condition` blocks controlling when the stage runs, as documented below. When omitted, the **first** stage defaults to starting on release creation (`ReleaseStarted`). At least one stage must start on release creation whenever a trigger is configured.
+* `variable` - (Optional) One or more stage-scoped `variable` blocks (same schema as above).
+* `variable_groups` - (Optional) A set of variable group IDs scoped to the stage.
+* `retention_policy` - (Optional) A `retention_policy` block as documented below.
+* `pre_deploy_approval` - (Optional) A `pre_deploy_approval` block as documented below.
+* `post_deploy_approval` - (Optional) A `post_deploy_approval` block as documented below.
+* `pre_deployment_gates` - (Optional) A `pre_deployment_gates` block as documented below.
+* `post_deployment_gates` - (Optional) A `post_deployment_gates` block as documented below.
+* `environment_options` - (Optional) An `environment_options` block as documented below.
+* `execution_policy` - (Optional) An `execution_policy` block as documented below.
+* `environment_trigger` - (Optional) One or more `environment_trigger` blocks as documented below.
+* `deploy_phase` - (Required) One or more `deploy_phase` blocks as documented below.
+
+A `condition` block supports the following:
+
+* `condition_type` - (Optional) The type of condition. One of `event`, `environmentState`, or `artifact`. Defaults to `event`.
+* `name` - (Required) The condition name. For an `event` condition that starts the stage on release creation, use `ReleaseStarted`. For an `environmentState` condition, use the name of the preceding stage.
+* `value` - (Optional) The condition value (for example, the required state for an `environmentState` condition).
+
+~> **Note** Stages run **in parallel** or **sequentially** based solely on their `condition` blocks. Give two or more stages an `event` / `ReleaseStarted` condition to run them in parallel (each starts on release creation). Use an `environmentState` condition that names a preceding stage to run a stage sequentially after it. The `rank` attribute only controls layout, not execution order.
+
+For example, to run `Dev` and `QA` in parallel and then `Prod` after `Dev` succeeds:
+
+```hcl
+stage {
+  name = "Dev"
+  condition {
+    condition_type = "event"
+    name           = "ReleaseStarted"
+  }
+  # ...deploy_phase...
+}
+
+stage {
+  name = "QA"
+  condition {
+    condition_type = "event"
+    name           = "ReleaseStarted"
+  }
+  # ...deploy_phase...
+}
+
+stage {
+  name = "Prod"
+  condition {
+    condition_type = "environmentState"
+    name           = "Dev"
+    value          = "4" # 4 = succeeded
+  }
+  # ...deploy_phase...
+}
+```
+
+A `retention_policy` block supports the following:
+
+* `days_to_keep` - (Optional) Number of days to keep a release. Defaults to `30`.
+* `releases_to_keep` - (Optional) Number of releases to keep. Defaults to `3`.
+* `retain_build` - (Optional) Whether to retain the associated build. Defaults to `true`.
+
+A `pre_deploy_approval` / `post_deploy_approval` block supports the following:
+
+* `approval` - (Optional) One or more `approval` blocks. When omitted, a single automated approval is configured.
+* `approval_options` - (Optional) An `approval_options` block as documented below.
+
+An `approval` block supports the following:
+
+* `approver_id` - (Optional) The ID of the identity that must approve. Omit for an automated approval. This must be the identity's storage-key UUID. When referencing a group from the `azuredevops_group` data source, use its `group_id` attribute (its `id` is a descriptor and `origin_id` is the Azure AD object ID, neither of which is accepted here).
+* `is_automated` - (Optional) Whether the approval is automated. Defaults to `false`.
+* `is_notification_on` - (Optional) Whether a notification is sent to the approver. Defaults to `false`.
+
+~> **NOTE:** `approver_id` requires the identity's storage-key UUID. To use a group as the approver, reference the `group_id` attribute of the `azuredevops_group` data source:
+
+```hcl
+data "azuredevops_group" "approvers" {
+  project_id = azuredevops_project.example.id
+  name       = "Release Administrators"
+}
+
+# ... within a stage block:
+pre_deploy_approval {
+  approval {
+    approver_id = data.azuredevops_group.approvers.group_id
+  }
+}
+```
+
+
+An `approval_options` block supports the following:
+
+* `required_approver_count` - (Optional) The number of approvals required to move the release forward. `0` means all approvers are required.
+* `release_creator_can_be_approver` - (Optional) Whether the user requesting the release or deployment is allowed to approve it. Defaults to `false`.
+* `auto_triggered_and_previous_environment_approved_can_be_skipped` - (Optional) Whether the approval can be skipped if the same approver approved the previous stage. Defaults to `false`.
+* `enforce_identity_revalidation` - (Optional) Whether to revalidate the identity of the approver before completing the approval. Defaults to `false`.
+* `timeout_in_minutes` - (Optional) The approval timeout in minutes. `0` means the default timeout of 30 days. Defaults to `0`.
+* `execution_order` - (Optional) The order in which approvals are shown relative to gates. Possible values are `beforeGates`, `afterSuccessfulGates`, and `afterGatesAlways`. Defaults to `beforeGates`.
+
+An `environment_options` block supports the following:
+
+* `auto_link_work_items` - (Optional) Whether to automatically link work items to the deployment. Defaults to `false`.
+* `badge_enabled` - (Optional) Whether the deployment badge is enabled for the stage. Defaults to `false`.
+* `publish_deployment_status` - (Optional) Whether to publish deployment status to source repositories. Defaults to `true`.
+* `pull_request_deployment_enabled` - (Optional) Whether pull request based deployments are enabled for the stage. Defaults to `false`.
+
+An `execution_policy` block supports the following:
+
+* `concurrency_count` - (Optional) The maximum number of deployments to run in parallel for the stage. Set to `0` for unlimited concurrency. Defaults to `0`.
+* `queue_depth_count` - (Optional) The number of deployments allowed to be queued for the stage. Defaults to `0`.
+
+An `environment_trigger` block supports the following:
+
+* `trigger_type` - (Optional) The type of environment trigger. One of `rollbackRedeploy` or `deploymentGroupRedeploy`. Defaults to `rollbackRedeploy`.
+* `action` - (Required) The action to take when the trigger fires. For an auto-redeploy trigger, use `LatestSuccessfulDeployment` to redeploy the last successful deployment.
+* `event_types` - (Required) A list of event types that fire the trigger. For an auto-redeploy trigger, use `["MS.TF.DistributedTask.DeploymentFailed"]`.
+
+A `pre_deployment_gates` / `post_deployment_gates` block supports the following:
+
+* `is_enabled` - (Optional) Whether the gates are enabled. Defaults to `true`.
+* `sampling_interval` - (Optional) The time in minutes between re-evaluation of gates. Defaults to `15`.
+* `stabilization_time` - (Optional) The delay in minutes before gate evaluation starts. Defaults to `0`.
+* `minimum_success_duration` - (Optional) The minimum duration in minutes for successful gate results to remain steady before the gate succeeds. Defaults to `0`.
+* `timeout` - (Optional) The timeout in minutes after which gates fail. Defaults to `1440`.
+* `gate` - (Optional) One or more `gate` blocks as documented below.
+
+A `gate` block supports the following:
+
+* `task` - (Required) One or more `task` blocks (same schema as the `deploy_phase` `task` block) that implement the gate, for example an "Invoke REST API" or "Query Azure Monitor alerts" task.
+
+A `deploy_phase` block supports the following:
+
+* `name` - (Required) The name of the deploy phase (job).
+* `phase_type` - (Optional) The type of deploy phase. One of `agentBasedDeployment` (agent job), `runOnServer` (agentless/server job), or `machineGroupBasedDeployment` (deployment group job). Defaults to `agentBasedDeployment`.
+* `rank` - (Optional) The order of the deploy phase. Defaults to its position in the list.
+* `timeout_in_minutes` - (Optional) The job execution timeout in minutes. `0` means no timeout. Defaults to `0`.
+* `job_cancel_timeout_in_minutes` - (Optional) The job cancel timeout in minutes when a deployment is cancelled. Defaults to `1`.
+* `condition` - (Optional) The phase run condition. Defaults to `succeeded()`.
+* `task` - (Required) One or more `task` blocks as documented below.
+
+The following arguments apply to `agentBasedDeployment` and `machineGroupBasedDeployment` phases:
+
+* `skip_artifacts_download` - (Optional) Whether to skip downloading artifacts for the phase. Defaults to `false`.
+* `enable_access_token` - (Optional) Whether to include the OAuth access token in the deployment job. Defaults to `false`.
+
+The following arguments apply only to `agentBasedDeployment` phases:
+
+* `agent_queue_id` - (Optional) The agent **queue** ID the phase runs on. This is a project-scoped agent queue, not an organization-level agent pool. Source it from the `azuredevops_agent_queue` data source (for example the built-in `Azure Pipelines` queue) rather than hard-coding a numeric ID, since queue IDs differ per project.
+* `agent_specification` - (Optional) The agent specification (image) identifier for the phase, for example `ubuntu-22.04`. Required when the phase runs on a Microsoft-hosted agent pool.
+
+The following arguments apply only to `machineGroupBasedDeployment` phases:
+
+* `deployment_group_id` - (Optional) The ID of the deployment group the phase deploys to.
+* `tags` - (Optional) A set of deployment target tags used to filter which machines in the deployment group are deployed to.
+* `deployment_health_option` - (Optional) The deployment health option, for example `OneTargetAtATime` or `Custom`.
+* `health_percent` - (Optional) When `deployment_health_option` is `Custom`, the minimum percentage of targets that must remain healthy. Between `0` and `100`. Defaults to `0`.
+
+A `task` block supports the following:
+
+* `task_id` - (Required) The UUID of the task to run.
+* `version` - (Optional) The version of the task. Defaults to `1.*`.
+* `name` - (Optional) The display name of the task.
+* `enabled` - (Optional) Whether the task is enabled. Defaults to `true`.
+* `condition` - (Optional) The task run condition. Defaults to `succeeded()`.
+* `inputs` - (Optional) A map of task input values.
+* `override_inputs` - (Optional) A map of task input values to override.
+* `environment` - (Optional) A map of environment variables to set for the task.
+* `always_run` - (Optional) Whether the task runs even when a previous task has failed (unless the deployment was stopped). Defaults to `false`.
+* `continue_on_error` - (Optional) Whether the deployment continues when the task fails. Defaults to `false`.
+* `timeout_in_minutes` - (Optional) The task timeout in minutes. `0` means no timeout (or the maximum allowed). Defaults to `0`.
+* `retry_count_on_task_failure` - (Optional) The number of times to retry the task if it fails. Defaults to `0`.
+* `ref_name` - (Optional) The reference name of the task, used to reference its outputs from later tasks.
+* `definition_type` - (Optional) The task definition type. For example `task` or `metaTask`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the release definition.
+* `revision` - The revision number of the release definition.
+
+## Import
+
+Azure DevOps Release Definitions can be imported using the project name/id and release definition ID:
+
+```sh
+terraform import azuredevops_release_definition.example "Example Project/10"
+```


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

This PR aims to add a new resource `azuredevops_release_definition` to the provider, which allows the user to manage the releases in the pipelines.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result
<!-- A screenshot or text pasted here to show the acctest result. -->

<pre>
=== RUN   TestAccReleaseDefinition_basic
--- PASS: TestAccReleaseDefinition_basic (28.81s)
=== RUN   TestAccReleaseDefinition_update
--- PASS: TestAccReleaseDefinition_update (36.85s)
=== RUN   TestAccReleaseDefinition_variables
--- PASS: TestAccReleaseDefinition_variables (24.62s)
=== RUN   TestAccReleaseDefinition_complete
--- PASS: TestAccReleaseDefinition_complete (46.37s)
PASS
</pre>

## Related Issue(s)

Fix #49

## Other information

Might need to implement a data source for tasks, as users are required to specify `task_id` in the `task` property, but there is no data source to get this. This leads to the user having to manually put in a `task_id` instead of being able to use `data.azuredevops_task.test.id` for example. 
