### PR TITLE
`azuredevops_serviceendpoint_azurerm` - Add `serviceprincipalkey_wo` property to support ephemeral variables

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
+++ b/azuredevops/internal/acceptancetests/resource_serviceendpoint_azurerm_test.go
@@ -381,6 +381,50 @@ func TestAccServiceEndpointAzureRm_azureStack(t *testing.T) {
 	})
 }
 
+func TestAccServiceEndpointAzureRm_writeOnlyServicePrincipalKey(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	serviceEndpointName := testutils.GenerateResourceName()
+	serviceprincipalid := uuid.New().String()
+	serviceprincipalkeyFirst := uuid.New().String()
+	serviceprincipalkeySecond := uuid.New().String()
+
+	tfNode := "azuredevops_serviceendpoint_azurerm.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckServiceEndpointDestroyed("azuredevops_serviceendpoint_azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: hclAzureRMServiceEndpointWriteOnlyServicePrincipalKey(projectName, serviceEndpointName, serviceprincipalid, serviceprincipalkeyFirst, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfNode, serviceEndpointName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttr(tfNode, "service_endpoint_name", serviceEndpointName),
+					resource.TestCheckResourceAttr(tfNode, "credentials.0.serviceprincipalid", serviceprincipalid),
+					resource.TestCheckResourceAttr(tfNode, "credentials.0.serviceprincipalkey_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(tfNode, "credentials.0.serviceprincipalkey_wo"),
+				),
+			},
+			{
+				Config: hclAzureRMServiceEndpointWriteOnlyServicePrincipalKey(projectName, serviceEndpointName, serviceprincipalid, serviceprincipalkeySecond, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckServiceEndpointExistsWithName(tfNode, serviceEndpointName),
+					resource.TestCheckResourceAttr(tfNode, "credentials.0.serviceprincipalid", serviceprincipalid),
+					resource.TestCheckResourceAttr(tfNode, "credentials.0.serviceprincipalkey_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(tfNode, "credentials.0.serviceprincipalkey_wo"),
+				),
+			},
+			{
+				ResourceName:            tfNode,
+				ImportStateIdFunc:       testutils.ComputeProjectQualifiedResourceImportID(tfNode),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"credentials.0.serviceprincipalkey_wo_version"},
+			},
+		},
+	})
+}
+
 func hclAzureRMServiceEndpointEnvironmentAzureStack(projectName, serviceEndpointName string) string {
 	return fmt.Sprintf(`
 resource "azuredevops_project" "test" {
@@ -401,4 +445,26 @@ resource "azuredevops_serviceendpoint_azurerm" "test" {
   }
 }
 `, projectName, serviceEndpointName)
+}
+
+func hclAzureRMServiceEndpointWriteOnlyServicePrincipalKey(projectName, serviceEndpointName, serviceprincipalid, serviceprincipalkey string, serviceprincipalkeyVersion int) string {
+	return fmt.Sprintf(`
+resource "azuredevops_project" "test" {
+  name = "%s"
+}
+
+resource "azuredevops_serviceendpoint_azurerm" "test" {
+  project_id                             = azuredevops_project.test.id
+  service_endpoint_name                  = "%s"
+  azurerm_spn_tenantid                   = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_id                = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_name              = "Test Sub"
+  service_endpoint_authentication_scheme = "ServicePrincipal"
+  credentials {
+    serviceprincipalid             = "%s"
+    serviceprincipalkey_wo         = "%s"
+    serviceprincipalkey_wo_version = %d
+  }
+}
+`, projectName, serviceEndpointName, serviceprincipalid, serviceprincipalkey, serviceprincipalkeyVersion)
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -111,11 +111,11 @@ func ResourceServiceEndpointAzureRM() *schema.Resource {
 						Type:      schema.TypeString,
 						Optional:  true,
 						WriteOnly: true,
+						Sensitive: true,
 						ConflictsWith: []string{
 							"credentials.0.serviceprincipalkey",
 							"credentials.0.serviceprincipalcertificate",
 						},
-						RequiredWith: []string{"credentials.0.serviceprincipalkey_wo_version"},
 						ValidateFunc: validation.StringIsNotEmpty,
 					},
 					"serviceprincipalkey_wo_version": {

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_azurerm.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/serviceendpoint"
@@ -97,18 +98,40 @@ func ResourceServiceEndpointAzureRM() *schema.Resource {
 						Description: "The service principal id which should be used.",
 					},
 					"serviceprincipalkey": {
-						Type:          schema.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"credentials.0.serviceprincipalcertificate"},
-						Sensitive:     true,
-						ValidateFunc:  validation.StringIsNotEmpty,
+						Type:     schema.TypeString,
+						Optional: true,
+						ConflictsWith: []string{
+							"credentials.0.serviceprincipalcertificate",
+							"credentials.0.serviceprincipalkey_wo",
+						},
+						Sensitive:    true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"serviceprincipalkey_wo": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						WriteOnly: true,
+						ConflictsWith: []string{
+							"credentials.0.serviceprincipalkey",
+							"credentials.0.serviceprincipalcertificate",
+						},
+						RequiredWith: []string{"credentials.0.serviceprincipalkey_wo_version"},
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"serviceprincipalkey_wo_version": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						RequiredWith: []string{"credentials.0.serviceprincipalkey_wo"},
 					},
 					"serviceprincipalcertificate": {
-						Type:          schema.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"credentials.0.serviceprincipalkey"},
-						Sensitive:     true,
-						ValidateFunc:  validation.StringIsNotEmpty,
+						Type:     schema.TypeString,
+						Optional: true,
+						ConflictsWith: []string{
+							"credentials.0.serviceprincipalkey",
+							"credentials.0.serviceprincipalkey_wo",
+						},
+						Sensitive:    true,
+						ValidateFunc: validation.StringIsNotEmpty,
 					},
 				},
 			},
