### PR TITLE
`azuredevops_serviceendpoint_*` resources - Fix fail to destroy error due to consistency issues

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -115,22 +115,35 @@ func updateServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceen
 func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *serviceendpoint.ServiceEndpoint, timeout time.Duration) error {
 	projectID := (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id
 
-	if err := retry.RetryContext(clients.Ctx, timeout, func() *retry.RetryError {
-		err := clients.ServiceEndpointClient.DeleteServiceEndpoint(
-			clients.Ctx,
-			serviceendpoint.DeleteServiceEndpointArgs{
-				ProjectIds: &[]string{
-					projectID.String(),
+	attempts := 0
+	deleteConf := &retry.StateChangeConf{
+		Pending:      []string{"Retrying"},
+		Target:       []string{"Deleted"},
+		PollInterval: 5 * time.Second,
+		Timeout:      timeout,
+		Refresh: func() (interface{}, string, error) {
+			attempts++
+			err := clients.ServiceEndpointClient.DeleteServiceEndpoint(
+				clients.Ctx,
+				serviceendpoint.DeleteServiceEndpointArgs{
+					ProjectIds: &[]string{
+						projectID.String(),
+					},
+					EndpointId: serviceEndpoint.Id,
 				},
-				EndpointId: serviceEndpoint.Id,
-			},
-		)
-		if err != nil {
-			log.Printf(":: %s :: delete failed, retrying. %v", serviceEndpoint.Id, err)
-			return retry.RetryableError(err)
-		}
-		return nil
-	}); err != nil {
+			)
+			if err != nil {
+				if attempts >= 3 {
+					return nil, "", err
+				}
+				log.Printf(":: %s :: delete failed on attempt %d of 3, retrying. %v", serviceEndpoint.Id, attempts, err)
+				return serviceEndpoint, "Retrying", nil
+			}
+			return serviceEndpoint, "Deleted", nil
+		},
+	}
+
+	if _, err := deleteConf.WaitForStateContext(clients.Ctx); err != nil {
 		return fmt.Errorf("Delete service endpoint error %v", err)
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -114,15 +114,23 @@ func updateServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceen
 
 func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *serviceendpoint.ServiceEndpoint, timeout time.Duration) error {
 	projectID := (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id
-	if err := clients.ServiceEndpointClient.DeleteServiceEndpoint(
-		clients.Ctx,
-		serviceendpoint.DeleteServiceEndpointArgs{
-			ProjectIds: &[]string{
-				projectID.String(),
+
+	if err := retry.RetryContext(clients.Ctx, timeout, func() *retry.RetryError {
+		err := clients.ServiceEndpointClient.DeleteServiceEndpoint(
+			clients.Ctx,
+			serviceendpoint.DeleteServiceEndpointArgs{
+				ProjectIds: &[]string{
+					projectID.String(),
+				},
+				EndpointId: serviceEndpoint.Id,
 			},
-			EndpointId: serviceEndpoint.Id,
-		},
-	); err != nil {
+		)
+		if err != nil {
+			log.Printf(":: %s :: delete failed, retrying. %v", serviceEndpoint.Id, err)
+			return retry.RetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return fmt.Errorf("Delete service endpoint error %v", err)
 	}
 

--- a/azuredevops/internal/service/serviceendpoint/commons.go
+++ b/azuredevops/internal/service/serviceendpoint/commons.go
@@ -115,6 +115,7 @@ func updateServiceEndpoint(clients *client.AggregatedClient, endpoint *serviceen
 func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *serviceendpoint.ServiceEndpoint, timeout time.Duration) error {
 	projectID := (*serviceEndpoint.ServiceEndpointProjectReferences)[0].ProjectReference.Id
 
+	const maxAttempts = 3
 	attempts := 0
 	deleteConf := &retry.StateChangeConf{
 		Pending:      []string{"Retrying"},
@@ -133,11 +134,11 @@ func deleteServiceEndpoint(clients *client.AggregatedClient, serviceEndpoint *se
 				},
 			)
 			if err != nil {
-				if attempts >= 3 {
+				if attempts >= maxAttempts {
 					return nil, "", err
 				}
-				log.Printf(":: %s :: delete failed on attempt %d of 3, retrying. %v", serviceEndpoint.Id, attempts, err)
-				return serviceEndpoint, "Retrying", nil
+				log.Printf("[DEBUG] Deleting service endpoint %s failed on attempt %d of %d, retrying. %v", serviceEndpoint.Id, attempts, maxAttempts, err)
+				return nil, "Retrying", nil
 			}
 			return serviceEndpoint, "Deleted", nil
 		},


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

Currently, in `azuredevops_serviceendpoint_*` resources, when the user tries to delete the resource, an error occurs if `azurerm_federated_identity_credential` is deleted, but due to consistency issues, the API returns it as not deleted, which then causes a `Delete service endpoint error Cannot delete this service connection while federated credentials for app <id of app> exist in Entra tenant <id of WIF>` error. This fix adds a retry to prevent it from erroring out due to consistency issues.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Test Result

<pre>
=== RUN   TestAccServiceEndpointAzureCR_dataSource
=== PAUSE TestAccServiceEndpointAzureCR_dataSource
=== RUN   TestAccServiceEndpointAzureCR_spn_basic
=== PAUSE TestAccServiceEndpointAzureCR_spn_basic
=== RUN   TestAccServiceEndpointAzureCR_spn_update
=== PAUSE TestAccServiceEndpointAzureCR_spn_update
=== RUN   TestAccServiceEndpointAzureCR_workLoadIdentity_basic
=== PAUSE TestAccServiceEndpointAzureCR_workLoadIdentity_basic
=== RUN   TestAccServiceEndpointAzureCR_workLoadIdentity_update
=== PAUSE TestAccServiceEndpointAzureCR_workLoadIdentity_update
=== CONT  TestAccServiceEndpointAzureCR_dataSource
=== CONT  TestAccServiceEndpointAzureCR_workLoadIdentity_basic
=== CONT  TestAccServiceEndpointAzureCR_workLoadIdentity_update
=== CONT  TestAccServiceEndpointAzureCR_spn_basic
=== CONT  TestAccServiceEndpointAzureCR_spn_update
--- PASS: TestAccServiceEndpointAzureCR_dataSource (54.11s)
--- PASS: TestAccServiceEndpointAzureCR_spn_basic (54.27s)
--- PASS: TestAccServiceEndpointAzureCR_spn_update (56.33s)
--- PASS: TestAccServiceEndpointAzureCR_workLoadIdentity_update (56.75s)
--- PASS: TestAccServiceEndpointAzureCR_workLoadIdentity_basic (64.84s)
PASS
ok      github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests        64.847s
</pre>

## Related Issue(s)

Fix #1131

## Other information

No acceptance test added due to this issue being cross provider, and doesn't seem to have any existing acceptance test that does this.