### PR TITLE
`azuredevops_team` - Fix create/update never reaching `Synched` when …

### DIFF
--- a/azuredevops/internal/service/core/resource_team.go
+++ b/azuredevops/internal/service/core/resource_team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/ahmetb/go-linq"
@@ -187,7 +188,7 @@ func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	if err = waitForTeamStateChange(d, clients, projectID, teamID, teamData.Name, teamData.Description, memberSet, administratorSet, areaSet); err != nil {
+	if err = waitForTeamStateChange(d, clients, projectID, teamID, teamData.Name, teamData.Description, memberSet, administratorSet, areaSet, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 
@@ -350,7 +351,7 @@ func resourceTeamUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	if err := waitForTeamStateChange(d, clients, projectID, teamID, newTeamName, newDescription, memberSet, administratorSet, areaSet); err != nil {
+	if err := waitForTeamStateChange(d, clients, projectID, teamID, newTeamName, newDescription, memberSet, administratorSet, areaSet, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
@@ -375,7 +376,7 @@ func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedClient, projectID string, teamID string, name *string, description *string, memberSet *schema.Set, administratorSet *schema.Set, areaSet *schema.Set) error {
+func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedClient, projectID string, teamID string, name *string, description *string, memberSet *schema.Set, administratorSet *schema.Set, areaSet *schema.Set, waitTimeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"Waiting"},
 		Target:  []string{"Synched"},
@@ -391,8 +392,16 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 				return nil, "", fmt.Errorf("Reading team data: %+v", err)
 			}
 
-			bDescriptionUpdated := nil == description || *team.Description == *description
-			bNameUpdated := nil == name || *team.Name == *name
+			// The service trims surrounding whitespace when it stores name
+			// and description, so compare trimmed values. A missing value in
+			// the response is not worth waiting for; the read at the end of
+			// create/update records whatever the service returned.
+			bDescriptionUpdated := nil == description ||
+				nil == team.Description ||
+				strings.TrimSpace(*team.Description) == strings.TrimSpace(*description)
+			bNameUpdated := nil == name ||
+				nil == team.Name ||
+				strings.TrimSpace(*team.Name) == strings.TrimSpace(*name)
 
 			bAdministratorsUpdated := true
 			if administratorSet != nil {
@@ -400,7 +409,13 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 				if err != nil {
 					return nil, "", fmt.Errorf("Reading team administrators: %+v", err)
 				}
-				bAdministratorsUpdated = actualAdministrators.Len() == administratorSet.Len()
+				// All configured administrators must be granted. The service
+				// can add ACEs of its own to the team token, so counting
+				// entries is not reliable.
+				bAdministratorsUpdated = actualAdministrators.Intersection(administratorSet).Len() == administratorSet.Len()
+				if bAdministratorsUpdated && actualAdministrators.Len() != administratorSet.Len() {
+					log.Printf("[WARN] team %s has %d administrators, %d configured", teamID, actualAdministrators.Len(), administratorSet.Len())
+				}
 			}
 
 			dashboards, err := clients.DashboardClient.GetDashboardsByProject(clients.Ctx, dashboard.GetDashboardsByProjectArgs{
@@ -410,9 +425,11 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 			if err != nil {
 				return nil, "", fmt.Errorf("Reading Team dashboard: %+v", err)
 			}
+			// A new team starts with a single default dashboard. A nil list
+			// used to panic here.
 			dashboardUpdate := true
-			if dashboards == nil && len(*dashboards) == 0 {
-				dashboardUpdate = false
+			if dashboards == nil || len(*dashboards) == 0 {
+				log.Printf("[WARN] team %s has no dashboards yet", teamID)
 			}
 
 			bMembersUpdated := true
@@ -421,7 +438,13 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 				if err != nil {
 					return nil, "", fmt.Errorf("Reading team memberships: %+v", err)
 				}
-				bMembersUpdated = actualMemberships.Len() == memberSet.Len()
+				// All configured members must be present. The identity service
+				// can report extra or duplicate entries, so counting entries
+				// is not reliable.
+				bMembersUpdated = actualMemberships.Intersection(memberSet).Len() == memberSet.Len()
+				if bMembersUpdated && actualMemberships.Len() != memberSet.Len() {
+					log.Printf("[WARN] team %s has %d members, %d configured", teamID, actualMemberships.Len(), memberSet.Len())
+				}
 			}
 
 			bAreasUpdated := true
@@ -441,7 +464,7 @@ func waitForTeamStateChange(d *schema.ResourceData, clients *client.AggregatedCl
 			}
 			return state, state, nil
 		},
-		Timeout:                   30 * time.Minute,
+		Timeout:                   waitTimeout,
 		MinTimeout:                5 * time.Second,
 		Delay:                     5 * time.Second,
 		PollInterval:              10 * time.Second,
@@ -754,7 +777,9 @@ func getSubjectDescriptors(clients *client.AggregatedClient, members *[]string) 
 
 			if memberIdentities != nil && len(*memberIdentities) > 0 {
 				for _, memberIdentity := range *memberIdentities {
-					set.Add(*memberIdentity.SubjectDescriptor)
+					if memberIdentity.SubjectDescriptor != nil {
+						set.Add(*memberIdentity.SubjectDescriptor)
+					}
 				}
 			}
 		}

--- a/azuredevops/internal/service/core/resource_team_wait_test.go
+++ b/azuredevops/internal/service/core/resource_team_wait_test.go
@@ -1,0 +1,325 @@
+//go:build (all || core || resource_team) && !exclude_resource_team
+// +build all core resource_team
+// +build !exclude_resource_team
+
+package core
+
+// Tests for the waitForTeamStateChange convergence loop. The service can
+// normalize name and description, seed its own ACEs, report duplicate
+// identities and delay membership reads, which made team creation hang for
+// 30 minutes in issue #1582.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/core"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/dashboard"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/identity"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/security"
+	"github.com/microsoft/terraform-provider-azuredevops/azdosdkmocks"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	securityhelper "github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions/utils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type waitTestClients struct {
+	clients         *client.AggregatedClient
+	coreClient      *azdosdkmocks.MockCoreClient
+	identityClient  *azdosdkmocks.MockIdentityClient
+	securityClient  *azdosdkmocks.MockSecurityClient
+	dashboardClient *azdosdkmocks.MockDashboardClient
+}
+
+func newWaitTestClients(t *testing.T, ctrl *gomock.Controller) *waitTestClients {
+	t.Helper()
+	c := &waitTestClients{
+		coreClient:      azdosdkmocks.NewMockCoreClient(ctrl),
+		identityClient:  azdosdkmocks.NewMockIdentityClient(ctrl),
+		securityClient:  azdosdkmocks.NewMockSecurityClient(ctrl),
+		dashboardClient: azdosdkmocks.NewMockDashboardClient(ctrl),
+	}
+	c.clients = &client.AggregatedClient{
+		CoreClient:      c.coreClient,
+		IdentityClient:  c.identityClient,
+		SecurityClient:  c.securityClient,
+		DashboardClient: c.dashboardClient,
+		Ctx:             context.Background(),
+	}
+	return c
+}
+
+func newWaitTestResourceData(t *testing.T, projectID string) *schema.ResourceData {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, ResourceTeam().Schema, nil)
+	d.Set("project_id", projectID)
+	return d
+}
+
+func mockWaitTestTeam(c *waitTestClients, projectUUID, teamUUID uuid.UUID, storedName, storedDescription *string) {
+	c.coreClient.
+		EXPECT().
+		GetTeam(c.clients.Ctx, gomock.Any()).
+		Return(&core.WebApiTeam{
+			Id:          &teamUUID,
+			Name:        storedName,
+			Description: storedDescription,
+			ProjectId:   &projectUUID,
+		}, nil).
+		AnyTimes()
+}
+
+func mockWaitTestDashboards(c *waitTestClients, dashboards *[]dashboard.Dashboard) {
+	c.dashboardClient.
+		EXPECT().
+		GetDashboardsByProject(c.clients.Ctx, gomock.Any()).
+		Return(dashboards, nil).
+		AnyTimes()
+}
+
+// Control: when the service returns exactly what was configured, the loop converges.
+func TestTeam_WaitForStateChange_Synced(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	teamDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, &teamDescription)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &teamDescription, nil, nil, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// The service trims surrounding whitespace when it stores name and description.
+func TestTeam_WaitForStateChange_Converges_WhenServiceNormalizesNameAndDescription(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+
+	sentName := " Squad X "
+	storedName := "Squad X"
+	sentDescription := "[Terraform Managed] squad "
+	storedDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &storedName, &storedDescription)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &sentName, &sentDescription, nil, nil, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// A missing description in the response used to panic here.
+func TestTeam_WaitForStateChange_Converges_WhenResponseOmitsDescription(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	sentDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, nil)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &sentDescription, nil, nil, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// The service can seed its own ACEs on the team token; a count comparison never matched.
+func TestTeam_WaitForStateChange_Converges_WhenACLContainsExtraAdministratorACE(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	teamDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, &teamDescription)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	configuredAdmins := schema.NewSet(schema.HashString, []interface{}{"aad.admin1"})
+
+	nsID := uuid.UUID(securityhelper.SecurityNamespaceIDValues.Identity)
+	c.securityClient.
+		EXPECT().
+		QuerySecurityNamespaces(c.clients.Ctx, security.QuerySecurityNamespacesArgs{
+			SecurityNamespaceId: &nsID,
+		}).
+		Return(&[]security.SecurityNamespaceDescription{
+			{
+				Actions: &[]security.ActionDefinition{
+					{Bit: converter.Int(1), Name: converter.String("Read")},
+					{Bit: converter.Int(2), Name: converter.String("Write")},
+					{Bit: converter.Int(4), Name: converter.String("Delete")},
+					{Bit: converter.Int(8), Name: converter.String("ManageMembership")},
+					{Bit: converter.Int(16), Name: converter.String("CreateScope")},
+				},
+			},
+		}, nil).
+		AnyTimes()
+
+	token := projectUUID.String() + "\\" + teamUUID.String()
+	fullBits := 1 | 2 | 4 | 8 | 16
+
+	// ACL contains the configured admin ACE plus one service-seeded extra ACE,
+	// both with the full permission bit set
+	c.securityClient.
+		EXPECT().
+		QueryAccessControlLists(c.clients.Ctx, security.QueryAccessControlListsArgs{
+			SecurityNamespaceId: &nsID,
+			Token:               &token,
+			IncludeExtendedInfo: converter.Bool(true),
+		}).
+		Return(&[]security.AccessControlList{
+			{
+				AcesDictionary: &map[string]security.AccessControlEntry{
+					"ace-configured-admin": {Allow: converter.Int(fullBits), Descriptor: converter.String("ace-configured-admin")},
+					"ace-extra-admin":      {Allow: converter.Int(fullBits), Descriptor: converter.String("ace-extra-admin")},
+				},
+			},
+		}, nil).
+		AnyTimes()
+
+	c.identityClient.
+		EXPECT().
+		ReadIdentities(c.clients.Ctx, gomock.Any()).
+		DoAndReturn(func(_ context.Context, args identity.ReadIdentitiesArgs) (*[]identity.Identity, error) {
+			require.NotNil(t, args.Descriptors)
+			require.Contains(t, *args.Descriptors, "ace-configured-admin")
+			require.Contains(t, *args.Descriptors, "ace-extra-admin")
+			return &[]identity.Identity{
+				{SubjectDescriptor: converter.String("aad.admin1")},
+				{SubjectDescriptor: converter.String("aad.extra-admin")},
+			}, nil
+		}).
+		AnyTimes()
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &teamDescription, nil, configuredAdmins, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// Team membership can contain members the config does not list.
+func TestTeam_WaitForStateChange_Converges_WhenTeamHasExtraMembers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	teamDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, &teamDescription)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	configuredMembers := schema.NewSet(schema.HashString, []interface{}{"aadgp.group1"})
+
+	c.identityClient.
+		EXPECT().
+		ReadMembers(c.clients.Ctx, identity.ReadMembersArgs{
+			ContainerId: converter.String(teamUUID.String()),
+		}).
+		Return(&[]string{"aadgp.group1", "aadgp.group-added-via-ui"}, nil).
+		AnyTimes()
+
+	c.identityClient.
+		EXPECT().
+		ReadIdentities(c.clients.Ctx, gomock.Any()).
+		DoAndReturn(func(_ context.Context, args identity.ReadIdentitiesArgs) (*[]identity.Identity, error) {
+			require.NotNil(t, args.Descriptors)
+			identities := make([]identity.Identity, 0)
+			for _, descriptor := range strings.Split(*args.Descriptors, ",") {
+				identities = append(identities, identity.Identity{SubjectDescriptor: converter.String(strings.TrimSpace(descriptor))})
+			}
+			return &identities, nil
+		}).
+		AnyTimes()
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &teamDescription, configuredMembers, nil, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// A nil dashboard list used to panic here.
+func TestTeam_WaitForStateChange_DoesNotPanic_WhenDashboardsListIsNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	teamDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, &teamDescription)
+	mockWaitTestDashboards(c, nil)
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &teamDescription, nil, nil, nil, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// A member that never shows up cannot converge; fail instead of hanging for 30 minutes.
+func TestTeam_WaitForStateChange_TimesOut_WhenConfiguredMemberNeverAppears(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newWaitTestClients(t, ctrl)
+	projectUUID := uuid.New()
+	teamUUID := uuid.New()
+	teamName := "Squad X"
+	teamDescription := "[Terraform Managed] squad"
+
+	d := newWaitTestResourceData(t, projectUUID.String())
+	mockWaitTestTeam(c, projectUUID, teamUUID, &teamName, &teamDescription)
+	mockWaitTestDashboards(c, &[]dashboard.Dashboard{{}})
+
+	configuredMembers := schema.NewSet(schema.HashString, []interface{}{"aadgp.group1", "aadgp.group2"})
+
+	// identity service only ever reports group1 as member; group2 was silently dropped
+	c.identityClient.
+		EXPECT().
+		ReadMembers(c.clients.Ctx, identity.ReadMembersArgs{
+			ContainerId: converter.String(teamUUID.String()),
+		}).
+		Return(&[]string{"aadgp.group1"}, nil).
+		AnyTimes()
+
+	c.identityClient.
+		EXPECT().
+		ReadIdentities(c.clients.Ctx, gomock.Any()).
+		DoAndReturn(func(_ context.Context, args identity.ReadIdentitiesArgs) (*[]identity.Identity, error) {
+			require.NotNil(t, args.Descriptors)
+			identities := make([]identity.Identity, 0)
+			for _, descriptor := range strings.Split(*args.Descriptors, ",") {
+				identities = append(identities, identity.Identity{SubjectDescriptor: converter.String(strings.TrimSpace(descriptor))})
+			}
+			return &identities, nil
+		}).
+		AnyTimes()
+
+	err := waitForTeamStateChange(d, c.clients, projectUUID.String(), teamUUID.String(), &teamName, &teamDescription, configuredMembers, nil, nil, 12*time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout while waiting for state to become 'Synched' (last state: 'Waiting'")
+}


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## Description

While migrating a few hundred teams to a new organization I ran into #1582: team creation hangs for 30 minutes and then fails with `timeout while waiting for state to become 'Synched' (last state: 'Waiting')`, even though the team and its members were created fine in Azure DevOps. Nothing lands in state, so the next run or an import picks the teams up immediately.

The convergence loop in `waitForTeamStateChange()` has five conditions that all have to hold, and several of them can never become true under normal service behavior:

- name and description are compared with exact string equality. The service trims surrounding whitespace when it stores them, so the comparison can never pass. A missing value in the response also dereferenced a nil pointer.
- members and administrators are compared by count only. The service can seed its own ACEs on the team identity token, report extra or duplicate entries, or silently drop a membership, so the counts never match even when everything the configuration asked for is there.
- the dashboard check reads `if dashboards == nil && len(*dashboards) == 0`, which dereferences a nil pointer. It could only ever crash or pass.
- the 30 minute wait timeout was hardcoded and ignored the resource `timeouts` configuration.

Because the loop does not log which condition is stuck, every one of these quirks produces the same silent 30 minute timeout. The same symptom came up in #1464, where the actual cause turned out to be an unrelated regression in `GetAccessControlList()` (fixed by the revert in #1466).

This PR changes the loop to:

- compare trimmed name and description values, and accept a missing value in the response instead of panicking or waiting forever
- require that all configured members and administrators are present (set intersection, the same semantics the standalone `azuredevops_team_members` resource already uses) and log a warning when the counts differ
- treat a nil or empty dashboard list as a warning instead of panicking
- take the wait timeout from the resource `timeouts` configuration instead of the hardcoded 30 minutes
- skip identities without a subject descriptor in `getSubjectDescriptors()`

No documentation changes are needed. There is no schema change, the documented `timeouts` block simply works now.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Config compatible. Two behavior changes worth calling out: the default create/update wait is now the documented 10 minute resource default instead of a hardcoded 30 minutes, and the loop converges on set intersection instead of exact counts, logging a warning when the team state differs from the configuration.

## Test Result

```
--- PASS: TestTeam_WaitForStateChange_Synced (15.01s)
--- PASS: TestTeam_WaitForStateChange_Converges_WhenServiceNormalizesNameAndDescription (15.01s)
--- PASS: TestTeam_WaitForStateChange_Converges_WhenResponseOmitsDescription (15.01s)
--- PASS: TestTeam_WaitForStateChange_Converges_WhenACLContainsExtraAdministratorACE (15.00s)
--- PASS: TestTeam_WaitForStateChange_Converges_WhenTeamHasExtraMembers (15.01s)
--- PASS: TestTeam_WaitForStateChange_DoesNotPanic_WhenDashboardsListIsNil (15.01s)
--- PASS: TestTeam_WaitForStateChange_TimesOut_WhenConfiguredMemberNeverAppears (12.01s)
ok  	github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/core	102.071s
```

`go build`, `go vet` and the full core package test suite pass. The patched provider has also been verified in a production pipeline while migrating teams between organizations: teams and members are created and the loop converges in seconds instead of hanging for 30 minutes.

## Related Issue(s)

Addresses #1582. The same symptom came up in #1464, caused by an unrelated regression and fixed by the revert in PR #1466.

## Other information

The triggers for the original hang are all realistic service side behaviors: normalized name and description (confirmed in the #1582 thread), extra ACEs on the team identity namespace, and memberships the identity service does not persist. Each one used to produce the same 30 minute timeout with no indication of which condition was stuck. The loop now logs the drifted condition, which should make reports like #1582 much easier to diagnose.