@@ -362,7 +385,15 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 				Scheme: converter.String(string(serviceEndPointAuthenticationScheme)),
 			}
 
-			if spnKey := credentials["serviceprincipalkey"].(string); spnKey != "" {
+			spnKey := credentials["serviceprincipalkey"].(string)
+			if spnKey == "" {
+				woSpnKey, err := writeOnlyServicePrincipalKey(d)
+				if err != nil {
+					return nil, err
+				}
+				spnKey = woSpnKey
+			}
+			if spnKey != "" {
 				(*serviceEndpoint.Authorization.Parameters)["authenticationType"] = "spnKey"
 				(*serviceEndpoint.Authorization.Parameters)["serviceprincipalkey"] = spnKey
 			}
@@ -456,6 +487,22 @@ func expandServiceEndpointAzureRM(d *schema.ResourceData) (*serviceendpoint.Serv
 	serviceEndpoint.Type = converter.String("azurerm")
 	serviceEndpoint.Url = converter.String(endpointUrl)
 	return serviceEndpoint, nil
+}
+
+func writeOnlyServicePrincipalKey(d *schema.ResourceData) (string, error) {
+	if d.GetRawConfig().IsNull() {
+		return "", nil
+	}
+
+	value, diags := d.GetRawConfigAt(cty.GetAttrPath("credentials").IndexInt(0).GetAttr("serviceprincipalkey_wo"))
+	if diags.HasError() {
+		return "", fmt.Errorf("retrieving `credentials.0.serviceprincipalkey_wo`: %+v", diags)
+	}
+	if value.IsNull() {
+		return "", nil
+	}
+
+	return value.AsString(), nil
 }
 
 // Convert AzDO data structure to internal Terraform data structure

--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -47,6 +47,39 @@ resource "azuredevops_serviceendpoint_azurerm" "example" {
 }
 ```
 
+### Service Principal Manual AzureRM Service Endpoint (Write-Only Secret)
+
+~> **Note:** Write-only attributes require Terraform 1.11 or later.
+
+```hcl
+resource "azuredevops_project" "example" {
+  name               = "Example Project"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+  description        = "Managed by Terraform"
+}
+
+ephemeral "azuread_application_password" "example" {
+  application_id = "/applications/00000000-0000-0000-0000-000000000000"
+}
+
+resource "azuredevops_serviceendpoint_azurerm" "example" {
+  project_id                             = azuredevops_project.example.id
+  service_endpoint_name                  = "Example AzureRM"
+  description                            = "Managed by Terraform"
+  service_endpoint_authentication_scheme = "ServicePrincipal"
+  credentials {
+    serviceprincipalid             = "00000000-0000-0000-0000-000000000000"
+    serviceprincipalkey_wo         = ephemeral.azuread_application_password.example.value
+    serviceprincipalkey_wo_version = 1
+  }
+  azurerm_spn_tenantid      = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_id   = "00000000-0000-0000-0000-000000000000"
+  azurerm_subscription_name = "Example Subscription Name"
+}
+```
+
 ### Service Principal Manual AzureRM Service Endpoint (ManagementGroup Scoped)
 
 ```hcl
@@ -239,9 +272,15 @@ A `credentials` block supports the following:
 
 * `serviceprincipalid` - (Required) The service principal application ID
 
-* `serviceprincipalkey` - (Optional) The service principal secret. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`.
+* `serviceprincipalkey` - (Optional) The service principal secret. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. Conflicts with `serviceprincipalkey_wo` and `serviceprincipalcertificate`.
 
-* `serviceprincipalcertificate` - (Optional) The service principal certificate. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`.
+* `serviceprincipalkey_wo` - (Optional, Write-Only) The service principal secret. Conflicts with `serviceprincipalkey` and `serviceprincipalcertificate`. This is a write-only attribute, which allows ephemeral resources to be used and is never persisted to state. Requires `serviceprincipalkey_wo_version`.
+
+* `serviceprincipalkey_wo_version` - (Optional) An integer value used to trigger an update for `serviceprincipalkey_wo`. This property should be incremented when updating `serviceprincipalkey_wo`. Requires `serviceprincipalkey_wo`.
+
+~> **Note:** Because `serviceprincipalkey_wo` is never written to state, Terraform cannot detect changes to its value on its own. `serviceprincipalkey_wo_version` must be incremented whenever the secret is rotated, otherwise the new value will not be sent to Azure DevOps.
+
+* `serviceprincipalcertificate` - (Optional) The service principal certificate. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. Conflicts with `serviceprincipalkey` and `serviceprincipalkey_wo`.
 
 ---
 

--- a/website/docs/r/serviceendpoint_azurerm.html.markdown
+++ b/website/docs/r/serviceendpoint_azurerm.html.markdown
@@ -274,11 +274,11 @@ A `credentials` block supports the following:
 
 * `serviceprincipalkey` - (Optional) The service principal secret. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. Conflicts with `serviceprincipalkey_wo` and `serviceprincipalcertificate`.
 
-* `serviceprincipalkey_wo` - (Optional, Write-Only) The service principal secret. Conflicts with `serviceprincipalkey` and `serviceprincipalcertificate`. This is a write-only attribute, which allows ephemeral resources to be used and is never persisted to state. Requires `serviceprincipalkey_wo_version`.
+* `serviceprincipalkey_wo` - (Optional, Write-Only) The service principal secret. Conflicts with `serviceprincipalkey` and `serviceprincipalcertificate`. This is a write-only attribute, which allows ephemeral resources to be used and is never persisted to state.
 
-* `serviceprincipalkey_wo_version` - (Optional) An integer value used to trigger an update for `serviceprincipalkey_wo`. This property should be incremented when updating `serviceprincipalkey_wo`. Requires `serviceprincipalkey_wo`.
+* `serviceprincipalkey_wo_version` - (Optional) An integer value used to trigger an update for `serviceprincipalkey_wo`. This property should be set or incremented when updating `serviceprincipalkey_wo`. Requires `serviceprincipalkey_wo`.
 
-~> **Note:** Because `serviceprincipalkey_wo` is never written to state, Terraform cannot detect changes to its value on its own. `serviceprincipalkey_wo_version` must be incremented whenever the secret is rotated, otherwise the new value will not be sent to Azure DevOps.
+~> **Note:** Because `serviceprincipalkey_wo` is never written to state, Terraform cannot detect changes to its value on its own. To roll out a rotated secret, set `serviceprincipalkey_wo_version` (or increment it if it is already set), otherwise the new value will not be sent to Azure DevOps.
 
 * `serviceprincipalcertificate` - (Optional) The service principal certificate. This not required if `service_endpoint_authentication_scheme` is set to `WorkloadIdentityFederation`. Conflicts with `serviceprincipalkey` and `serviceprincipalkey_wo`.
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the `azuredevops_serviceendpoint_azurerm` resource, there is currently no support for ephemeral variables as the client secret when `service_endpoint_authentication_scheme = "ServicePrincipal"`. This PR aims to allow support for this by adding the `serviceprincipalkey_wo` property.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_Create_WithValidate
=== PAUSE TestAccServiceEndpointAzureRm_Create_WithValidate
=== RUN   TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== PAUSE TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== RUN   TestAccServiceEndpointAzureRm_azureStack
=== PAUSE TestAccServiceEndpointAzureRm_azureStack
=== RUN   TestAccServiceEndpointAzureRm_writeOnlyServicePrincipalKey
=== PAUSE TestAccServiceEndpointAzureRm_writeOnlyServicePrincipalKey
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_Create_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate
=== CONT  TestAccServiceEndpointAzureRm_writeOnlyServicePrincipalKey
=== CONT  TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate
=== CONT  TestAccServiceEndpointAzureRm_azureStack
--- PASS: TestAccServiceEndpointAzureRm_MgmtGrpCreateAndUpdate (54.83s)
--- PASS: TestAccServiceEndpointAzureRm_azureStack (55.39s)
--- PASS: TestAccServiceEndpointAzureRm_ManagedServiceIdentity_CreateAndUpdate (56.01s)
--- PASS: TestAccServiceEndpointAzureRm_AutomaticCreateAndUpdate (56.16s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Automatic_CreateAndUpdate (56.27s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate (56.29s)
--- PASS: TestAccServiceEndpointAzureRm_WorkloadFederation_Manual_CreateAndUpdate (56.63s)
--- PASS: TestAccServiceEndpointAzureRm_writeOnlyServicePrincipalKey (56.77s)
--- PASS: TestAccServiceEndpointAzureRm_Create_WithValidate (103.45s)
--- PASS: TestAccServiceEndpointAzureRm_CreateAndUpdate_WithValidate (115.39s)
PASS
</pre>

## Related Issue(s)

Fix #1591
